### PR TITLE
chore: integrate config validator & error conformance testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,12 @@ jobs:
           name: Check license
           command: |
             find -name '*.go' -not -name '*.pb.go' | xargs go run utils/license.go --
+      - run: go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
+      - run:
+          name: verify error conformance
+          command: |
+            go install github.com/googleapis/gapic-config-validator/cmd/gapic-error-conformance
+            gapic-error-conformance -plugin=protoc-gen-go_gapic -plugin_opts="go-gapic-package=foo.com/bar/v1;bar"
       # Install protoc, showcase.bash needs it
       - run:
           name: Run Showcase
@@ -46,8 +52,7 @@ jobs:
             mkdir protobuf
             curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip > protobuf/protoc.zip
             unzip -d protobuf protobuf/protoc.zip
-            export PATH=$PATH:$(pwd)/protobuf/bin
-            go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
+            export PATH=$PATH:$(pwd)/protobuf/bin            
             ./utils/showcase.bash
   publish_image:
     docker:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM debian:stable-slim
 COPY --from=gcr.io/gapic-images/api-common-protos:beta /usr/local/bin/protoc /usr/local/bin/protoc
 COPY --from=gcr.io/gapic-images/api-common-protos:beta /protos/ /protos/
 
+# Add gapic-config-validator plugin
+COPY --from=gcr.io/gapic-images/gapic-config-validator /usr/local/bin/protoc-gen-gapic-validator /usr/local/bin/protoc-gen-gapic-validator
+
 # Add protoc-gen-go_gapic binary
 COPY protoc-gen-go_gapic /usr/local/bin
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,6 +38,7 @@ if [ -z "$GO_GAPIC_PACKAGE" ]; then
 fi
 
 protoc --proto_path=/protos/ --proto_path=/in/ \
+                  --gapic-validator_out=. \
                   --go_gapic_out=/out/ \
                   --go_gapic_opt="$GO_GAPIC_PACKAGE" \
                   --go_gapic_opt="$GAPIC_SERVICE_CONFIG" \


### PR DESCRIPTION
* adds the `gapic-validator` plugin to Docker wrapper's `protoc` invocation
* adds `gapic-error-conformance` step to CI