### PR TITLE
respect default_host port if present

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -15,8 +15,6 @@
 package gengapic
 
 import (
-	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
@@ -26,10 +24,6 @@ import (
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/googleapis/rpc/code"
 )
-
-const defaultPort = 443
-
-var portRegex = regexp.MustCompile(":[0-9]{1,5}$")
 
 func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servName string) error {
 	p := g.printf
@@ -59,8 +53,8 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 			return errors.E(err, "cannot read default host")
 		}
 
-		if !portRegex.MatchString(host) {
-			host = fmt.Sprintf("%s:%d", host, defaultPort)
+		if !strings.Contains(host, ":") {
+			host += ":443"
 		}
 
 		p("func default%sClientOptions() []option.ClientOption {", servName)

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -15,6 +15,8 @@
 package gengapic
 
 import (
+	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/golang/protobuf/proto"
@@ -24,6 +26,10 @@ import (
 	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/googleapis/rpc/code"
 )
+
+const defaultPort = 443
+
+var portRegex = regexp.MustCompile(":[0-9]{1,5}$")
 
 func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servName string) error {
 	p := g.printf
@@ -53,9 +59,13 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 			return errors.E(err, "cannot read default host")
 		}
 
+		if !portRegex.MatchString(host) {
+			host = fmt.Sprintf("%s:%d", host, defaultPort)
+		}
+
 		p("func default%sClientOptions() []option.ClientOption {", servName)
 		p("  return []option.ClientOption{")
-		p(`    option.WithEndpoint("%s:443"),`, host)
+		p(`    option.WithEndpoint("%s"),`, host)
 		p("    option.WithScopes(DefaultAuthScopes()...),")
 		p("  }")
 		p("}")

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -57,14 +57,26 @@ func TestClientOpt(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	servHostPort := &descriptor.ServiceDescriptorProto{
+		Method: []*descriptor.MethodDescriptorProto{
+			{Name: proto.String("Smack")},
+		},
+		Options: &descriptor.ServiceOptions{},
+	}
+	if err := proto.SetExtension(servHostPort.Options, annotations.E_DefaultHost, proto.String("foo.bar.com:1234")); err != nil {
+		t.Fatal(err)
+	}
+
 	for _, tst := range []struct {
 		tstName, servName string
+		serv              *descriptor.ServiceDescriptorProto
 	}{
-		{tstName: "foo_opt", servName: "Foo"},
-		{tstName: "empty_opt", servName: ""},
+		{tstName: "foo_opt", servName: "Foo", serv: serv},
+		{tstName: "empty_opt", servName: "", serv: serv},
+		{tstName: "host_port_opt", servName: "Bar", serv: servHostPort},
 	} {
 		g.reset()
-		if err := g.clientOptions(serv, tst.servName); err != nil {
+		if err := g.clientOptions(tst.serv, tst.servName); err != nil {
 			t.Error(err)
 			continue
 		}

--- a/internal/gengapic/testdata/host_port_opt.want
+++ b/internal/gengapic/testdata/host_port_opt.want
@@ -1,0 +1,32 @@
+// BarCallOptions contains the retry settings for each method of BarClient.
+type BarCallOptions struct {
+	Smack []gax.CallOption
+}
+
+func defaultBarClientOptions() []option.ClientOption {
+	return []option.ClientOption{
+		option.WithEndpoint("foo.bar.com:1234"),
+		option.WithScopes(DefaultAuthScopes()...),
+	}
+}
+
+func defaultBarCallOptions() *BarCallOptions {
+	backoff := gax.Backoff{
+		Initial: 100 * time.Millisecond,
+		Max: time.Minute,
+		Multiplier: 1.3,
+	}
+
+	nonidempotent := []gax.CallOption{
+		gax.WithRetry(func() gax.Retryer {
+			return gax.OnCodes([]codes.Code{
+				codes.Unavailable,
+			}, backoff)
+		}),
+	}
+
+	return &BarCallOptions{
+		Smack: nonidempotent,
+	}
+}
+


### PR DESCRIPTION
Per offline discussions with @lukesneeringer and comparing to [gapic-generator-python](https://github.com/googleapis/gapic-generator-python/blob/master/gapic/templates/$namespace/$name_$version/$sub/services/$service/transports/base.py.j2#L42-L45), a port present in the `google.api.default_host` annotation value should be respected. A default of `443` should be used otherwise.

Note: This was not explicitly stated in the implementation or configuration specification documentation.