### PR TITLE
chore: update gapic-showcase to 0.0.16

### DIFF
--- a/utils/showcase.bash
+++ b/utils/showcase.bash
@@ -21,7 +21,9 @@ if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
 	return
 fi
 
-SHOWCASE_SEMVER=0.0.13
+go install ./cmd/protoc-gen-go_gapic
+
+SHOWCASE_SEMVER=0.0.16
 
 pushd showcase
 rm -rf gen


### PR DESCRIPTION
bumps gapic-showcase version to 0.0.16