### PR TITLE
add image build & publish workflow to Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - run:
           name: Set up authentication to Google Container Registry.
           command: |
-            echo ${GCLOUD_SERVICE_KEY} > ${GOOGLE_APPLICATION_CREDENTIALS}
+            echo ${GCLOUD_SERVICE_KEY} | base64 --decode > ${GOOGLE_APPLICATION_CREDENTIALS}
             docker-credential-gcr configure-docker
       - run:
           name: Tag the Docker image and push it to Google Container Registry.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,12 +4,12 @@ workflows:
   build_test_publish:
     jobs:
       - build:
-        filters:
-          tags:
+          filters:
+            tags:
               only: /^\d+\.\d+\.\d+$/
       - publish_image:
           requires:
-           - build
+            - build
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,20 @@
 version: 2
+workflows:
+  version: 2
+  build_test_publish:
+    jobs:
+      - build:
+        filters:
+          tags:
+              only: /^\d+\.\d+\.\d+$/
+      - publish_image:
+          requires:
+           - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^\d+\.\d+\.\d+$/
 jobs:
   build:
     docker:
@@ -20,3 +36,38 @@ jobs:
             export PATH=$PATH:$(pwd)/protobuf/bin
             go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
             ./utils/showcase.bash
+  publish_image:
+    docker:
+      - image: circleci/golang:1.11
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Build Docker image.
+          command: make image
+      - run:
+          name: Download the GCR credential helper.
+          command: |
+            curl -fsSL https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v1.5.0/docker-credential-gcr_linux_amd64-1.5.0.tar.gz \
+              | tar xz --to-stdout ./docker-credential-gcr \
+              > /usr/bin/docker-credential-gcr && chmod a+x /usr/bin/docker-credential-gcr
+      - run:
+          name: Set up authentication to Google Container Registry.
+          command: |
+            echo ${GCLOUD_SERVICE_KEY} > ${GOOGLE_APPLICATION_CREDENTIALS}
+            docker-credential-gcr configure-docker
+      - run:
+          name: Tag the Docker image and push it to Google Container Registry.
+          command: |
+            if [ -n "$CIRCLE_TAG" ]; then
+              export MAJOR=`echo $CIRCLE_TAG | awk -F '.' '{ print $1; }'`
+              export MINOR=`echo $CIRCLE_TAG | awk -F '.' '{ print $2; }'`
+              export PATCH=`echo $CIRCLE_TAG | awk -F '.' '{ print $3; }'`
+              docker tag gcr.io/gapic-images/gapic-generator-go:latest gcr.io/gapic-images/gapic-generator-go:$MAJOR.$MINOR.$PATCH
+              docker tag gcr.io/gapic-images/gapic-generator-go:latest gcr.io/gapic-images/gapic-generator-go:$MAJOR.$MINOR
+              docker tag gcr.io/gapic-images/gapic-generator-go:latest gcr.io/gapic-images/gapic-generator-go:$MAJOR
+              docker push gcr.io/gapic-images/gapic-generator-go:$MAJOR.$MINOR.$PATCH
+              docker push gcr.io/gapic-images/gapic-generator-go:$MAJOR.$MINOR
+              docker push gcr.io/gapic-images/gapic-generator-go:$MAJOR
+            fi
+            docker push gcr.io/gapic-images/gapic-generator-go:latest


### PR DESCRIPTION
* add `publish_image` job & `build_test_publish` workflow to Circle CI config

Note: this was adapted from `gapic-generator-python`