### PR TITLE
remove retry internal status code

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -121,7 +121,6 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 			p("  gax.WithRetry(func() gax.Retryer {")
 			p("    return gax.OnCodes([]codes.Code{")
 			p("      codes.Aborted,")
-			p("      codes.Internal,")
 			p("      codes.Unavailable,")
 			p("      codes.Unknown,")
 			p("    }, backoff)")

--- a/internal/gengapic/testdata/empty_opt.want
+++ b/internal/gengapic/testdata/empty_opt.want
@@ -23,7 +23,6 @@ func defaultCallOptions() *CallOptions {
 		gax.WithRetry(func() gax.Retryer {
 			return gax.OnCodes([]codes.Code{
 				codes.Aborted,
-				codes.Internal,
 				codes.Unavailable,
 				codes.Unknown,
 			}, backoff)

--- a/internal/gengapic/testdata/foo_opt.want
+++ b/internal/gengapic/testdata/foo_opt.want
@@ -23,7 +23,6 @@ func defaultFooCallOptions() *FooCallOptions {
 		gax.WithRetry(func() gax.Retryer {
 			return gax.OnCodes([]codes.Code{
 				codes.Aborted,
-				codes.Internal,
 				codes.Unavailable,
 				codes.Unknown,
 			}, backoff)


### PR DESCRIPTION
Per offline discussion, the `INTERNAL` status code will not be retried _at all_.