### PR TITLE
use shared utility code

### DIFF
--- a/gengapic/client_init.go
+++ b/gengapic/client_init.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-generator-go/internal/errors"
+	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"google.golang.org/genproto/googleapis/api/annotations"
 )
 
@@ -28,22 +29,15 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 
 	// CallOptions struct
 	{
-		var maxNameLen int
-		for _, m := range serv.Method {
-			if l := len(*m.Name); maxNameLen < l {
-				maxNameLen = l
-			}
-		}
-
 		p("// %[1]sCallOptions contains the retry settings for each method of %[1]sClient.", servName)
 		p("type %sCallOptions struct {", servName)
 		for _, m := range serv.Method {
-			p("%s%s[]gax.CallOption", *m.Name, spaces(maxNameLen-len(*m.Name)+1))
+			p("%s []gax.CallOption", *m.Name)
 		}
 		p("}")
 		p("")
 
-		g.imports[importSpec{"gax", "github.com/googleapis/gax-go"}] = true
+		g.imports[pbinfo.ImportSpec{"gax", "github.com/googleapis/gax-go"}] = true
 	}
 
 	// defaultClientOptions
@@ -61,7 +55,7 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 		p("}")
 		p("")
 
-		g.imports[importSpec{path: "google.golang.org/api/option"}] = true
+		g.imports[pbinfo.ImportSpec{Path: "google.golang.org/api/option"}] = true
 	}
 
 	// defaultCallOptions
@@ -98,8 +92,8 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 			p("}")
 			p("")
 
-			g.imports[importSpec{path: "time"}] = true
-			g.imports[importSpec{path: "google.golang.org/grpc/codes"}] = true
+			g.imports[pbinfo.ImportSpec{Path: "time"}] = true
+			g.imports[pbinfo.ImportSpec{Path: "google.golang.org/grpc/codes"}] = true
 		}
 
 		p("  return &%sCallOptions{", servName)
@@ -125,7 +119,7 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 		}
 	}
 
-	imp, err := g.importSpec(serv)
+	imp, err := g.descInfo.ImportSpec(serv)
 	if err != nil {
 		return err
 	}
@@ -142,7 +136,7 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 		p("")
 
 		p("// The gRPC API client.")
-		p("%s %s.%sClient", grpcClientField(servName), imp.name, serv.GetName())
+		p("%s %s.%sClient", grpcClientField(servName), imp.Name, serv.GetName())
 		p("")
 
 		if hasLRO {
@@ -152,7 +146,7 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 			p("LROClient *lroauto.OperationsClient")
 			p("")
 
-			g.imports[importSpec{name: "lroauto", path: "cloud.google.com/go/longrunning/autogen"}] = true
+			g.imports[pbinfo.ImportSpec{Name: "lroauto", Path: "cloud.google.com/go/longrunning/autogen"}] = true
 		}
 
 		p("// The call options for this service.")
@@ -164,8 +158,8 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 		p("}")
 		p("")
 
-		g.imports[importSpec{path: "google.golang.org/grpc"}] = true
-		g.imports[importSpec{path: "google.golang.org/grpc/metadata"}] = true
+		g.imports[pbinfo.ImportSpec{Path: "google.golang.org/grpc"}] = true
+		g.imports[pbinfo.ImportSpec{Path: "google.golang.org/grpc/metadata"}] = true
 	}
 
 	// Client constructor
@@ -185,7 +179,7 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 		p("    conn:        conn,")
 		p("    CallOptions: default%sCallOptions(),", servName)
 		p("")
-		p("    %s: %s.New%sClient(conn),", grpcClientField(servName), imp.name, serv.GetName())
+		p("    %s: %s.New%sClient(conn),", grpcClientField(servName), imp.Name, serv.GetName())
 		p("  }")
 		p("  c.setGoogleClientInfo()")
 		p("")
@@ -207,8 +201,8 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 		p("}")
 		p("")
 
-		g.imports[importSpec{path: "google.golang.org/api/transport"}] = true
-		g.imports[importSpec{path: "golang.org/x/net/context"}] = true
+		g.imports[pbinfo.ImportSpec{Path: "google.golang.org/api/transport"}] = true
+		g.imports[pbinfo.ImportSpec{Path: "golang.org/x/net/context"}] = true
 	}
 
 	// Connection()
@@ -242,7 +236,7 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 		p("}")
 		p("")
 
-		g.imports[importSpec{path: "cloud.google.com/go/internal/version"}] = true
+		g.imports[pbinfo.ImportSpec{Path: "cloud.google.com/go/internal/version"}] = true
 	}
 	return nil
 }

--- a/gengapic/client_init_test.go
+++ b/gengapic/client_init_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/google/go-cmp/cmp"
+	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"google.golang.org/genproto/googleapis/api/annotations"
 )
 
@@ -47,7 +48,7 @@ func diff(t *testing.T, name, got, goldenFile string) {
 
 func TestClientOpt(t *testing.T) {
 	var g generator
-	g.imports = map[importSpec]bool{}
+	g.imports = map[pbinfo.ImportSpec]bool{}
 
 	serv := &descriptor.ServiceDescriptorProto{
 		Method: []*descriptor.MethodDescriptorProto{
@@ -78,14 +79,14 @@ func TestClientOpt(t *testing.T) {
 			t.Error(err)
 			continue
 		}
-		diff(t, tst.tstName, g.sb.String(), filepath.Join("testdata", tst.tstName+".want"))
+		diff(t, tst.tstName, g.pt.String(), filepath.Join("testdata", tst.tstName+".want"))
 	}
 }
 
 func TestClientInit(t *testing.T) {
 	var g generator
 	g.apiName = "Awesome Foo"
-	g.imports = map[importSpec]bool{}
+	g.imports = map[pbinfo.ImportSpec]bool{}
 
 	servPlain := &descriptor.ServiceDescriptorProto{
 		Name: proto.String("Foo"),
@@ -110,7 +111,7 @@ func TestClientInit(t *testing.T) {
 		{tstName: "empty_client_init", servName: "", serv: servPlain},
 		{tstName: "lro_client_init", servName: "Foo", serv: servLRO},
 	} {
-		g.parentFile = map[proto.Message]*descriptor.FileDescriptorProto{
+		g.descInfo.ParentFile = map[proto.Message]*descriptor.FileDescriptorProto{
 			tst.serv: &descriptor.FileDescriptorProto{
 				Options: &descriptor.FileOptions{
 					GoPackage: proto.String("mypackage"),
@@ -123,6 +124,6 @@ func TestClientInit(t *testing.T) {
 
 		g.reset()
 		g.clientInit(tst.serv, tst.servName)
-		diff(t, tst.tstName, g.sb.String(), filepath.Join("testdata", tst.tstName+".want"))
+		diff(t, tst.tstName, g.pt.String(), filepath.Join("testdata", tst.tstName+".want"))
 	}
 }

--- a/gengapic/doc_file_test.go
+++ b/gengapic/doc_file_test.go
@@ -23,5 +23,5 @@ func TestDocFile(t *testing.T) {
 	var g generator
 	g.apiName = "Awesome Foo"
 	g.genDocFile("path/to/awesome", "awesome", 42, []string{"https://foo.bar.com/auth", "https://zip.zap.com/auth"})
-	diff(t, "doc_file", g.sb.String(), filepath.Join("testdata", "doc_file.want"))
+	diff(t, "doc_file", g.pt.String(), filepath.Join("testdata", "doc_file.want"))
 }

--- a/gengapic/example_test.go
+++ b/gengapic/example_test.go
@@ -20,11 +20,12 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 )
 
 func TestExample(t *testing.T) {
 	var g generator
-	g.imports = map[importSpec]bool{}
+	g.imports = map[pbinfo.ImportSpec]bool{}
 
 	inputType := &descriptor.DescriptorProto{
 		Name: proto.String("InputType"),
@@ -81,8 +82,8 @@ func TestExample(t *testing.T) {
 	for _, typ := range []*descriptor.DescriptorProto{
 		inputType, outputType, pageInputType, pageOutputType,
 	} {
-		g.types[".my.pkg."+*typ.Name] = typ
-		g.parentFile[typ] = file
+		g.descInfo.Type[".my.pkg."+*typ.Name] = typ
+		g.descInfo.ParentFile[typ] = file
 	}
 
 	serv := &descriptor.ServiceDescriptorProto{
@@ -125,7 +126,7 @@ func TestExample(t *testing.T) {
 	} {
 		g.reset()
 		g.genExampleFile(serv, tst.pkgName)
-		diff(t, tst.tstName, g.sb.String(), filepath.Join("testdata", tst.tstName+".want"))
+		diff(t, tst.tstName, g.pt.String(), filepath.Join("testdata", tst.tstName+".want"))
 	}
 }
 
@@ -137,11 +138,11 @@ func commonTypes(g *generator) {
 		Name: proto.String("Operation"),
 	}
 
-	g.types = map[string]*descriptor.DescriptorProto{
+	g.descInfo.Type = map[string]*descriptor.DescriptorProto{
 		emptyType: empty,
 		lroType:   lro,
 	}
-	g.parentFile = map[proto.Message]*descriptor.FileDescriptorProto{
+	g.descInfo.ParentFile = map[proto.Message]*descriptor.FileDescriptorProto{
 		empty: &descriptor.FileDescriptorProto{
 			Options: &descriptor.FileOptions{
 				GoPackage: proto.String("github.com/golang/protobuf/ptypes/empty"),

--- a/gengapic/gengapic_test.go
+++ b/gengapic/gengapic_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 )
 
 func TestComment(t *testing.T) {
@@ -37,9 +38,9 @@ func TestComment(t *testing.T) {
 			want: "// abc\n// def\n",
 		},
 	} {
-		g.sb.Reset()
+		g.pt.Reset()
 		g.comment(tst.in)
-		if got := g.sb.String(); got != tst.want {
+		if got := g.pt.String(); got != tst.want {
 			t.Errorf("comment(%q) = %q, want %q", tst.in, got, tst.want)
 		}
 	}
@@ -66,9 +67,9 @@ func TestMethodDoc(t *testing.T) {
 		},
 	} {
 		g.comments[m] = tst.in
-		g.sb.Reset()
+		g.pt.Reset()
 		g.methodDoc(m)
-		if got := g.sb.String(); got != tst.want {
+		if got := g.pt.String(); got != tst.want {
 			t.Errorf("comment(%q) = %q, want %q", tst.in, got, tst.want)
 		}
 	}
@@ -168,16 +169,16 @@ func TestGenMethod(t *testing.T) {
 	serv := &descriptor.ServiceDescriptorProto{}
 
 	var g generator
-	g.imports = map[importSpec]bool{}
+	g.imports = map[pbinfo.ImportSpec]bool{}
 
 	commonTypes(&g)
 	for _, typ := range []*descriptor.DescriptorProto{
 		inputType, outputType, pageInputType, pageOutputType,
 	} {
-		g.types[".my.pkg."+*typ.Name] = typ
-		g.parentFile[typ] = file
+		g.descInfo.Type[".my.pkg."+*typ.Name] = typ
+		g.descInfo.ParentFile[typ] = file
 	}
-	g.parentFile[serv] = file
+	g.descInfo.ParentFile[serv] = file
 
 	meths := []*descriptor.MethodDescriptorProto{
 		{
@@ -216,7 +217,7 @@ func TestGenMethod(t *testing.T) {
 		if err := g.genMethod("Foo", serv, m, &aux); err != nil {
 			t.Error(err)
 		} else {
-			diff(t, m.GetName(), g.sb.String(), filepath.Join("testdata", "method_"+m.GetName()+".want"))
+			diff(t, m.GetName(), g.pt.String(), filepath.Join("testdata", "method_"+m.GetName()+".want"))
 		}
 	}
 }

--- a/gengapic/imports.go
+++ b/gengapic/imports.go
@@ -17,30 +17,28 @@ package gengapic
 import (
 	"sort"
 	"strings"
-)
 
-type importSpec struct {
-	name, path string
-}
+	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
+)
 
 // sortImports sorts the import specs,
 // and returns the index of the first non-standard import.
-func sortImports(a []importSpec) int {
+func sortImports(a []pbinfo.ImportSpec) int {
 	sort.Slice(a, func(i, j int) bool {
-		iDot := strings.IndexByte(a[i].path, '.') >= 0
-		jDot := strings.IndexByte(a[j].path, '.') >= 0
+		iDot := strings.IndexByte(a[i].Path, '.') >= 0
+		jDot := strings.IndexByte(a[j].Path, '.') >= 0
 
 		// standard import (without dots) comes first
 		if iDot != jDot {
 			return jDot
 		}
 
-		if a[i].path != a[j].path {
-			return a[i].path < a[j].path
+		if a[i].Path != a[j].Path {
+			return a[i].Path < a[j].Path
 		}
-		return a[i].name < a[j].name
+		return a[i].Name < a[j].Name
 	})
 	return sort.Search(len(a), func(i int) bool {
-		return strings.IndexByte(a[i].path, '.') >= 0
+		return strings.IndexByte(a[i].Path, '.') >= 0
 	})
 }

--- a/gengapic/lro.go
+++ b/gengapic/lro.go
@@ -14,18 +14,21 @@
 
 package gengapic
 
-import "github.com/golang/protobuf/protoc-gen-go/descriptor"
+import (
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
+)
 
 func (g *generator) lroCall(servName string, m *descriptor.MethodDescriptorProto) error {
-	inType := g.types[m.GetInputType()]
-	outType := g.types[m.GetOutputType()]
+	inType := g.descInfo.Type[m.GetInputType()]
+	outType := g.descInfo.Type[m.GetOutputType()]
 
-	inSpec, err := g.importSpec(inType)
+	inSpec, err := g.descInfo.ImportSpec(inType)
 	if err != nil {
 		return err
 	}
 
-	outSpec, err := g.importSpec(outType)
+	outSpec, err := g.descInfo.ImportSpec(outType)
 	if err != nil {
 		return err
 	}
@@ -34,11 +37,11 @@ func (g *generator) lroCall(servName string, m *descriptor.MethodDescriptorProto
 	p := g.printf
 
 	p("func (c *%sClient) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s, error) {",
-		servName, *m.Name, inSpec.name, *inType.Name, lroType)
+		servName, *m.Name, inSpec.Name, *inType.Name, lroType)
 
 	g.insertMetadata()
 	g.appendCallOpts(m)
-	p("  var resp *%s.%s", outSpec.name, *outType.Name)
+	p("  var resp *%s.%s", outSpec.Name, *outType.Name)
 	p("  err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")
 	p("    var err error")
 	p("    resp, err = %s", grpcClientCall(servName, *m.Name))
@@ -54,7 +57,7 @@ func (g *generator) lroCall(servName string, m *descriptor.MethodDescriptorProto
 	p("}")
 	p("")
 
-	g.imports[importSpec{path: "cloud.google.com/go/longrunning"}] = true
+	g.imports[pbinfo.ImportSpec{Path: "cloud.google.com/go/longrunning"}] = true
 	g.imports[inSpec] = true
 	g.imports[outSpec] = true
 	return nil
@@ -89,7 +92,7 @@ func (g *generator) lroType(servName string, m *descriptor.MethodDescriptorProto
 		p("}")
 		p("")
 
-		g.imports[importSpec{name: "longrunningpb", path: "google.golang.org/genproto/googleapis/longrunning"}] = true
+		g.imports[pbinfo.ImportSpec{Name: "longrunningpb", Path: "google.golang.org/genproto/googleapis/longrunning"}] = true
 	}
 
 	// Wait
@@ -106,7 +109,7 @@ func (g *generator) lroType(servName string, m *descriptor.MethodDescriptorProto
 		p("}")
 		p("")
 
-		g.imports[importSpec{path: "time"}] = true
+		g.imports[pbinfo.ImportSpec{Path: "time"}] = true
 	}
 
 	// Poll

--- a/gengapic/stream.go
+++ b/gengapic/stream.go
@@ -19,17 +19,17 @@ import "github.com/golang/protobuf/protoc-gen-go/descriptor"
 func (g *generator) bidiCall(servName string, s *descriptor.ServiceDescriptorProto, m *descriptor.MethodDescriptorProto) error {
 	p := g.printf
 
-	servSpec, err := g.importSpec(s)
+	servSpec, err := g.descInfo.ImportSpec(s)
 	if err != nil {
 		return err
 	}
 	g.imports[servSpec] = true
 
 	p("func (c *%sClient) %s(ctx context.Context, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
-		servName, m.GetName(), servSpec.name, s.GetName(), m.GetName())
+		servName, m.GetName(), servSpec.Name, s.GetName(), m.GetName())
 	g.insertMetadata()
 	g.appendCallOpts(m)
-	p("  var resp %s.%s_%sClient", servSpec.name, s.GetName(), m.GetName())
+	p("  var resp %s.%s_%sClient", servSpec.Name, s.GetName(), m.GetName())
 
 	p("  err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")
 	p("    var err error")

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -69,3 +69,7 @@ func (p *P) Printf(s string, args ...interface{}) {
 func (p *P) Bytes() []byte {
 	return p.buf.Bytes()
 }
+
+func (p *P) String() string {
+	return p.buf.String()
+}


### PR DESCRIPTION
The delete code were moved into internal/ when bootstrapping samplegen.

No real changes, just renaming.