### PR TITLE
gapic: support LRO types nested 1 level deep

### DIFF
--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -102,7 +102,6 @@ func (g *generator) lroType(servName string, serv *descriptor.ServiceDescriptorP
 		fullName = "." + fullName
 
 		typ := g.descInfo.Type[fullName]
-
 		respSpec, err := g.descInfo.ImportSpec(typ)
 		if err != nil {
 			return fmt.Errorf("unable to resolve google.longrunning.operation_info.response_type value %q in rpc %q", opInfo.GetResponseType(), mFQN)
@@ -131,7 +130,6 @@ func (g *generator) lroType(servName string, serv *descriptor.ServiceDescriptorP
 		fullName = "." + fullName
 
 		typ := g.descInfo.Type[fullName]
-
 		meta, err := g.descInfo.ImportSpec(typ)
 		if err != nil {
 			return fmt.Errorf("unable to resolve google.longrunning.operation_info.metadata_type value %q in rpc %q", opInfo.GetMetadataType(), mFQN)

--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -102,13 +102,14 @@ func (g *generator) lroType(servName string, serv *descriptor.ServiceDescriptorP
 		fullName = "." + fullName
 
 		typ := g.descInfo.Type[fullName]
-		name := typ.GetName()
 
 		respSpec, err := g.descInfo.ImportSpec(typ)
 		if err != nil {
 			return fmt.Errorf("unable to resolve google.longrunning.operation_info.response_type value %q in rpc %q", opInfo.GetResponseType(), mFQN)
 		}
 		g.imports[respSpec] = true
+
+		name := typ.GetName()
 
 		// handle nested message types
 		if parent, ok := g.descInfo.ParentElement[typ]; ok {
@@ -130,13 +131,14 @@ func (g *generator) lroType(servName string, serv *descriptor.ServiceDescriptorP
 		fullName = "." + fullName
 
 		typ := g.descInfo.Type[fullName]
-		name := typ.GetName()
 
 		meta, err := g.descInfo.ImportSpec(typ)
 		if err != nil {
 			return fmt.Errorf("unable to resolve google.longrunning.operation_info.metadata_type value %q in rpc %q", opInfo.GetMetadataType(), mFQN)
 		}
 		g.imports[meta] = true
+
+		name := typ.GetName()
 
 		// handle nested message types
 		if parent, ok := g.descInfo.ParentElement[typ]; ok {

--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -89,7 +89,10 @@ func (g *generator) lroType(servName string, serv *descriptor.ServiceDescriptorP
 
 	var respType string
 	{
-		// eLRO.ResponseType is either fully-qualified or in the same package as the method.
+		// eLRO.ResponseType is either fully-qualified or top-level in the same package as the method.
+		//
+		// TODO(ndietz) this won't work with nested message types in the same package;
+		// migrating to protoreflect will help remove from semantic meaning in the names.
 		if strings.IndexByte(fullName, '.') < 0 {
 			fullName = g.descInfo.ParentFile[serv].GetPackage() + "." + fullName
 		}
@@ -99,30 +102,48 @@ func (g *generator) lroType(servName string, serv *descriptor.ServiceDescriptorP
 		fullName = "." + fullName
 
 		typ := g.descInfo.Type[fullName]
+		name := typ.GetName()
+
 		respSpec, err := g.descInfo.ImportSpec(typ)
 		if err != nil {
 			return fmt.Errorf("unable to resolve google.longrunning.operation_info.response_type value %q in rpc %q", opInfo.GetResponseType(), mFQN)
 		}
 		g.imports[respSpec] = true
-		respType = fmt.Sprintf("%s.%s", respSpec.Name, typ.GetName())
+
+		// handle nested message types
+		if parent, ok := g.descInfo.ParentElement[typ]; ok {
+			name = fmt.Sprintf("%s_%s", parent.GetName(), name)
+		}
+
+		respType = fmt.Sprintf("%s.%s", respSpec.Name, name)
 	}
 
 	hasMeta := opInfo.GetMetadataType() != ""
 	var metaType string
 	if hasMeta {
 		fullName := opInfo.GetMetadataType()
+		// TODO(ndietz) this won't work with nested message types in the same package;
+		// migrating to protoreflect will help remove from semantic meaning in the names.
 		if strings.IndexByte(fullName, '.') < 0 {
 			fullName = g.descInfo.ParentFile[serv].GetPackage() + "." + fullName
 		}
 		fullName = "." + fullName
 
 		typ := g.descInfo.Type[fullName]
+		name := typ.GetName()
+
 		meta, err := g.descInfo.ImportSpec(typ)
 		if err != nil {
 			return fmt.Errorf("unable to resolve google.longrunning.operation_info.metadata_type value %q in rpc %q", opInfo.GetMetadataType(), mFQN)
 		}
 		g.imports[meta] = true
-		metaType = fmt.Sprintf("%s.%s", meta.Name, typ.GetName())
+
+		// handle nested message types
+		if parent, ok := g.descInfo.ParentElement[typ]; ok {
+			name = fmt.Sprintf("%s_%s", parent.GetName(), name)
+		}
+
+		metaType = fmt.Sprintf("%s.%s", meta.Name, name)
 	}
 
 	// Type definition


### PR DESCRIPTION
* support use of nested message types (only 1 level deep) for LRO metadata & response types
  * real use case in Ads `RunMutateJob` ([example](https://github.com/googleapis/googleapis/blob/adsgen/google/ads/googleads/v1/services/mutate_job_service.proto#L82) in `adsgen` branch)
* add TODO for eventually migrating from pbinfo to [protoreflect/desc](https://godoc.org/github.com/jhump/protoreflect/desc)