### PR TITLE
improve detection of nested types/msg fields

### DIFF
--- a/internal/gencli/gencli.go
+++ b/internal/gencli/gencli.go
@@ -312,7 +312,7 @@ func (g *gcli) buildOneOfFlag(cmd *Command, msg *descriptor.DescriptorProto, fie
 
 	// handle oneof message or enum fields
 	if flag.IsMessage() || flag.IsEnum() {
-		flag.Message = parseMessageName(field, msg)
+		flag.Message = g.prepareMessageName(field)
 
 		nested := g.descInfo.Type[field.GetTypeName()]
 
@@ -354,8 +354,10 @@ func (g *gcli) buildFieldFlags(cmd *Command, msg *descriptor.DescriptorProto, pr
 		if field.OneofIndex != nil {
 			g.buildOneOfSelectors(cmd, msg, prefix)
 
-			in := cmd.InputMessage[strings.LastIndex(cmd.InputMessage, ".")+1:]
-			flags = append(flags, g.buildOneOfFlag(cmd, msg, field, prefix, in != msg.GetName())...)
+			// check if we've recursed into a nested message's oneof
+			isInNested := g.descInfo.Type[cmd.InputMessageType].(*descriptor.DescriptorProto) != msg
+
+			flags = append(flags, g.buildOneOfFlag(cmd, msg, field, prefix, isInNested)...)
 
 			continue
 		}
@@ -376,7 +378,7 @@ func (g *gcli) buildFieldFlags(cmd *Command, msg *descriptor.DescriptorProto, pr
 		cmd.HasEnums = cmd.HasEnums || flag.IsEnum()
 
 		if flag.IsMessage() || flag.IsEnum() {
-			flag.Message = parseMessageName(field, msg)
+			flag.Message = g.prepareMessageName(field)
 
 			nested := g.descInfo.Type[field.GetTypeName()]
 
@@ -509,4 +511,16 @@ func (g *gcli) addGoFile(name string) {
 	file.Content = proto.String(string(data))
 
 	g.response.File = append(g.response.File, file)
+}
+
+func (g *gcli) prepareMessageName(field *descriptor.FieldDescriptorProto) string {
+	f := g.descInfo.Type[field.GetTypeName()]
+	name := f.GetName()
+
+	// check if it is a nested type
+	if p, ok := g.descInfo.ParentElement[f]; ok {
+		name = p.GetName() + "_" + name
+	}
+
+	return name
 }

--- a/internal/gencli/gencli.go
+++ b/internal/gencli/gencli.go
@@ -355,7 +355,7 @@ func (g *gcli) buildFieldFlags(cmd *Command, msg *descriptor.DescriptorProto, pr
 			g.buildOneOfSelectors(cmd, msg, prefix)
 
 			// check if we've recursed into a nested message's oneof
-			isInNested := g.descInfo.Type[cmd.InputMessageType].(*descriptor.DescriptorProto) != msg
+			isInNested := g.descInfo.Type[cmd.InputMessageType] != msg
 
 			flags = append(flags, g.buildOneOfFlag(cmd, msg, field, prefix, isInNested)...)
 
@@ -517,8 +517,8 @@ func (g *gcli) prepareMessageName(field *descriptor.FieldDescriptorProto) string
 	f := g.descInfo.Type[field.GetTypeName()]
 	name := f.GetName()
 
-	// check if it is a nested type
-	if p, ok := g.descInfo.ParentElement[f]; ok {
+	// prepend parent name for nested message types
+	for p, ok := g.descInfo.ParentElement[f]; ok; p, ok = g.descInfo.ParentElement[p] {
 		name = p.GetName() + "_" + name
 	}
 

--- a/internal/gencli/util.go
+++ b/internal/gencli/util.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 )
 
@@ -101,21 +100,6 @@ func putImport(imports map[string]*pbinfo.ImportSpec, pkg *pbinfo.ImportSpec) {
 	if _, ok := imports[pkg.Name]; !ok {
 		imports[pkg.Name] = pkg
 	}
-}
-
-func parseMessageName(field *descriptor.FieldDescriptorProto, msg *descriptor.DescriptorProto) (name string) {
-	t := field.GetTypeName()
-	last := strings.LastIndex(t, ".")
-	name = t[last+1:]
-
-	// check if it is a nested type
-	if strings.Contains(t, msg.GetName()) {
-		pre := t[:last]
-		parent := pre[strings.LastIndex(pre, ".")+1:]
-		name = parent + "_" + name
-	}
-
-	return
 }
 
 func title(name string) string {


### PR DESCRIPTION
Detect nested types (for naming purposes) using `ParentElem` map to address brittleness pointed out [here](https://github.com/googleapis/gapic-generator-go/pull/53#discussion_r238442110)

Detect processing of `oneof` fields within an already nested message field (for naming purposes) using descriptor comparison (instead of name) prompted by [comment](https://github.com/googleapis/gapic-generator-go/pull/53#discussion_r238442447) on brittleness/confusion