### PR TITLE
add minimum service config support

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,6 +16,7 @@
 # THIS SCRIPT IS MEANT ONLY TO BE USED IN THE GAPIC-GENERATOR-GO DOCKER IMAGE
 
 GO_GAPIC_PACKAGE=
+GO_GAPIC_SERVICE_CONFIG=
 
 # enable extended globbing for flag pattern matching
 shopt -s extglob
@@ -24,6 +25,7 @@ shopt -s extglob
 while true; do
   case "$1" in
     --go-gapic-package ) GO_GAPIC_PACKAGE="go-gapic-package=$2"; shift 2 ;;
+    --go-gapic-service-config ) GO_GAPIC_SERVICE_CONFIG="go-gapic-service-config=/conf/$2"; shift 2;;
     --go-gapic* ) echo "Skipping unrecognized go-gapic flag: $1" >&2; shift ;;
     --* | +([[:word:][:punct:]]) ) shift ;;
     * ) break ;;
@@ -38,4 +40,5 @@ fi
 protoc --proto_path=/protos/ --proto_path=/in/ \
                   --go_gapic_out=/out/ \
                   --go_gapic_opt="$GO_GAPIC_PACKAGE" \
+                  --go_gapic_opt="$GO_GAPIC_SERVICE_CONFIG" \
                   `find /in/ -name *.proto`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,7 +16,7 @@
 # THIS SCRIPT IS MEANT ONLY TO BE USED IN THE GAPIC-GENERATOR-GO DOCKER IMAGE
 
 GO_GAPIC_PACKAGE=
-GO_GAPIC_SERVICE_CONFIG=
+GAPIC_SERVICE_CONFIG=
 
 # enable extended globbing for flag pattern matching
 shopt -s extglob
@@ -25,7 +25,7 @@ shopt -s extglob
 while true; do
   case "$1" in
     --go-gapic-package ) GO_GAPIC_PACKAGE="go-gapic-package=$2"; shift 2 ;;
-    --go-gapic-service-config ) GO_GAPIC_SERVICE_CONFIG="go-gapic-service-config=/conf/$2"; shift 2;;
+    --gapic-service-config ) GAPIC_SERVICE_CONFIG="gapic-service-config=/conf/$2"; shift 2;;
     --go-gapic* ) echo "Skipping unrecognized go-gapic flag: $1" >&2; shift ;;
     --* | +([[:word:][:punct:]]) ) shift ;;
     * ) break ;;
@@ -40,5 +40,5 @@ fi
 protoc --proto_path=/protos/ --proto_path=/in/ \
                   --go_gapic_out=/out/ \
                   --go_gapic_opt="$GO_GAPIC_PACKAGE" \
-                  --go_gapic_opt="$GO_GAPIC_SERVICE_CONFIG" \
+                  --go_gapic_opt="$GAPIC_SERVICE_CONFIG" \
                   `find /in/ -name *.proto`

--- a/gapic.sh
+++ b/gapic.sh
@@ -94,6 +94,7 @@ fi
 
 # Generate the client library.
 docker run \
+  --mount type=bind,source=${PROTO_PATH},destination=/conf,readonly \
   --mount type=bind,source=${PROTO_PATH}/${IN},destination=/in/${IN},readonly \
   --mount type=bind,source=$OUT,destination=/out \
   --rm \

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -46,9 +46,9 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 		var host string
 		if eHost, err := proto.GetExtension(serv.Options, annotations.E_DefaultHost); err == nil {
 			host = *eHost.(*string)
-		} else if len(g.serviceConfig) > 0 {
+		} else if g.serviceConfig != nil {
 			// TODO(ndietz) remove this once default_host annotation is acepted
-			host = g.serviceConfig["name"].(string)
+			host = g.serviceConfig.Name
 		} else {
 			return errors.E(err, "cannot read default host")
 		}

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -43,14 +43,19 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 
 	// defaultClientOptions
 	{
-		eHost, err := proto.GetExtension(serv.Options, annotations.E_DefaultHost)
-		if err != nil {
+		var host string
+		if eHost, err := proto.GetExtension(serv.Options, annotations.E_DefaultHost); err == nil {
+			host = *eHost.(*string)
+		} else if len(g.serviceConfig) > 0 {
+			// TODO(ndietz) remove this once default_host annotation is acepted
+			host = g.serviceConfig["name"].(string)
+		} else {
 			return errors.E(err, "cannot read default host")
 		}
 
 		p("func default%sClientOptions() []option.ClientOption {", servName)
 		p("  return []option.ClientOption{")
-		p(`    option.WithEndpoint("%s:443"),`, *eHost.(*string))
+		p(`    option.WithEndpoint("%s:443"),`, host)
 		p("    option.WithScopes(DefaultAuthScopes()...),")
 		p("  }")
 		p("}")
@@ -187,7 +192,7 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 
 	// client struct
 	{
-		p("// %sClient is a client for interacting with %s API.", servName, g.apiName)
+		p("// %sClient is a client for interacting with %s.", servName, g.apiName)
 		p("//")
 		p("// Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.")
 		p("type %sClient struct {", servName)

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -74,7 +74,7 @@ func TestClientOpt(t *testing.T) {
 
 func TestClientInit(t *testing.T) {
 	var g generator
-	g.apiName = "Awesome Foo"
+	g.apiName = "Awesome Foo API"
 	g.imports = map[pbinfo.ImportSpec]bool{}
 
 	servPlain := &descriptor.ServiceDescriptorProto{

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -15,8 +15,6 @@
 package gengapic
 
 import (
-	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -153,7 +151,6 @@ func collectScopes(servs []*descriptor.ServiceDescriptorProto, config *serviceCo
 	}
 
 	// TODO(ndietz) remove this once oauth scopes annotation is accepted
-	fmt.Fprintf(os.Stderr, "Auth in collectScopes: %+v\n", config.Authentication.Rules[0].Oauth)
 	if len(scopeSet) == 0 && config != nil && config.Authentication != nil {
 		if len(config.Authentication.Rules) > 0 {
 			for _, rule := range config.Authentication.Rules {

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -35,16 +35,19 @@ func (g *generator) genDocFile(pkgPath, pkgName string, year int, scopes []strin
 	p(license.Apache, year)
 	p("")
 
-	if an := g.apiName; an != "" {
+	if g.apiName != "" {
 		p("// Package %s is an auto-generated package for the", pkgName)
-		p("// %s.", an)
+		p("// %s.", g.apiName)
 	}
 
 	// TODO(ndietz) figure out how to include this without the service config
 	if g.serviceConfig != nil && g.serviceConfig.Documentation != nil {
 		wrapped := wrapString(g.serviceConfig.Documentation.Summary, 75)
 
-		p("")
+		if len(wrapped) > 0 && g.apiName != "" {
+			p("//")
+		}
+
 		for _, line := range wrapped {
 			p("// %s", strings.TrimSpace(line))
 		}

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -188,7 +188,7 @@ func wrapString(str string, max int) []string {
 		return lines
 	}
 
-	split := strings.Split(str, " ")
+	split := strings.Fields(str)
 	for _, w := range split {
 		if len(line)+len(w)+1 > max {
 			lines = append(lines, line)

--- a/internal/gengapic/doc_file_test.go
+++ b/internal/gengapic/doc_file_test.go
@@ -24,9 +24,9 @@ import (
 func TestDocFile(t *testing.T) {
 	var g generator
 	g.apiName = "Awesome Foo API"
-	g.serviceConfig = map[string]interface{}{
-		"documentation": map[interface{}]interface{}{
-			"summary": "The Awesome Foo API is really really awesome. It enables the use of Foo with Buz and Baz to acclerate bar.",
+	g.serviceConfig = &serviceConfig{
+		Documentation: &configDocumentation{
+			Summary: "The Awesome Foo API is really really awesome. It enables the use of Foo with Buz and Baz to acclerate bar.",
 		},
 	}
 

--- a/internal/gengapic/doc_file_test.go
+++ b/internal/gengapic/doc_file_test.go
@@ -23,7 +23,13 @@ import (
 
 func TestDocFile(t *testing.T) {
 	var g generator
-	g.apiName = "Awesome Foo"
+	g.apiName = "Awesome Foo API"
+	g.serviceConfig = map[string]interface{}{
+		"documentation": map[interface{}]interface{}{
+			"summary": "The Awesome Foo API is really really awesome. It enables the use of Foo with Buz and Baz to acclerate bar.",
+		},
+	}
+
 	g.genDocFile("path/to/awesome", "awesome", 42, []string{"https://foo.bar.com/auth", "https://zip.zap.com/auth"})
 	txtdiff.Diff(t, "doc_file", g.pt.String(), filepath.Join("testdata", "doc_file.want"))
 }

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -107,9 +107,9 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 		nameParts := append([]string(nil), eMeta.PackageNamespace...)
 		nameParts = append(nameParts, eMeta.ProductName, "API")
 		g.apiName = strings.Join(nameParts, " ")
-	} else if len(g.serviceConfig) > 0 {
+	} else if g.serviceConfig != nil {
 		// TODO(ndietz) remove this once metadata/packaging annotations are accepted
-		g.apiName = g.serviceConfig["title"].(string)
+		g.apiName = g.serviceConfig.Title
 	}
 
 	for _, s := range genServs {
@@ -174,7 +174,7 @@ type generator struct {
 	apiName string
 
 	// Parsed service config from plugin option
-	serviceConfig map[string]interface{}
+	serviceConfig *serviceConfig
 }
 
 func (g *generator) init(files []*descriptor.FileDescriptorProto) {

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -16,12 +16,15 @@ package gengapic
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"time"
 	"unicode"
 	"unicode/utf8"
+
+	"gopkg.in/yaml.v2"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
@@ -42,22 +45,37 @@ const (
 
 func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, error) {
 	var pkgPath, pkgName, outDir string
+	var g generator
+
 	if genReq.Parameter == nil {
 		return nil, errors.E(nil, paramError)
 	}
 
 	// parse plugin params, ignoring unknown values
 	for _, s := range strings.Split(*genReq.Parameter, ",") {
-		if e := strings.IndexByte(*genReq.Parameter, '='); e > 0 && s[:e] == "go-gapic-package" {
-			p := strings.IndexByte(*genReq.Parameter, ';')
+		if e := strings.IndexByte(s, '='); e > 0 {
+			switch s[:e] {
+			case "go-gapic-package":
+				p := strings.IndexByte(s, ';')
 
-			if p < 0 {
-				return nil, errors.E(nil, paramError)
+				if p < 0 {
+					return nil, errors.E(nil, paramError)
+				}
+
+				pkgPath = s[e+1 : p]
+				pkgName = s[p+1:]
+				outDir = filepath.FromSlash(pkgPath)
+			case "go-gapic-service-config":
+				f, err := os.Open(s[e+1:])
+				if err != nil {
+					return nil, errors.E(nil, "error opening service config: %v", err)
+				}
+
+				err = yaml.NewDecoder(f).Decode(&g.serviceConfig)
+				if err != nil {
+					return nil, errors.E(nil, "error decoding service config: %v", err)
+				}
 			}
-
-			pkgPath = (*genReq.Parameter)[e+1 : p]
-			pkgName = (*genReq.Parameter)[p+1:]
-			outDir = filepath.FromSlash(pkgPath)
 		}
 	}
 
@@ -65,7 +83,6 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 		return nil, errors.E(nil, paramError)
 	}
 
-	var g generator
 	g.init(genReq.ProtoFile)
 
 	var genServs []*descriptor.ServiceDescriptorProto
@@ -83,11 +100,16 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 			}
 		}
 	}
+
+	// favor annotations over service config
 	if eMeta != nil {
 		// Without this, the doc is going to be a little bad but this is not an error.
 		nameParts := append([]string(nil), eMeta.PackageNamespace...)
-		nameParts = append(nameParts, eMeta.ProductName)
+		nameParts = append(nameParts, eMeta.ProductName, "API")
 		g.apiName = strings.Join(nameParts, " ")
+	} else if len(g.serviceConfig) > 0 {
+		// TODO(ndietz) remove this once metadata/packaging annotations are accepted
+		g.apiName = g.serviceConfig["title"].(string)
 	}
 
 	for _, s := range genServs {
@@ -114,7 +136,7 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 	}
 
 	g.reset()
-	scopes, err := collectScopes(genServs)
+	scopes, err := collectScopes(genServs, g.serviceConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -150,6 +172,9 @@ type generator struct {
 
 	// Human-readable name of the API used in docs
 	apiName string
+
+	// Parsed service config from plugin option
+	serviceConfig map[string]interface{}
 }
 
 func (g *generator) init(files []*descriptor.FileDescriptorProto) {

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -65,7 +65,7 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 				pkgPath = s[e+1 : p]
 				pkgName = s[p+1:]
 				outDir = filepath.FromSlash(pkgPath)
-			case "go-gapic-service-config":
+			case "gapic-service-config":
 				f, err := os.Open(s[e+1:])
 				if err != nil {
 					return nil, errors.E(nil, "error opening service config: %v", err)

--- a/internal/gengapic/service_config.go
+++ b/internal/gengapic/service_config.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gengapic
+
+// serviceConfig represents a gapic service config
+// Deprecated: workaround for not having annotations yet; to be removed
+type serviceConfig struct {
+	Name           string
+	Title          string
+	Documentation  *configDocumentation
+	Authentication *configAuthentication
+}
+
+// configDocumentation represents gapic service config documentation section
+// Deprecated: workaround for not having annotations yet; to be removed
+type configDocumentation struct {
+	Summary string
+}
+
+// configAuthentication represents gapic service config authentication section
+// Deprecated: workaround for not having annotations yet; to be removed
+type configAuthentication struct {
+	Rules []*configAuthRules
+}
+
+// configAuthRules represents gapic service config auth rules
+// Deprecated: workaround for not having annotations yet; to be removed
+type configAuthRules struct {
+	Selector string
+	Oauth    *configAuthRulesOauth
+}
+
+// configAuthRulesOauth represents a gapic service config oauth rule
+// Deprecated: workaround for not having annotations yet; to be removed
+type configAuthRulesOauth struct {
+	CanonicalScopes string `yaml:"canonical_scopes"`
+}

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -17,7 +17,6 @@
 // Package awesome is an auto-generated package for the
 // Awesome Foo API.
 
-//
 // The Awesome Foo API is really really awesome. It enables the use of Foo
 // with Buz and Baz to acclerate bar.
 package awesome // import "path/to/awesome"

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -16,6 +16,10 @@
 
 // Package awesome is an auto-generated package for the
 // Awesome Foo API.
+
+//
+// The Awesome Foo API is really really awesome. It enables the use of Foo
+// with Buz and Baz to acclerate bar.
 package awesome // import "path/to/awesome"
 
 import (

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -16,7 +16,7 @@
 
 // Package awesome is an auto-generated package for the
 // Awesome Foo API.
-
+//
 // The Awesome Foo API is really really awesome. It enables the use of Foo
 // with Buz and Baz to acclerate bar.
 package awesome // import "path/to/awesome"


### PR DESCRIPTION
* adds `gapic-service-config` plugin option
* uses service config as **primary** source for the documentation summary header comment
* uses service config as **secondary** source (defers to annotations when present) for API Name, oauth scopes, and default_host 

This is a temporary workaround for: 
1. severely delayed metadata annotations
2. annotation config lacking the doc summary content
3. TBD acceptance of the oauth scope & default_host annotations

This workaround can be removed entirely once the above gaps have been closed. Also, individual workarounds can be removed as each individual gap is closed.