### PR TITLE
gengapic: add http-based request header param support

### DIFF
--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -18,6 +18,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"google.golang.org/genproto/googleapis/api/annotations"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
@@ -163,6 +165,10 @@ func TestGenMethod(t *testing.T) {
 		},
 	}
 
+	opts := &descriptor.MethodOptions{}
+	ext := &annotations.HttpRule{Pattern: &annotations.HttpRule_Get{Get: "/v1/{field_name=projects/*/foo/*}/bars/{other=bar/*/baz/*}/buz"}}
+	proto.SetExtension(opts, annotations.E_Http, ext)
+
 	file := &descriptor.FileDescriptorProto{
 		Package: proto.String("my.pkg"),
 		Options: &descriptor.FileOptions{
@@ -188,34 +194,39 @@ func TestGenMethod(t *testing.T) {
 			Name:       proto.String("GetEmptyThing"),
 			InputType:  proto.String(".my.pkg.InputType"),
 			OutputType: proto.String(emptyType),
+			Options:    opts,
 		},
 		{
 			Name:       proto.String("GetOneThing"),
 			InputType:  proto.String(".my.pkg.InputType"),
 			OutputType: proto.String(".my.pkg.OutputType"),
+			Options:    opts,
 		},
 		{
 			Name:       proto.String("GetBigThing"),
 			InputType:  proto.String(".my.pkg.InputType"),
 			OutputType: proto.String(".google.longrunning.Operation"),
-			Options:    &descriptor.MethodOptions{},
+			Options:    opts,
 		},
 		{
 			Name:       proto.String("GetManyThings"),
 			InputType:  proto.String(".my.pkg.PageInputType"),
 			OutputType: proto.String(".my.pkg.PageOutputType"),
+			Options:    opts,
 		},
 		{
 			Name:            proto.String("ServerThings"),
 			InputType:       proto.String(".my.pkg.InputType"),
 			OutputType:      proto.String(".my.pkg.OutputType"),
 			ServerStreaming: proto.Bool(true),
+			Options:         opts,
 		},
 		{
 			Name:            proto.String("ClientThings"),
 			InputType:       proto.String(".my.pkg.InputType"),
 			OutputType:      proto.String(".my.pkg.OutputType"),
 			ClientStreaming: proto.Bool(true),
+			Options:         opts,
 		},
 		{
 			Name:            proto.String("BidiThings"),
@@ -223,6 +234,7 @@ func TestGenMethod(t *testing.T) {
 			OutputType:      proto.String(".my.pkg.OutputType"),
 			ServerStreaming: proto.Bool(true),
 			ClientStreaming: proto.Bool(true),
+			Options:         opts,
 		},
 	}
 

--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -44,7 +44,7 @@ func (g *generator) lroCall(servName string, m *descriptor.MethodDescriptorProto
 	p("func (c *%sClient) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s, error) {",
 		servName, *m.Name, inSpec.Name, inType.GetName(), lroType)
 
-	g.insertMetadata()
+	g.insertMetadata(m)
 	g.appendCallOpts(m)
 	p("  var resp *%s.%s", outSpec.Name, outType.GetName())
 	p("  err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")

--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -44,7 +44,11 @@ func (g *generator) lroCall(servName string, m *descriptor.MethodDescriptorProto
 	p("func (c *%sClient) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s, error) {",
 		servName, *m.Name, inSpec.Name, inType.GetName(), lroType)
 
-	g.insertMetadata(m)
+	err = g.insertMetadata(m)
+	if err != nil {
+		return err
+	}
+
 	g.appendCallOpts(m)
 	p("  var resp *%s.%s", outSpec.Name, outType.GetName())
 	p("  err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -134,6 +134,7 @@ func (g *generator) pagingCall(servName string, m *descriptor.MethodDescriptorPr
 	if err != nil {
 		return err
 	}
+
 	outSpec, err := g.descInfo.ImportSpec(outType)
 	if err != nil {
 		return err
@@ -143,7 +144,7 @@ func (g *generator) pagingCall(servName string, m *descriptor.MethodDescriptorPr
 	p("func (c *%sClient) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) *%s {",
 		servName, *m.Name, inSpec.Name, inType.GetName(), pt.iterTypeName)
 
-	g.insertMetadata()
+	g.insertMetadata(m)
 	g.appendCallOpts(m)
 
 	p("it := &%s{}", pt.iterTypeName)

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -144,7 +144,11 @@ func (g *generator) pagingCall(servName string, m *descriptor.MethodDescriptorPr
 	p("func (c *%sClient) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) *%s {",
 		servName, *m.Name, inSpec.Name, inType.GetName(), pt.iterTypeName)
 
-	g.insertMetadata(m)
+	err = g.insertMetadata(m)
+	if err != nil {
+		return err
+	}
+
 	g.appendCallOpts(m)
 
 	p("it := &%s{}", pt.iterTypeName)

--- a/internal/gengapic/stream.go
+++ b/internal/gengapic/stream.go
@@ -66,7 +66,11 @@ func (g *generator) serverStreamCall(servName string, s *descriptor.ServiceDescr
 	p("func (c *%sClient) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 		servName, m.GetName(), inSpec.Name, inType.GetName(), servSpec.Name, s.GetName(), m.GetName())
 
-	g.insertMetadata(m)
+	err = g.insertMetadata(m)
+	if err != nil {
+		return err
+	}
+
 	g.appendCallOpts(m)
 	p("  var resp %s.%s_%sClient", servSpec.Name, s.GetName(), m.GetName())
 	p("err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")

--- a/internal/gengapic/stream.go
+++ b/internal/gengapic/stream.go
@@ -28,7 +28,7 @@ func (g *generator) noRequestStreamCall(servName string, s *descriptor.ServiceDe
 
 	p("func (c *%sClient) %s(ctx context.Context, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 		servName, m.GetName(), servSpec.Name, s.GetName(), m.GetName())
-	g.insertMetadata()
+	g.insertMetadata(nil)
 	g.appendCallOpts(m)
 	p("  var resp %s.%s_%sClient", servSpec.Name, s.GetName(), m.GetName())
 
@@ -66,7 +66,7 @@ func (g *generator) serverStreamCall(servName string, s *descriptor.ServiceDescr
 	p("func (c *%sClient) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 		servName, m.GetName(), inSpec.Name, inType.GetName(), servSpec.Name, s.GetName(), m.GetName())
 
-	g.insertMetadata()
+	g.insertMetadata(m)
 	g.appendCallOpts(m)
 	p("  var resp %s.%s_%sClient", servSpec.Name, s.GetName(), m.GetName())
 	p("err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")

--- a/internal/gengapic/testdata/method_GetBigThing.want
+++ b/internal/gengapic/testdata/method_GetBigThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetBigThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*GetBigThingOperation, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "field_name", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("%s=%v", "other", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("field_name=%v", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("other=%v", req.GetOther()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetBigThing[0:len(c.CallOptions.GetBigThing):len(c.CallOptions.GetBigThing)], opts...)
 	var resp *longrunningpb.Operation

--- a/internal/gengapic/testdata/method_GetBigThing.want
+++ b/internal/gengapic/testdata/method_GetBigThing.want
@@ -1,5 +1,6 @@
 func (c *FooClient) GetBigThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*GetBigThingOperation, error) {
-	ctx = insertMetadata(ctx, c.xGoogMetadata)
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "field_name", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("%s=%v", "other", req.GetOther()))
+	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetBigThing[0:len(c.CallOptions.GetBigThing):len(c.CallOptions.GetBigThing)], opts...)
 	var resp *longrunningpb.Operation
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_GetEmptyThing.want
+++ b/internal/gengapic/testdata/method_GetEmptyThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetEmptyThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) error {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "field_name", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("%s=%v", "other", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("field_name=%v", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("other=%v", req.GetOther()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetEmptyThing[0:len(c.CallOptions.GetEmptyThing):len(c.CallOptions.GetEmptyThing)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_GetEmptyThing.want
+++ b/internal/gengapic/testdata/method_GetEmptyThing.want
@@ -1,5 +1,6 @@
 func (c *FooClient) GetEmptyThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) error {
-	ctx = insertMetadata(ctx, c.xGoogMetadata)
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "field_name", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("%s=%v", "other", req.GetOther()))
+	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetEmptyThing[0:len(c.CallOptions.GetEmptyThing):len(c.CallOptions.GetEmptyThing)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		var err error

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -1,5 +1,6 @@
 func (c *FooClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
-	ctx = insertMetadata(ctx, c.xGoogMetadata)
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "field_name", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("%s=%v", "other", req.GetOther()))
+	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetManyThings[0:len(c.CallOptions.GetManyThings):len(c.CallOptions.GetManyThings)], opts...)
 	it := &StringIterator{}
 	req = proto.Clone(req).(*mypackagepb.PageInputType)

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "field_name", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("%s=%v", "other", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("field_name=%v", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("other=%v", req.GetOther()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetManyThings[0:len(c.CallOptions.GetManyThings):len(c.CallOptions.GetManyThings)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetOneThing.want
+++ b/internal/gengapic/testdata/method_GetOneThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetOneThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "field_name", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("%s=%v", "other", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("field_name=%v", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("other=%v", req.GetOther()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetOneThing[0:len(c.CallOptions.GetOneThing):len(c.CallOptions.GetOneThing)], opts...)
 	var resp *mypackagepb.OutputType

--- a/internal/gengapic/testdata/method_GetOneThing.want
+++ b/internal/gengapic/testdata/method_GetOneThing.want
@@ -1,5 +1,6 @@
 func (c *FooClient) GetOneThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
-	ctx = insertMetadata(ctx, c.xGoogMetadata)
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "field_name", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("%s=%v", "other", req.GetOther()))
+	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetOneThing[0:len(c.CallOptions.GetOneThing):len(c.CallOptions.GetOneThing)], opts...)
 	var resp *mypackagepb.OutputType
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb._ServerThingsClient, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "field_name", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("%s=%v", "other", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("field_name=%v", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("other=%v", req.GetOther()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.ServerThings[0:len(c.CallOptions.ServerThings):len(c.CallOptions.ServerThings)], opts...)
 	var resp mypackagepb._ServerThingsClient

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,5 +1,6 @@
 func (c *FooClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb._ServerThingsClient, error) {
-	ctx = insertMetadata(ctx, c.xGoogMetadata)
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "field_name", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("%s=%v", "other", req.GetOther()))
+	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.ServerThings[0:len(c.CallOptions.ServerThings):len(c.CallOptions.ServerThings)], opts...)
 	var resp mypackagepb._ServerThingsClient
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {


### PR DESCRIPTION
Fixes #114 

Adds insertion of request header params based on HTTP extension's pattern value