### PR TITLE
gapic: make iterator.Response an interface

### DIFF
--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -27,9 +27,6 @@ import (
 type iterType struct {
 	iterTypeName, elemTypeName string
 
-	resType string
-	resSpec pbinfo.ImportSpec
-
 	// If the elem type is a message, elemImports contains pbinfo.ImportSpec for the type.
 	// Otherwise, len(elemImports)==0.
 	elemImports []pbinfo.ImportSpec
@@ -39,17 +36,6 @@ type iterType struct {
 // elemField should be the "resource" of a paginating RPC.
 func (g *generator) iterTypeOf(elemField *descriptor.FieldDescriptorProto) (iterType, error) {
 	var pt iterType
-
-	parent, ok := g.descInfo.ParentElement[elemField]
-	if !ok {
-		return iterType{}, errors.E(nil, "cannot find parent element for %q, malformed descriptor?", elemField.GetName())
-	}
-
-	var err error
-	pt.resType, pt.resSpec, err = g.descInfo.NameSpec(parent)
-	if err != nil {
-		return iterType{}, errors.E(err, "unable to get a name & import spec for %s", parent.GetName())
-	}
 
 	switch t := *elemField.Type; {
 	case t == descriptor.FieldDescriptorProto_TYPE_MESSAGE:
@@ -226,8 +212,9 @@ func (g *generator) pagingIter(pt iterType) {
 	p("  nextFunc func() error")
 	p("")
 	p("  // Response is the raw response for the current page.")
+	p("  // It must be cast to the RPC response type.")
 	p("  // Calling Next() or InternalFetch() updates this value.")
-	p("  Response *%s.%s", pt.resSpec.Name, pt.resType)
+	p("  Response interface{}")
 	p("")
 	p("  // InternalFetch is for use by the Google Cloud Libraries only.")
 	p("  // It is not part of the stable interface of this package.")

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -177,8 +177,6 @@ func TestIterTypeOf(t *testing.T) {
 			want: iterType{
 				iterTypeName: "StringIterator",
 				elemTypeName: "string",
-				resType:      "Foo",
-				resSpec:      pbinfo.ImportSpec{Name: "foopb", Path: "path/to/foo"},
 			},
 		},
 		{
@@ -188,8 +186,6 @@ func TestIterTypeOf(t *testing.T) {
 			want: iterType{
 				iterTypeName: "BytesIterator",
 				elemTypeName: "[]byte",
-				resType:      "Foo",
-				resSpec:      pbinfo.ImportSpec{Name: "foopb", Path: "path/to/foo"},
 			},
 		},
 		{
@@ -201,8 +197,6 @@ func TestIterTypeOf(t *testing.T) {
 				iterTypeName: "FooIterator",
 				elemTypeName: "*foopb.Foo",
 				elemImports:  []pbinfo.ImportSpec{{Name: "foopb", Path: "path/to/foo"}},
-				resType:      "Foo",
-				resSpec:      pbinfo.ImportSpec{Name: "foopb", Path: "path/to/foo"},
 			},
 		},
 	} {

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -45,8 +45,9 @@ type StringIterator struct {
 	nextFunc func() error
 
 	// Response is the raw response for the current page.
+	// It must be cast to the RPC response type.
 	// Calling Next() or InternalFetch() updates this value.
-	Response *mypackagepb.PageOutputType
+	Response interface{}
 
 	// InternalFetch is for use by the Google Cloud Libraries only.
 	// It is not part of the stable interface of this package.


### PR DESCRIPTION
I realized a little late that generated Iterator structs are "singletons" based on the **repeated field type**. There is only one iterator class generated for a `repeated Foo foo = 1;` field, `FooIterator`. Any RPC that implements the paging interface that pages over such a field will use the same `FooIterator` struct. However, the RPC responses might (most likely) differ. ListFoo and ListFooAgain might have ListFooResponse and ListFooAgainResponse response types, resulting in the recently added `Response {RPC response type pb}` field breaking.

An example exists today in the Cloud Vision API between the [ListProductsResponse](https://github.com/googleapis/googleapis/blob/152dabdfea620675c2db2f2a74878572324e8fd2/google/cloud/vision/v1/product_search_service.proto#L456-L463) and the [ListProductsInProductSetResponse](https://github.com/googleapis/googleapis/blob/152dabdfea620675c2db2f2a74878572324e8fd2/google/cloud/vision/v1/product_search_service.proto#L683-L690).

Changing the returned iterator type today would break the generated API surface. But having the original response is also important. So i made the generated Iterator's `Response` field an `interface{}` requiring the caller to cast it to the proper type to access it. Not the best experience but maintains flexibility. Generics would be nice here.

cc @jadekler for opinion on this solution.