### PR TITLE
generate streaming methods

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -317,12 +317,10 @@ func (g *generator) genMethod(servName string, serv *descriptor.ServiceDescripto
 	}
 
 	switch {
-	case m.GetClientStreaming() && m.GetServerStreaming():
-		return g.bidiCall(servName, serv, m)
-	case m.GetClientStreaming() && !m.GetServerStreaming():
-		return errors.E(nil, "client streaming methods not implemented yet")
-	case !m.GetClientStreaming() && m.GetServerStreaming():
-		return errors.E(nil, "server streaming methods not implemented yet")
+	case m.GetClientStreaming():
+		return g.noRequestStreamCall(servName, serv, m)
+	case m.GetServerStreaming():
+		return g.serverStreamCall(servName, serv, m)
 	default:
 		return g.unaryCall(servName, m)
 	}

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -205,6 +205,18 @@ func TestGenMethod(t *testing.T) {
 			OutputType: proto.String(".my.pkg.PageOutputType"),
 		},
 		{
+			Name:            proto.String("ServerThings"),
+			InputType:       proto.String(".my.pkg.InputType"),
+			OutputType:      proto.String(".my.pkg.OutputType"),
+			ServerStreaming: proto.Bool(true),
+		},
+		{
+			Name:            proto.String("ClientThings"),
+			InputType:       proto.String(".my.pkg.InputType"),
+			OutputType:      proto.String(".my.pkg.OutputType"),
+			ClientStreaming: proto.Bool(true),
+		},
+		{
 			Name:            proto.String("BidiThings"),
 			InputType:       proto.String(".my.pkg.InputType"),
 			OutputType:      proto.String(".my.pkg.OutputType"),

--- a/internal/gengapic/testdata/method_ClientThings.want
+++ b/internal/gengapic/testdata/method_ClientThings.want
@@ -1,0 +1,15 @@
+func (c *FooClient) ClientThings(ctx context.Context, opts ...gax.CallOption) (mypackagepb._ClientThingsClient, error) {
+	ctx = insertMetadata(ctx, c.xGoogMetadata)
+	opts = append(c.CallOptions.ClientThings[0:len(c.CallOptions.ClientThings):len(c.CallOptions.ClientThings)], opts...)
+	var resp mypackagepb._ClientThingsClient
+	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+		var err error
+		resp, err = c.fooClient.ClientThings(ctx, settings.GRPC...)
+		return err
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,0 +1,15 @@
+func (c *FooClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb._ServerThingsClient, error) {
+	ctx = insertMetadata(ctx, c.xGoogMetadata)
+	opts = append(c.CallOptions.ServerThings[0:len(c.CallOptions.ServerThings):len(c.CallOptions.ServerThings)], opts...)
+	var resp mypackagepb._ServerThingsClient
+	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+		var err error
+		resp, err = c.fooClient.ServerThings(ctx, req, settings.GRPC...)
+		return err
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+


### PR DESCRIPTION
None of the currently proto-annotated cloud APIs use server or client
streaming right now, so I haven't gotten a chance to baseline-test this
against production. Still, I believe problems (if any) will be small
and easily fixed in a followup, and we'll likely catch them when we
test with Showcase [1].

[1] Showcase is an API we created to exercise various functionalities
of the generator. It has an in-memory implementation we can test
against.