### PR TITLE
parse comment inline html

### DIFF
--- a/internal/gengapic/markdown_test.go
+++ b/internal/gengapic/markdown_test.go
@@ -39,6 +39,14 @@ func TestMDPlain(t *testing.T) {
 			in:   "paragraph\n\nanother paragraph",
 			want: "paragraph\n\nanother paragraph",
 		},
+		{
+			in:   "<b>html</b> <a href=\"/link/to/some#thing\">value</a> <br> test",
+			want: "html value (at /link/to/some#thing) \n test",
+		},
+		{
+			in:   "not <actually: html, just some> docs",
+			want: "not <actually: html, just some> docs",
+		},
 	} {
 		got := MDPlain(tst.in)
 		if got != tst.want {


### PR DESCRIPTION
Fix #51 

* ignores font-based tags like `<b>` or `<strong>`
* copies approach of MD links for `<a href="">`
* insert new lines for `<br>`

Note: did not go with HTML parser approach as piggy backing on the MD parsing is much simpler and there should only be a small subset of HTML used in proto comments