### PR TITLE
fix flag parsing in docker-entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,11 +17,15 @@
 
 GO_GAPIC_PACKAGE=
 
+# enable extended globbing for flag pattern matching
+shopt -s extglob
+
 # Parse out options.
 while true; do
   case "$1" in
     --go-gapic-package ) GO_GAPIC_PACKAGE="go-gapic-package=$2"; shift 2 ;;
-    -- ) shift; break; ;;
+    --go-gapic* ) echo "Skipping unrecognized go-gapic flag: $1"; shift ;;
+    --* | +([[:word:][:punct:]]) ) shift ;;
     * ) break ;;
   esac
 done

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -24,7 +24,7 @@ shopt -s extglob
 while true; do
   case "$1" in
     --go-gapic-package ) GO_GAPIC_PACKAGE="go-gapic-package=$2"; shift 2 ;;
-    --go-gapic* ) echo "Skipping unrecognized go-gapic flag: $1"; shift ;;
+    --go-gapic* ) echo "Skipping unrecognized go-gapic flag: $1" >&2; shift ;;
     --* | +([[:word:][:punct:]]) ) shift ;;
     * ) break ;;
   esac


### PR DESCRIPTION
* warns about skipping unrecognized flags prefixed with `--go-gapic`
* skip all other unknown flags and values