### PR TITLE
add more default retry codes

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -72,12 +72,15 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 
 		for _, m := range serv.GetMethod() {
 			if m.GetOptions() == nil {
-				// Some methods are not annotated, this is not an error.
+				// Some methods are not annotated, this is not an error, give it default/nonidempotent config.
+				nonidempotent = append(nonidempotent, m.GetName())
 				continue
 			}
 
 			eHttp, err := proto.GetExtension(m.GetOptions(), annotations.E_Http)
 			if err == proto.ErrMissingExtension {
+				// Give method default/nonidempotent config
+				nonidempotent = append(nonidempotent, m.GetName())
 				continue
 			}
 			if err != nil {

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -66,7 +66,8 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 			codes  []code.Code
 		}
 
-		var defaultRetry []string
+		var idempotent []string
+		var nonidempotent []string
 		var overrideRetry []methodCode
 
 		for _, m := range serv.GetMethod() {
@@ -82,17 +83,20 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 			if err != nil {
 				return errors.E(err, "cannot read HTTP annotation")
 			}
-			// Generator spec mandates we should only retry on GET, unless there is an override.
+			// Generator spec mandates we bucket methods into idempotent and non-idempotent for retries, unless there is an override.
 			// TODO(pongad): implement the override.
-			if _, ok := eHttp.(*annotations.HttpRule).Pattern.(*annotations.HttpRule_Get); ok {
-				defaultRetry = append(defaultRetry, m.GetName())
+			switch eHttp.(*annotations.HttpRule).Pattern.(type) {
+			case *annotations.HttpRule_Get:
+				idempotent = append(idempotent, m.GetName())
+			default:
+				nonidempotent = append(nonidempotent, m.GetName())
 			}
 		}
 
 		// TODO(pongad): read retry params from somewhere
 		p("func default%[1]sCallOptions() *%[1]sCallOptions {", servName)
 
-		if len(defaultRetry) > 0 || len(overrideRetry) > 0 {
+		if len(idempotent) > 0 || len(nonidempotent) > 0 || len(overrideRetry) > 0 {
 			p("backoff := gax.Backoff{")
 			p("  Initial: 100 * time.Millisecond,")
 			p("  Max: time.Minute,")
@@ -103,11 +107,26 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 			g.imports[pbinfo.ImportSpec{Path: "google.golang.org/grpc/codes"}] = true
 		}
 
-		if len(defaultRetry) > 0 {
-			p("retry := []gax.CallOption{")
+		if len(idempotent) > 0 {
+			p("")
+			p("idempotent := []gax.CallOption{")
 			p("  gax.WithRetry(func() gax.Retryer {")
 			p("    return gax.OnCodes([]codes.Code{")
+			p("      codes.Aborted,")
 			p("      codes.Internal,")
+			p("      codes.Unavailable,")
+			p("      codes.Unknown,")
+			p("    }, backoff)")
+			p("  }),")
+			p("}")
+			p("")
+
+		}
+
+		if len(nonidempotent) > 0 {
+			p("nonidempotent := []gax.CallOption{")
+			p("  gax.WithRetry(func() gax.Retryer {")
+			p("    return gax.OnCodes([]codes.Code{")
 			p("      codes.Unavailable,")
 			p("    }, backoff)")
 			p("  }),")
@@ -117,8 +136,11 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 		}
 
 		p("  return &%sCallOptions{", servName)
-		for _, m := range defaultRetry {
-			p("%s: retry,", m)
+		for _, m := range idempotent {
+			p("%s: idempotent,", m)
+		}
+		for _, m := range nonidempotent {
+			p("%s: nonidempotent,", m)
 		}
 		for _, retry := range overrideRetry {
 			p("%s: []gax.CallOption{", retry.method)

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -102,13 +102,13 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 			p("  Max: time.Minute,")
 			p("  Multiplier: 1.3,")
 			p("}")
+			p("")
 
 			g.imports[pbinfo.ImportSpec{Path: "time"}] = true
 			g.imports[pbinfo.ImportSpec{Path: "google.golang.org/grpc/codes"}] = true
 		}
 
 		if len(idempotent) > 0 {
-			p("")
 			p("idempotent := []gax.CallOption{")
 			p("  gax.WithRetry(func() gax.Retryer {")
 			p("    return gax.OnCodes([]codes.Code{")

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -33,7 +33,7 @@ func TestClientOpt(t *testing.T) {
 		Method: []*descriptor.MethodDescriptorProto{
 			{Name: proto.String("Zip"), Options: &descriptor.MethodOptions{}},
 			{Name: proto.String("Zap"), Options: &descriptor.MethodOptions{}},
-			{Name: proto.String("Smack"), Options: &descriptor.MethodOptions{}},
+			{Name: proto.String("Smack")},
 		},
 		Options: &descriptor.ServiceOptions{},
 	}

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -49,6 +49,13 @@ func TestClientOpt(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	if err := proto.SetExtension(serv.Method[1].Options, annotations.E_Http, &annotations.HttpRule{
+		Pattern: &annotations.HttpRule_Post{
+			Post: "/zap",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	for _, tst := range []struct {
 		tstName, servName string

--- a/internal/gengapic/testdata/empty_opt.want
+++ b/internal/gengapic/testdata/empty_opt.want
@@ -41,6 +41,7 @@ func defaultCallOptions() *CallOptions {
 	return &CallOptions{
 		Zip: idempotent,
 		Zap: nonidempotent,
+		Smack: nonidempotent,
 	}
 }
 

--- a/internal/gengapic/testdata/empty_opt.want
+++ b/internal/gengapic/testdata/empty_opt.want
@@ -18,17 +18,29 @@ func defaultCallOptions() *CallOptions {
 		Max: time.Minute,
 		Multiplier: 1.3,
 	}
-	retry := []gax.CallOption{
+
+	idempotent := []gax.CallOption{
 		gax.WithRetry(func() gax.Retryer {
 			return gax.OnCodes([]codes.Code{
+				codes.Aborted,
 				codes.Internal,
+				codes.Unavailable,
+				codes.Unknown,
+			}, backoff)
+		}),
+	}
+
+	nonidempotent := []gax.CallOption{
+		gax.WithRetry(func() gax.Retryer {
+			return gax.OnCodes([]codes.Code{
 				codes.Unavailable,
 			}, backoff)
 		}),
 	}
 
 	return &CallOptions{
-		Zip: retry,
+		Zip: idempotent,
+		Zap: nonidempotent,
 	}
 }
 

--- a/internal/gengapic/testdata/foo_opt.want
+++ b/internal/gengapic/testdata/foo_opt.want
@@ -41,6 +41,7 @@ func defaultFooCallOptions() *FooCallOptions {
 	return &FooCallOptions{
 		Zip: idempotent,
 		Zap: nonidempotent,
+		Smack: nonidempotent,
 	}
 }
 

--- a/internal/gengapic/testdata/foo_opt.want
+++ b/internal/gengapic/testdata/foo_opt.want
@@ -18,17 +18,29 @@ func defaultFooCallOptions() *FooCallOptions {
 		Max: time.Minute,
 		Multiplier: 1.3,
 	}
-	retry := []gax.CallOption{
+
+	idempotent := []gax.CallOption{
 		gax.WithRetry(func() gax.Retryer {
 			return gax.OnCodes([]codes.Code{
+				codes.Aborted,
 				codes.Internal,
+				codes.Unavailable,
+				codes.Unknown,
+			}, backoff)
+		}),
+	}
+
+	nonidempotent := []gax.CallOption{
+		gax.WithRetry(func() gax.Retryer {
+			return gax.OnCodes([]codes.Code{
 				codes.Unavailable,
 			}, backoff)
 		}),
 	}
 
 	return &FooCallOptions{
-		Zip: retry,
+		Zip: idempotent,
+		Zap: nonidempotent,
 	}
 }
 


### PR DESCRIPTION
Fix #74 

* group RPC retries based on idempotency
* add `ABORTED` and `UNKNOWN` to the existing idempotent retry config
* add retry config on `UNAVAILABLE` for non-idempotent methods 