### PR TITLE
fix circleci publish trigger regexp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ workflows:
       - build:
           filters:
             tags:
-              only: /^\d+\.\d+\.\d+$/
+              only: /^v\d+\.\d+\.\d+$|^v\d+\.\d+\.\d+-[a-z]+$/
       - publish_image:
           requires:
             - build
@@ -14,7 +14,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^\d+\.\d+\.\d+$/
+              only: /^v\d+\.\d+\.\d+$|^v\d+\.\d+\.\d+-[a-z]+$/
 jobs:
   build:
     docker:


### PR DESCRIPTION
Only trigger full workflow on tags that look like `v0.0.0` or `v0.0.0-something`

Note: CircleCI uses Java regexp and it [does not support conditionals](https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html), so the regexp used here is a bit clumsy