### PR TITLE
fix panic from nil LeadingComments

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -155,9 +155,9 @@ func (g *generator) init(files []*descriptor.FileDescriptorProto) {
 			// since the field tag of Method is 2.
 			p := loc.Path
 			switch {
-			case len(p) == 2 && p[0] == 6:
+			case len(p) == 2 && p[0] == 6 && loc.LeadingComments != nil:
 				g.comments[f.Service[p[1]]] = *loc.LeadingComments
-			case len(p) == 4 && p[0] == 6 && p[2] == 2:
+			case len(p) == 4 && p[0] == 6 && p[2] == 2 && loc.LeadingComments != nil:
 				g.comments[f.Service[p[1]].Method[p[3]]] = *loc.LeadingComments
 			}
 		}

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -145,6 +145,10 @@ func (g *generator) init(files []*descriptor.FileDescriptorProto) {
 
 	for _, f := range files {
 		for _, loc := range f.GetSourceCodeInfo().GetLocation() {
+			if loc.LeadingComments == nil {
+				continue
+			}
+
 			// p is an array with format [f1, i1, f2, i2, ...]
 			// - f1 refers to the protobuf field tag
 			// - if field refer to by f1 is a slice, i1 refers to an element in that slice
@@ -155,9 +159,9 @@ func (g *generator) init(files []*descriptor.FileDescriptorProto) {
 			// since the field tag of Method is 2.
 			p := loc.Path
 			switch {
-			case len(p) == 2 && p[0] == 6 && loc.LeadingComments != nil:
+			case len(p) == 2 && p[0] == 6:
 				g.comments[f.Service[p[1]]] = *loc.LeadingComments
-			case len(p) == 4 && p[0] == 6 && p[2] == 2 && loc.LeadingComments != nil:
+			case len(p) == 4 && p[0] == 6 && p[2] == 2:
 				g.comments[f.Service[p[1]].Method[p[3]]] = *loc.LeadingComments
 			}
 		}


### PR DESCRIPTION
Checks that `loc.LeadingComments` is not `nil` before dereferencing it.

I ran into this after I pulled master of this repo and tried to generate a client for the [Kiosk API](https://github.com/googleapis/kiosk/blob/master/protos/kiosk.proto).

I'm not entirely sure what a LeadingComment is. Also not sure if something about this proto made it crash or if it was something else I did. Once I put the check in, the plugin progressed passed the afflicted `init` method.