### PR TITLE
fix circleci gcr helper download path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           command: |
             curl -fsSL https://github.com/GoogleCloudPlatform/docker-credential-gcr/releases/download/v1.5.0/docker-credential-gcr_linux_amd64-1.5.0.tar.gz \
               | tar xz --to-stdout ./docker-credential-gcr \
-              > bin/docker-credential-gcr && chmod a+x bin/docker-credential-gcr
+              > $GOPATH/bin/docker-credential-gcr && chmod a+x $GOPATH/bin/docker-credential-gcr
       - run:
           name: Set up authentication to Google Container Registry.
           command: |


### PR DESCRIPTION
For real this time...I swear...perms are more lax in the $GOPATH/bin I believe