### PR TITLE
gcli client stream ignore blanks

### DIFF
--- a/internal/gencli/cmd_file.go
+++ b/internal/gencli/cmd_file.go
@@ -244,7 +244,7 @@ var {{$methodCmdVar}} = &cobra.Command{
 		}()
 		{{ end }}
 		if Verbose {
-			fmt.Println("Client stream open. Close with blank line.")
+			fmt.Println("Client stream open. Close with ctrl+D.")
 		}
 
 		var {{ $inputVar }} {{ .InputMessage }}
@@ -252,7 +252,7 @@ var {{$methodCmdVar}} = &cobra.Command{
     for scanner.Scan() {
 				input := scanner.Text()
 				if input == "" {
-					break
+					continue
 				}
         err = jsonpb.UnmarshalString(input, &{{ $inputVar }})
 				if err != nil {

--- a/internal/gencli/testdata/copy-todos.want
+++ b/internal/gencli/testdata/copy-todos.want
@@ -44,7 +44,7 @@ var CopyTodosCmd = &cobra.Command{
 		stream, err := TodoClient.CopyTodos(ctx)
 
 		if Verbose {
-			fmt.Println("Client stream open. Close with blank line.")
+			fmt.Println("Client stream open. Close with ctrl+D.")
 		}
 
 		var CopyTodosInput todopb.Todo
@@ -52,7 +52,7 @@ var CopyTodosCmd = &cobra.Command{
 		for scanner.Scan() {
 			input := scanner.Text()
 			if input == "" {
-				break
+				continue
 			}
 			err = jsonpb.UnmarshalString(input, &CopyTodosInput)
 			if err != nil {

--- a/internal/gencli/testdata/manage-todos.want
+++ b/internal/gencli/testdata/manage-todos.want
@@ -73,7 +73,7 @@ var ManageTodosCmd = &cobra.Command{
 		}()
 
 		if Verbose {
-			fmt.Println("Client stream open. Close with blank line.")
+			fmt.Println("Client stream open. Close with ctrl+D.")
 		}
 
 		var ManageTodosInput todopb.Todo
@@ -81,7 +81,7 @@ var ManageTodosCmd = &cobra.Command{
 		for scanner.Scan() {
 			input := scanner.Text()
 			if input == "" {
-				break
+				continue
 			}
 			err = jsonpb.UnmarshalString(input, &ManageTodosInput)
 			if err != nil {


### PR DESCRIPTION
Per [discussion](https://github.com/googleapis/gapic-generator-go/pull/53#discussion_r238512569) in #53 , generated client streaming commands should ignore blank lines. They can be terminated with a `ctrl+D` sequence.