### PR TITLE
Strip 'v' from release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
           name: Tag the Docker image and push it to Google Container Registry.
           command: |
             if [ -n "$CIRCLE_TAG" ]; then
-              export MAJOR=`echo $CIRCLE_TAG | awk -F '.' '{ print $1; }'`
+              export MAJOR=`echo ${CIRCLE_TAG:1} | awk -F '.' '{ print $1; }'`
               export MINOR=`echo $CIRCLE_TAG | awk -F '.' '{ print $2; }'`
               export PATCH=`echo $CIRCLE_TAG | awk -F '.' '{ print $3; }'`
               docker tag gcr.io/gapic-images/gapic-generator-go:latest gcr.io/gapic-images/gapic-generator-go:$MAJOR.$MINOR.$PATCH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,8 @@ jobs:
           command: |
             if [ -n "$CIRCLE_TAG" ]; then
               export MAJOR=`echo ${CIRCLE_TAG:1} | awk -F '.' '{ print $1; }'`
-              export MINOR=`echo $CIRCLE_TAG | awk -F '.' '{ print $2; }'`
-              export PATCH=`echo $CIRCLE_TAG | awk -F '.' '{ print $3; }'`
+              export MINOR=`echo ${CIRCLE_TAG:1} | awk -F '.' '{ print $2; }'`
+              export PATCH=`echo ${CIRCLE_TAG:1} | awk -F '.' '{ print $3; }'`
               docker tag gcr.io/gapic-images/gapic-generator-go:latest gcr.io/gapic-images/gapic-generator-go:$MAJOR.$MINOR.$PATCH
               docker tag gcr.io/gapic-images/gapic-generator-go:latest gcr.io/gapic-images/gapic-generator-go:$MAJOR.$MINOR
               docker tag gcr.io/gapic-images/gapic-generator-go:latest gcr.io/gapic-images/gapic-generator-go:$MAJOR


### PR DESCRIPTION
I noticed that most of the go images in GCR start with a 'v'. Unless there's a reason for doing it that way, it may be better to just stick to the convention of using a version number.