### PR TITLE
gengaic: read retry code configuration

### DIFF
--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/genproto/googleapis/rpc/code"
 )
 
 var updateGolden = flag.Bool("update_golden", false, "update golden files")
@@ -54,16 +55,24 @@ func TestClientOpt(t *testing.T) {
 		Method: []*descriptor.MethodDescriptorProto{
 			{Name: proto.String("Zip"), Options: &descriptor.MethodOptions{}},
 			{Name: proto.String("Zap"), Options: &descriptor.MethodOptions{}},
+			{Name: proto.String("Smack"), Options: &descriptor.MethodOptions{}},
 		},
 		Options: &descriptor.ServiceOptions{},
 	}
 	if err := proto.SetExtension(serv.Options, annotations.E_DefaultHost, proto.String("foo.bar.com")); err != nil {
 		t.Fatal(err)
 	}
+
+	// Test some annotations
 	if err := proto.SetExtension(serv.Method[0].Options, annotations.E_Http, &annotations.HttpRule{
 		Pattern: &annotations.HttpRule_Get{
 			Get: "/zip",
 		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := proto.SetExtension(serv.Method[1].Options, annotations.E_Retry, &annotations.Retry{
+		Codes: []code.Code{code.Code_NOT_FOUND, code.Code_CANCELLED},
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -475,6 +475,7 @@ func camelToSnake(s string) string {
 	return sb.String()
 }
 
+// snakeToCamel converts snake_case and SNAKE_CASE to CamelCase.
 func snakeToCamel(s string) string {
 	var sb strings.Builder
 	up := true
@@ -485,7 +486,7 @@ func snakeToCamel(s string) string {
 			sb.WriteRune(unicode.ToUpper(r))
 			up = false
 		} else {
-			sb.WriteRune(r)
+			sb.WriteRune(unicode.ToLower(r))
 		}
 	}
 	return sb.String()

--- a/internal/gengapic/testdata/empty_opt.want
+++ b/internal/gengapic/testdata/empty_opt.want
@@ -2,6 +2,7 @@
 type CallOptions struct {
 	Zip []gax.CallOption
 	Zap []gax.CallOption
+	Smack []gax.CallOption
 }
 
 func defaultClientOptions() []option.ClientOption {
@@ -12,21 +13,30 @@ func defaultClientOptions() []option.ClientOption {
 }
 
 func defaultCallOptions() *CallOptions {
+	backoff := gax.Backoff{
+		Initial: 100 * time.Millisecond,
+		Max: time.Minute,
+		Multiplier: 1.3,
+	}
 	retry := []gax.CallOption{
 		gax.WithRetry(func() gax.Retryer {
 			return gax.OnCodes([]codes.Code{
 				codes.Internal,
 				codes.Unavailable,
-			}, gax.Backoff{
-				Initial: 100 * time.Millisecond,
-				Max: time.Minute,
-				Multiplier: 1.3,
-			})
+			}, backoff)
 		}),
 	}
 
 	return &CallOptions{
 		Zip: retry,
+		Zap: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnCodes([]codes.Code{
+					codes.NotFound,
+					codes.Canceled,
+				}, backoff)
+			}),
+		},
 	}
 }
 

--- a/internal/gengapic/testdata/foo_opt.want
+++ b/internal/gengapic/testdata/foo_opt.want
@@ -2,6 +2,7 @@
 type FooCallOptions struct {
 	Zip []gax.CallOption
 	Zap []gax.CallOption
+	Smack []gax.CallOption
 }
 
 func defaultFooClientOptions() []option.ClientOption {
@@ -12,21 +13,30 @@ func defaultFooClientOptions() []option.ClientOption {
 }
 
 func defaultFooCallOptions() *FooCallOptions {
+	backoff := gax.Backoff{
+		Initial: 100 * time.Millisecond,
+		Max: time.Minute,
+		Multiplier: 1.3,
+	}
 	retry := []gax.CallOption{
 		gax.WithRetry(func() gax.Retryer {
 			return gax.OnCodes([]codes.Code{
 				codes.Internal,
 				codes.Unavailable,
-			}, gax.Backoff{
-				Initial: 100 * time.Millisecond,
-				Max: time.Minute,
-				Multiplier: 1.3,
-			})
+			}, backoff)
 		}),
 	}
 
 	return &FooCallOptions{
 		Zip: retry,
+		Zap: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnCodes([]codes.Code{
+					codes.NotFound,
+					codes.Canceled,
+				}, backoff)
+			}),
+		},
 	}
 }
 


### PR DESCRIPTION
Proto annotation only configures the codes to retry on.
Just use something sensible as backoff parameter.