### PR TITLE
gapic: remove nonidempotent default retry

### DIFF
--- a/internal/gengapic/testdata/empty_opt.want
+++ b/internal/gengapic/testdata/empty_opt.want
@@ -29,18 +29,8 @@ func defaultCallOptions() *CallOptions {
 		}),
 	}
 
-	nonidempotent := []gax.CallOption{
-		gax.WithRetry(func() gax.Retryer {
-			return gax.OnCodes([]codes.Code{
-				codes.Unavailable,
-			}, backoff)
-		}),
-	}
-
 	return &CallOptions{
 		Zip: idempotent,
-		Zap: nonidempotent,
-		Smack: nonidempotent,
 	}
 }
 

--- a/internal/gengapic/testdata/foo_opt.want
+++ b/internal/gengapic/testdata/foo_opt.want
@@ -29,18 +29,8 @@ func defaultFooCallOptions() *FooCallOptions {
 		}),
 	}
 
-	nonidempotent := []gax.CallOption{
-		gax.WithRetry(func() gax.Retryer {
-			return gax.OnCodes([]codes.Code{
-				codes.Unavailable,
-			}, backoff)
-		}),
-	}
-
 	return &FooCallOptions{
 		Zip: idempotent,
-		Zap: nonidempotent,
-		Smack: nonidempotent,
 	}
 }
 

--- a/internal/gengapic/testdata/host_port_opt.want
+++ b/internal/gengapic/testdata/host_port_opt.want
@@ -11,22 +11,7 @@ func defaultBarClientOptions() []option.ClientOption {
 }
 
 func defaultBarCallOptions() *BarCallOptions {
-	backoff := gax.Backoff{
-		Initial: 100 * time.Millisecond,
-		Max: time.Minute,
-		Multiplier: 1.3,
-	}
-
-	nonidempotent := []gax.CallOption{
-		gax.WithRetry(func() gax.Retryer {
-			return gax.OnCodes([]codes.Code{
-				codes.Unavailable,
-			}, backoff)
-		}),
-	}
-
 	return &BarCallOptions{
-		Smack: nonidempotent,
 	}
 }
 


### PR DESCRIPTION
It was decided that we cannot safely retry `UNAVAILABLE` by default for non-idempotent methods. This CL removes the generation of the default retry configuration for such methods.