### PR TITLE
add docker invocation wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:stable-slim
+
+# Add protoc and our common protos.
+COPY --from=gcr.io/gapic-images/api-common-protos:latest /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=gcr.io/gapic-images/api-common-protos:latest /protos/ /protos/
+
+# Add protoc-gen-go_gapic binary
+COPY protoc-gen-go_gapic /usr/local/bin
+
+# Define the generator as an entry point.
+ENTRYPOINT protoc --proto_path=/protos/ --proto_path=/in/ \
+                  --go_gapic_out=/out/ \
+                  --go_gapic_opt=$GO_GAPIC_OPT \
+                  `find /in/ -name *.proto`

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+image:
+	GOOS=linux GOARCH=amd64 go build github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
+	docker build -t gcr.io/gapic-images/gapic-generator-go .
+	rm protoc-gen-go_gapic

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 image:
-	GOOS=linux GOARCH=amd64 go build github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
 	docker build -t gcr.io/gapic-images/gapic-generator-go .
 	rm protoc-gen-go_gapic

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ $ docker pull gcr.io/gapic-images/gapic-generator-go
 $ docker run \
   --rm \
   --user $UID \
-  --mount type=bind,source=/abs/path/to/protos,destination=/in/protos,readonly \
+  --mount type=bind,source=</abs/path/to/protos>,destination=/in,readonly \
   --mount type=bind,source=$GOPATH/src,destination=/out/ \
-  --env "GO_GAPIC_OPT=github.com/package/import/path;name" \
+  --env "GO_GAPIC_OPT=<github.com/package/import/path;name>" \
   gcr.io/gapic-images/gapic-generator-go
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,38 @@ Idiomatically the name is last element of the path but it need not be.
 For instance, the last element of the path might be the package's version, and the package would benefit
 from a more descriptive name.
 
+Docker Wrapper
+--------------
+The generator can also be executed via a Docker container. The image containes `protoc`, the microgenerator
+binary, and the standard API protos.
+
+```bash
+$ docker pull gcr.io/gapic-images/gapic-generator-go
+$ docker run \
+  --rm \
+  --user $UID \
+  --mount type=bind,source=/abs/path/to/protos,destination=/in/protos,readonly \
+  --mount type=bind,source=$GOPATH/src,destination=/out/ \
+  --env "GO_GAPIC_OPT=github.com/package/import/path;name" \
+  gcr.io/gapic-images/gapic-generator-go
+```
+
+Replace `/abs/path/to/protos` with the absolute path to the input protos and `github.com/package/import/path;name`
+with the desired import path & name for the `gapic`, as described in [Invocation](#Invocation).
+
+For convenience, the [gapic.sh](./gapic.sh) script wraps the above `docker` invocation.
+An equivalent invocation using `gapic.sh` is:
+
+```bash
+$ gapic.sh \
+  --go_gapic_opt 'github.com/package/import/path;name' \
+  --image gcr.io/gapic-images/gapic-generator-go
+  --in /abs/path/to/protos \
+  --out $GOPATH/src
+```
+
+Use `gapic.sh --help` to print the usage documentation.
+
 Disclaimer
 ----------
 This generator is currently experimental. Please don't use it for anything mission-critical.

--- a/gapic.sh
+++ b/gapic.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CMD="$0"
+
+# Set variables used by this script.
+# All of these are set in options below, and all but $PATH are required.
+GO_GAPIC_OPT=
+IMAGE=
+IN=
+OUT=
+PROTO_PATH=`pwd`
+
+# Print help and exit.
+function show_help {
+  echo "Usage: $CMD --go_gapic_opt GO_GAPIC_OPT --image IMAGE --in IN_DIR --out OUT_DIR [--path PATH_DIR]"
+  echo ""
+  echo "Required arguments:"
+  echo "      --go_gapic_opt  The import path and name for the generated package"
+  echo "      --image         The Docker image to use. The script will attempt to pull"
+  echo "                      it if it is not present."
+  echo "  -i, --in            A directory containing the protos describing the API"
+  echo "                      to be generated."
+  echo "  -o, --out           Destination directory for the completed client library."
+  echo ""
+  echo "Optional arguments:"
+  echo "  -p, --path   The base import path for the protos. Assumed to be the"
+  echo "               current working directory if unspecified."
+  echo "  -h, --help   This help information."
+  exit 0
+}
+
+# Parse out options.
+while true; do
+  case "$1" in
+    -h | --help ) show_help ;;
+    --go_gapic_opt ) GO_GAPIC_OPT="$2"; shift 2 ;;
+    --image ) IMAGE="$2"; shift 2 ;;
+    -i | --in ) IN="$2"; shift 2 ;;
+    -o | --out ) OUT="$2"; shift 2 ;;
+    -p | --path ) PROTO_PATH=$2; shift 2 ;;
+    -- ) shift; break; ;;
+    * ) break ;;
+  esac
+done
+
+# Ensure that all required options are set.
+if [ -z "$GO_GAPIC_OPT" ] || [ -z "$IMAGE" ] || [ -z "$IN" ] || [ -z "$OUT" ]; then
+  >&2 echo "Required argument missing."
+  >&2 echo "The --go_gapic_opt, --image, --in, and --out arguments are all required."
+  >&2 echo "Run $CMD --help for more information."
+  exit 64
+fi
+
+# Ensure that the input directory exists (and is a directory).
+if ! [ -d $IN ]; then
+  >&2 echo "Directory does not exist: $IN"
+  exit 2
+fi
+
+# Ensure Docker is running and seems healthy.
+# This is mostly a check to bubble useful errors quickly.
+if ! docker ps > /dev/null; then
+  exit $?
+fi
+
+# If the output directory does not exist, create it.
+if ! mkdir -p $OUT ; then
+  exit $?
+fi
+
+# If the output directory is not empty, warn (but continue).
+if [ "$(ls -A $OUT )" ]; then
+  >&2 echo "Warning: Output directory is not empty."
+fi
+
+# If the image is not yet on the machine, pull it.
+if ! docker images $IMAGE > /dev/null; then
+  echo "Image $IMAGE not found; pulling."
+  if ! docker pull $IMAGE; then
+    exit $?
+  fi
+fi
+
+# Generate the client library.
+docker run \
+  --mount type=bind,source=${PROTO_PATH}/${IN},destination=/in/${IN},readonly \
+  --mount type=bind,source=$OUT,destination=/out \
+  --rm \
+  --user $UID \
+  --env "GO_GAPIC_OPT=$GO_GAPIC_OPT" \
+  $IMAGE
+exit $?

--- a/gapic.sh
+++ b/gapic.sh
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+set -e 
 
 CMD="$0"
 
@@ -25,20 +26,23 @@ PROTO_PATH=`pwd`
 
 # Print help and exit.
 function show_help {
-  echo "Usage: $CMD --go_gapic_opt GO_GAPIC_OPT --image IMAGE --in IN_DIR --out OUT_DIR [--path PATH_DIR]"
-  echo ""
-  echo "Required arguments:"
-  echo "      --go_gapic_opt  The import path and name for the generated package"
-  echo "      --image         The Docker image to use. The script will attempt to pull"
-  echo "                      it if it is not present."
-  echo "  -i, --in            A directory containing the protos describing the API"
-  echo "                      to be generated."
-  echo "  -o, --out           Destination directory for the completed client library."
-  echo ""
-  echo "Optional arguments:"
-  echo "  -p, --path   The base import path for the protos. Assumed to be the"
-  echo "               current working directory if unspecified."
-  echo "  -h, --help   This help information."
+  cat << EOF
+Usage: $CMD --go_gapic_opt GO_GAPIC_OPT --image IMAGE --in IN_DIR --out OUT_DIR [--path PATH_DIR]
+
+Required arguments:
+      --go_gapic_opt  The import path and name for the generated package
+      --image         The Docker image to use. The script will attempt to pull
+                      it if it is not present.
+  -i, --in            A directory containing the protos describing the API
+                      to be generated.
+  -o, --out           Destination directory for the completed client library.
+
+Optional arguments:
+  -p, --path   The base import path for the protos. Assumed to be the
+                current working directory if unspecified.
+  -h, --help   This help information.
+EOF
+ 
   exit 0
 }
 
@@ -58,40 +62,35 @@ done
 
 # Ensure that all required options are set.
 if [ -z "$GO_GAPIC_OPT" ] || [ -z "$IMAGE" ] || [ -z "$IN" ] || [ -z "$OUT" ]; then
-  >&2 echo "Required argument missing."
-  >&2 echo "The --go_gapic_opt, --image, --in, and --out arguments are all required."
-  >&2 echo "Run $CMD --help for more information."
+  cat << EOF
+Required argument missing.
+The --go_gapic_opt, --image, --in, and --out arguments are all required.
+Run $CMD --help for more information.
+EOF
+
   exit 64
 fi
 
 # Ensure that the input directory exists (and is a directory).
 if ! [ -d $IN ]; then
-  >&2 echo "Directory does not exist: $IN"
+  cat << EOF
+Directory does not exist: $IN
+EOF
   exit 2
 fi
 
 # Ensure Docker is running and seems healthy.
 # This is mostly a check to bubble useful errors quickly.
-if ! docker ps > /dev/null; then
-  exit $?
-fi
+docker ps > /dev/null
 
 # If the output directory does not exist, create it.
-if ! mkdir -p $OUT ; then
-  exit $?
-fi
+mkdir -p $OUT
 
 # If the output directory is not empty, warn (but continue).
 if [ "$(ls -A $OUT )" ]; then
-  >&2 echo "Warning: Output directory is not empty."
-fi
-
-# If the image is not yet on the machine, pull it.
-if ! docker images $IMAGE > /dev/null; then
-  echo "Image $IMAGE not found; pulling."
-  if ! docker pull $IMAGE; then
-    exit $?
-  fi
+  cat << EOF
+Warning: Output directory is not empty.
+EOF
 fi
 
 # Generate the client library.
@@ -102,4 +101,3 @@ docker run \
   --user $UID \
   --env "GO_GAPIC_OPT=$GO_GAPIC_OPT" \
   $IMAGE
-exit $?


### PR DESCRIPTION
* add `Dockerfile` for invocation wrapper image per micro-generator docker invocation spec
* add Makefile w/image building target
* add docker wrapper usage instructions to the README
* add copy of `gapic.sh` from [gapic-generator-python](https://github.com/googleapis/gapic-generator-python/blob/master/gapic.sh) w/added required flag

Note: Using `debian:stable-slim` as the base image because I couldn't get `alpine` to work (would always get `protoc: not found` even though it was in the right dir & marked executable). Image is only 65.6MB in size.

This was tested on linux & macOS machines.

Once this is merged, I will manually publish images tagged `0.1.0`  (only current release) & `latest`