### PR TITLE
change markdown panic to warning

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -109,7 +109,7 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 		if err := g.genExampleFile(s, pkgName); err != nil {
 			return nil, errors.E(err, "example: %s", s.GetName())
 		}
-		g.imports[pbinfo.ImportSpec{Path: pkgPath}] = true
+		g.imports[pbinfo.ImportSpec{Name: pkgName, Path: pkgPath}] = true
 		g.commit(outFile+"_client_example_test.go", pkgName+"_test")
 	}
 

--- a/internal/gengapic/markdown.go
+++ b/internal/gengapic/markdown.go
@@ -20,6 +20,7 @@ package gengapic
 import (
 	"fmt"
 	"log"
+	"os"
 	"strings"
 
 	"github.com/golang-commonmark/markdown"
@@ -71,6 +72,7 @@ func (m *mdRenderer) plain(t markdown.Token) {
 	default:
 		// TODO(pongad): When going into production, we should turn this to warn.
 		// In the meantime, it's nice to crash to make sure we see it.
-		log.Panicf("unhandled type: %#v", t)
+		log.SetOutput(os.Stderr)
+		log.Printf("unhandled type: %#v", t)
 	}
 }

--- a/internal/gengapic/markdown.go
+++ b/internal/gengapic/markdown.go
@@ -20,7 +20,6 @@ package gengapic
 import (
 	"fmt"
 	"log"
-	"os"
 	"strings"
 
 	"github.com/golang-commonmark/markdown"
@@ -70,9 +69,6 @@ func (m *mdRenderer) plain(t markdown.Token) {
 		m.linkTargets = m.linkTargets[:l-1]
 
 	default:
-		// TODO(pongad): When going into production, we should turn this to warn.
-		// In the meantime, it's nice to crash to make sure we see it.
-		log.SetOutput(os.Stderr)
-		log.Printf("unhandled type: %#v", t)
+		log.Printf("unhandled type: %T", t)
 	}
 }


### PR DESCRIPTION
Takes initial step of changing the panic at unknown markdown types to a warning, described in #70 

While evaluating generated output for Go Cloud clients, missing `pkgName` in client example headers caused some automated vetting (a comparison to `goimport` output) to fail.