### PR TITLE
change gapic gax-go to v2

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -38,7 +38,7 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 		p("}")
 		p("")
 
-		g.imports[pbinfo.ImportSpec{"gax", "github.com/googleapis/gax-go"}] = true
+		g.imports[pbinfo.ImportSpec{"gax", "github.com/googleapis/gax-go/v2"}] = true
 	}
 
 	// defaultClientOptions


### PR DESCRIPTION
Mirroring work for [gapic-generator #2483](https://github.com/googleapis/gapic-generator/issues/2483)

Note: tested by successfully generating & installing a couple of gapics, and by running showcase tests, since the imports aren't covered in the diff testing

cc @jadekler