### PR TITLE
plugins: report error in res rather than crash

### DIFF
--- a/cmd/protoc-gen-go_cli/main.go
+++ b/cmd/protoc-gen-go_cli/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	genResp, err := gencli.Gen(&genReq)
 	if err != nil {
-		log.Fatal(err)
+		genResp.Error = proto.String(err.Error())
 	}
 
 	outBytes, err := proto.Marshal(genResp)

--- a/cmd/protoc-gen-go_gapic/main.go
+++ b/cmd/protoc-gen-go_gapic/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	genResp, err := gengapic.Gen(&genReq)
 	if err != nil {
-		log.Fatal(err)
+		genResp.Error = proto.String(err.Error())
 	}
 
 	outBytes, err := proto.Marshal(genResp)


### PR DESCRIPTION
Per the `plugin.proto` [documentation](https://github.com/protocolbuffers/protobuf/blob/d9ccd0c0e6bbda9bf4476088eeb46b02d7dcd327/src/google/protobuf/compiler/plugin.proto#L99-L100), when code generation fails the plugin should *not* crash, but instead report the error via the `CodeGeneratorResponse` and `exit 0`. 

This PR implements that error reporting style in `protoc-gen-go_gapic` and `protoc-gen-go_cli`.