### PR TITLE
gengapic: add import comment in example snippets

### DIFF
--- a/internal/gengapic/example.go
+++ b/internal/gengapic/example.go
@@ -78,7 +78,7 @@ func (g *generator) exampleMethod(pkgName, servName string, m *descriptor.Method
 	}
 
 	if *m.OutputType != emptyType {
-		p("// import \"%s\" %s", inSpec.Path, inSpec.Name)
+		p("// import %s \"%s\"", inSpec.Name, inSpec.Path)
 		if pf == nil {
 			p("")
 		}

--- a/internal/gengapic/example.go
+++ b/internal/gengapic/example.go
@@ -75,6 +75,7 @@ func (g *generator) exampleMethod(pkgName, servName string, m *descriptor.Method
 
 	if !m.GetClientStreaming() && !m.GetServerStreaming() {
 		p("")
+		p("// %s is import %s.", inSpec.Name, inSpec.Path)
 		p("req := &%s.%s{", inSpec.Name, inType.GetName())
 		p("  // TODO: Fill request struct fields.")
 		p("}")
@@ -141,6 +142,7 @@ func (g *generator) examplePagingCall(m *descriptor.MethodDescriptorProto) {
 
 	p("it := c.%s(ctx, req)", *m.Name)
 	p("for {")
+	p("  // iterator from http://godoc.org/google.golang.org/api/iterator.")
 	p("  resp, err := it.Next()")
 	p("  if err == iterator.Done {")
 	p("    break")
@@ -164,6 +166,7 @@ func (g *generator) exampleBidiCall(m *descriptor.MethodDescriptorProto, inType 
 	p("}")
 
 	p("go func() {")
+	p("  // %s is import %s.", inSpec.Name, inSpec.Path)
 	p("  reqs := []*%s.%s{", inSpec.Name, inType.GetName())
 	p("    // TODO: Create requests.")
 	p("  }")

--- a/internal/gengapic/testdata/empty_example.want
+++ b/internal/gengapic/testdata/empty_example.want
@@ -15,7 +15,6 @@ func ExampleClient_GetEmptyThing() {
 		// TODO: Handle error.
 	}
 
-	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -26,13 +25,14 @@ func ExampleClient_GetEmptyThing() {
 }
 
 func ExampleClient_GetOneThing() {
+	// import "mypackage" mypackagepb
+
 	ctx := context.Background()
 	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
 
-	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -45,13 +45,14 @@ func ExampleClient_GetOneThing() {
 }
 
 func ExampleClient_GetBigThing() {
+	// import "mypackage" mypackagepb
+
 	ctx := context.Background()
 	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
 
-	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -69,19 +70,20 @@ func ExampleClient_GetBigThing() {
 }
 
 func ExampleClient_GetManyThings() {
+	// import "mypackage" mypackagepb
+	// import "google.golang.org/api/iterator"
+
 	ctx := context.Background()
 	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
 
-	// mypackagepb is import mypackage.
 	req := &mypackagepb.PageInputType{
 		// TODO: Fill request struct fields.
 	}
 	it := c.GetManyThings(ctx, req)
 	for {
-		// iterator from http://godoc.org/google.golang.org/api/iterator.
 		resp, err := it.Next()
 		if err == iterator.Done {
 			break
@@ -95,6 +97,8 @@ func ExampleClient_GetManyThings() {
 }
 
 func ExampleClient_BidiThings() {
+	// import "mypackage" mypackagepb
+
 	ctx := context.Background()
 	c, err := Foo.NewClient(ctx)
 	if err != nil {
@@ -105,7 +109,6 @@ func ExampleClient_BidiThings() {
 		// TODO: Handle error.
 	}
 	go func() {
-		// mypackagepb is import mypackage.
 		reqs := []*mypackagepb.InputType{
 			// TODO: Create requests.
 		}

--- a/internal/gengapic/testdata/empty_example.want
+++ b/internal/gengapic/testdata/empty_example.want
@@ -25,7 +25,7 @@ func ExampleClient_GetEmptyThing() {
 }
 
 func ExampleClient_GetOneThing() {
-	// import "mypackage" mypackagepb
+	// import mypackagepb "mypackage"
 
 	ctx := context.Background()
 	c, err := Foo.NewClient(ctx)
@@ -45,7 +45,7 @@ func ExampleClient_GetOneThing() {
 }
 
 func ExampleClient_GetBigThing() {
-	// import "mypackage" mypackagepb
+	// import mypackagepb "mypackage"
 
 	ctx := context.Background()
 	c, err := Foo.NewClient(ctx)
@@ -70,7 +70,7 @@ func ExampleClient_GetBigThing() {
 }
 
 func ExampleClient_GetManyThings() {
-	// import "mypackage" mypackagepb
+	// import mypackagepb "mypackage"
 	// import "google.golang.org/api/iterator"
 
 	ctx := context.Background()
@@ -97,7 +97,7 @@ func ExampleClient_GetManyThings() {
 }
 
 func ExampleClient_BidiThings() {
-	// import "mypackage" mypackagepb
+	// import mypackagepb "mypackage"
 
 	ctx := context.Background()
 	c, err := Foo.NewClient(ctx)

--- a/internal/gengapic/testdata/empty_example.want
+++ b/internal/gengapic/testdata/empty_example.want
@@ -15,6 +15,7 @@ func ExampleClient_GetEmptyThing() {
 		// TODO: Handle error.
 	}
 
+	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -31,6 +32,7 @@ func ExampleClient_GetOneThing() {
 		// TODO: Handle error.
 	}
 
+	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -49,6 +51,7 @@ func ExampleClient_GetBigThing() {
 		// TODO: Handle error.
 	}
 
+	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -72,11 +75,13 @@ func ExampleClient_GetManyThings() {
 		// TODO: Handle error.
 	}
 
+	// mypackagepb is import mypackage.
 	req := &mypackagepb.PageInputType{
 		// TODO: Fill request struct fields.
 	}
 	it := c.GetManyThings(ctx, req)
 	for {
+		// iterator from http://godoc.org/google.golang.org/api/iterator.
 		resp, err := it.Next()
 		if err == iterator.Done {
 			break
@@ -100,6 +105,7 @@ func ExampleClient_BidiThings() {
 		// TODO: Handle error.
 	}
 	go func() {
+		// mypackagepb is import mypackage.
 		reqs := []*mypackagepb.InputType{
 			// TODO: Create requests.
 		}

--- a/internal/gengapic/testdata/foo_example.want
+++ b/internal/gengapic/testdata/foo_example.want
@@ -15,6 +15,7 @@ func ExampleFooClient_GetEmptyThing() {
 		// TODO: Handle error.
 	}
 
+	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -31,6 +32,7 @@ func ExampleFooClient_GetOneThing() {
 		// TODO: Handle error.
 	}
 
+	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -49,6 +51,7 @@ func ExampleFooClient_GetBigThing() {
 		// TODO: Handle error.
 	}
 
+	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -72,11 +75,13 @@ func ExampleFooClient_GetManyThings() {
 		// TODO: Handle error.
 	}
 
+	// mypackagepb is import mypackage.
 	req := &mypackagepb.PageInputType{
 		// TODO: Fill request struct fields.
 	}
 	it := c.GetManyThings(ctx, req)
 	for {
+		// iterator from http://godoc.org/google.golang.org/api/iterator.
 		resp, err := it.Next()
 		if err == iterator.Done {
 			break
@@ -100,6 +105,7 @@ func ExampleFooClient_BidiThings() {
 		// TODO: Handle error.
 	}
 	go func() {
+		// mypackagepb is import mypackage.
 		reqs := []*mypackagepb.InputType{
 			// TODO: Create requests.
 		}

--- a/internal/gengapic/testdata/foo_example.want
+++ b/internal/gengapic/testdata/foo_example.want
@@ -15,7 +15,6 @@ func ExampleFooClient_GetEmptyThing() {
 		// TODO: Handle error.
 	}
 
-	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -26,13 +25,14 @@ func ExampleFooClient_GetEmptyThing() {
 }
 
 func ExampleFooClient_GetOneThing() {
+	// import "mypackage" mypackagepb
+
 	ctx := context.Background()
 	c, err := Bar.NewFooClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
 
-	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -45,13 +45,14 @@ func ExampleFooClient_GetOneThing() {
 }
 
 func ExampleFooClient_GetBigThing() {
+	// import "mypackage" mypackagepb
+
 	ctx := context.Background()
 	c, err := Bar.NewFooClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
 
-	// mypackagepb is import mypackage.
 	req := &mypackagepb.InputType{
 		// TODO: Fill request struct fields.
 	}
@@ -69,19 +70,20 @@ func ExampleFooClient_GetBigThing() {
 }
 
 func ExampleFooClient_GetManyThings() {
+	// import "mypackage" mypackagepb
+	// import "google.golang.org/api/iterator"
+
 	ctx := context.Background()
 	c, err := Bar.NewFooClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
 
-	// mypackagepb is import mypackage.
 	req := &mypackagepb.PageInputType{
 		// TODO: Fill request struct fields.
 	}
 	it := c.GetManyThings(ctx, req)
 	for {
-		// iterator from http://godoc.org/google.golang.org/api/iterator.
 		resp, err := it.Next()
 		if err == iterator.Done {
 			break
@@ -95,6 +97,8 @@ func ExampleFooClient_GetManyThings() {
 }
 
 func ExampleFooClient_BidiThings() {
+	// import "mypackage" mypackagepb
+
 	ctx := context.Background()
 	c, err := Bar.NewFooClient(ctx)
 	if err != nil {
@@ -105,7 +109,6 @@ func ExampleFooClient_BidiThings() {
 		// TODO: Handle error.
 	}
 	go func() {
-		// mypackagepb is import mypackage.
 		reqs := []*mypackagepb.InputType{
 			// TODO: Create requests.
 		}

--- a/internal/gengapic/testdata/foo_example.want
+++ b/internal/gengapic/testdata/foo_example.want
@@ -25,7 +25,7 @@ func ExampleFooClient_GetEmptyThing() {
 }
 
 func ExampleFooClient_GetOneThing() {
-	// import "mypackage" mypackagepb
+	// import mypackagepb "mypackage"
 
 	ctx := context.Background()
 	c, err := Bar.NewFooClient(ctx)
@@ -45,7 +45,7 @@ func ExampleFooClient_GetOneThing() {
 }
 
 func ExampleFooClient_GetBigThing() {
-	// import "mypackage" mypackagepb
+	// import mypackagepb "mypackage"
 
 	ctx := context.Background()
 	c, err := Bar.NewFooClient(ctx)
@@ -70,7 +70,7 @@ func ExampleFooClient_GetBigThing() {
 }
 
 func ExampleFooClient_GetManyThings() {
-	// import "mypackage" mypackagepb
+	// import mypackagepb "mypackage"
 	// import "google.golang.org/api/iterator"
 
 	ctx := context.Background()
@@ -97,7 +97,7 @@ func ExampleFooClient_GetManyThings() {
 }
 
 func ExampleFooClient_BidiThings() {
-	// import "mypackage" mypackagepb
+	// import mypackagepb "mypackage"
 
 	ctx := context.Background()
 	c, err := Bar.NewFooClient(ctx)


### PR DESCRIPTION
Fixes #107 
Fixes [google-cloud-go#1356](https://github.com/googleapis/google-cloud-go/issues/1356)

In generated example snippets, add comment beside request payloads indicating import path of struct and for the iterator type.

@broady @jadekler can you review?