### PR TITLE
gapic: add Response to gen'd iterator type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ test-go-cli:
 test-gapic:
 	go test github.com/googleapis/gapic-generator-go/internal/gengapic
 
+golden:
+	go test github.com/googleapis/gapic-generator-go/internal/gengapic -update_golden
+
 test:
 	go test ./...
 	./utils/showcase.bash

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -149,6 +149,11 @@ func TestGenMethod(t *testing.T) {
 			},
 		},
 	}
+	paginatedField := &descriptor.FieldDescriptorProto{
+		Name:  proto.String("items"),
+		Type:  typep(descriptor.FieldDescriptorProto_TYPE_STRING),
+		Label: labelp(descriptor.FieldDescriptorProto_LABEL_REPEATED),
+	}
 	pageOutputType := &descriptor.DescriptorProto{
 		Name: proto.String("PageOutputType"),
 		Field: []*descriptor.FieldDescriptorProto{
@@ -157,11 +162,7 @@ func TestGenMethod(t *testing.T) {
 				Type:  typep(descriptor.FieldDescriptorProto_TYPE_STRING),
 				Label: labelp(descriptor.FieldDescriptorProto_LABEL_OPTIONAL),
 			},
-			{
-				Name:  proto.String("items"),
-				Type:  typep(descriptor.FieldDescriptorProto_TYPE_STRING),
-				Label: labelp(descriptor.FieldDescriptorProto_LABEL_REPEATED),
-			},
+			paginatedField,
 		},
 	}
 
@@ -188,6 +189,9 @@ func TestGenMethod(t *testing.T) {
 		g.descInfo.ParentFile[typ] = file
 	}
 	g.descInfo.ParentFile[serv] = file
+	g.descInfo.ParentElement = map[pbinfo.ProtoType]pbinfo.ProtoType{
+		paginatedField: pageOutputType,
+	}
 
 	meths := []*descriptor.MethodDescriptorProto{
 		{

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -27,6 +27,9 @@ import (
 type iterType struct {
 	iterTypeName, elemTypeName string
 
+	resType string
+	resSpec pbinfo.ImportSpec
+
 	// If the elem type is a message, elemImports contains pbinfo.ImportSpec for the type.
 	// Otherwise, len(elemImports)==0.
 	elemImports []pbinfo.ImportSpec
@@ -36,6 +39,17 @@ type iterType struct {
 // elemField should be the "resource" of a paginating RPC.
 func (g *generator) iterTypeOf(elemField *descriptor.FieldDescriptorProto) (iterType, error) {
 	var pt iterType
+
+	parent, ok := g.descInfo.ParentElement[elemField]
+	if !ok {
+		return iterType{}, errors.E(nil, "cannot find parent element for %q, malformed descriptor?", elemField.GetName())
+	}
+
+	var err error
+	pt.resType, pt.resSpec, err = g.descInfo.NameSpec(parent)
+	if err != nil {
+		return iterType{}, errors.E(err, "unable to get a name & import spec for %s", parent.GetName())
+	}
 
 	switch t := *elemField.Type; {
 	case t == descriptor.FieldDescriptorProto_TYPE_MESSAGE:
@@ -207,6 +221,7 @@ func (g *generator) pagingIter(pt iterType) {
 	p("  items    []%s", pt.elemTypeName)
 	p("  pageInfo *iterator.PageInfo")
 	p("  nextFunc func() error")
+	p("  Response *%s.%s", pt.resSpec.Name, pt.resType)
 	p("")
 	p("  // InternalFetch is for use by the Google Cloud Libraries only.")
 	p("  // It is not part of the stable interface of this package.")

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -183,6 +183,8 @@ func (g *generator) pagingCall(servName string, m *descriptor.MethodDescriptorPr
 	p("  if err != nil {")
 	p("    return nil, \"\", err")
 	p("  }")
+	p("")
+	p("  it.Response = resp")
 	p("  return resp.%s, resp.NextPageToken, nil", snakeToCamel(*elemField.Name))
 	p("}")
 
@@ -221,6 +223,9 @@ func (g *generator) pagingIter(pt iterType) {
 	p("  items    []%s", pt.elemTypeName)
 	p("  pageInfo *iterator.PageInfo")
 	p("  nextFunc func() error")
+	p("")
+	p("  // Response is the raw response for the current page.")
+	p("  // Calling Next() or InternalFetch() updates this value.")
 	p("  Response *%s.%s", pt.resSpec.Name, pt.resType)
 	p("")
 	p("  // InternalFetch is for use by the Google Cloud Libraries only.")

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -155,6 +155,7 @@ func TestIterTypeOf(t *testing.T) {
 			Type: map[string]pbinfo.ProtoType{
 				msgType.GetName(): msgType,
 			},
+			ParentElement: map[pbinfo.ProtoType]pbinfo.ProtoType{},
 			ParentFile: map[proto.Message]*descriptor.FileDescriptorProto{
 				msgType: &descriptor.FileDescriptorProto{
 					Options: &descriptor.FileOptions{
@@ -176,6 +177,8 @@ func TestIterTypeOf(t *testing.T) {
 			want: iterType{
 				iterTypeName: "StringIterator",
 				elemTypeName: "string",
+				resType:      "Foo",
+				resSpec:      pbinfo.ImportSpec{Name: "foopb", Path: "path/to/foo"},
 			},
 		},
 		{
@@ -185,6 +188,8 @@ func TestIterTypeOf(t *testing.T) {
 			want: iterType{
 				iterTypeName: "BytesIterator",
 				elemTypeName: "[]byte",
+				resType:      "Foo",
+				resSpec:      pbinfo.ImportSpec{Name: "foopb", Path: "path/to/foo"},
 			},
 		},
 		{
@@ -196,9 +201,12 @@ func TestIterTypeOf(t *testing.T) {
 				iterTypeName: "FooIterator",
 				elemTypeName: "*foopb.Foo",
 				elemImports:  []pbinfo.ImportSpec{{Name: "foopb", Path: "path/to/foo"}},
+				resType:      "Foo",
+				resSpec:      pbinfo.ImportSpec{Name: "foopb", Path: "path/to/foo"},
 			},
 		},
 	} {
+		g.descInfo.ParentElement[tst.field] = msgType
 		got, err := g.iterTypeOf(tst.field)
 		if err != nil {
 			t.Error(err)

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -20,6 +20,8 @@ func (c *FooClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInpu
 		if err != nil {
 			return nil, "", err
 		}
+
+		it.Response = resp
 		return resp.Items, resp.NextPageToken, nil
 	}
 	fetch := func(pageSize int, pageToken string) (string, error) {
@@ -40,6 +42,9 @@ type StringIterator struct {
 	items    []string
 	pageInfo *iterator.PageInfo
 	nextFunc func() error
+
+	// Response is the raw response for the current page.
+	// Calling Next() or InternalFetch() updates this value.
 	Response *mypackagepb.PageOutputType
 
 	// InternalFetch is for use by the Google Cloud Libraries only.

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -40,6 +40,7 @@ type StringIterator struct {
 	items    []string
 	pageInfo *iterator.PageInfo
 	nextFunc func() error
+	Response *mypackagepb.PageOutputType
 
 	// InternalFetch is for use by the Google Cloud Libraries only.
 	// It is not part of the stable interface of this package.

--- a/internal/pbinfo/pbinfo.go
+++ b/internal/pbinfo/pbinfo.go
@@ -111,6 +111,10 @@ func addMessage(typMap map[string]ProtoType, parentMap map[ProtoType]ProtoType, 
 		typMap[fullName+"."+subEnum.GetName()] = subEnum
 		parentMap[subEnum] = msg
 	}
+
+	for _, field := range msg.GetField() {
+		parentMap[field] = msg
+	}
 }
 
 type ImportSpec struct {


### PR DESCRIPTION
Fix #123 

* add `Response *foopb.Foo` field to gen'd `FooIterator` type to preserve original response
* set `it.Response` to `resp` of fetch
* add `make golden` target for updating `want` files