### PR TITLE
gapic: fix header request params

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -454,10 +454,11 @@ func (g *generator) insertMetadata(m *descriptor.MethodDescriptorProto) error {
 		f := formats.String()[:formats.Len()-1]
 		v := values.String()[:values.Len()-1]
 
-		g.printf("md := metadata.Pairs(\"x-goog-request-params\", fmt.Sprintf(%q,%s))", f, v)
+		g.printf("md := metadata.Pairs(\"x-goog-request-params\", url.QueryEscape(fmt.Sprintf(%q,%s)))", f, v)
 		g.printf("ctx = insertMetadata(ctx, c.xGoogMetadata, md)")
 
 		g.imports[pbinfo.ImportSpec{Path: "fmt"}] = true
+		g.imports[pbinfo.ImportSpec{Path: "net/url"}] = true
 
 		return nil
 	}

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -469,12 +469,12 @@ func (g *generator) insertMetadata(m *descriptor.MethodDescriptorProto) error {
 }
 
 func buildAccessor(field string) string {
-	var ax string
+	var ax strings.Builder
 	split := strings.Split(field, ".")
 	for _, s := range split {
-		ax += fmt.Sprintf(".Get%s()", snakeToCamel(s))
+		fmt.Fprintf(&ax, ".Get%s()", snakeToCamel(s))
 	}
-	return ax
+	return ax.String()
 }
 
 func (g *generator) appendCallOpts(m *descriptor.MethodDescriptorProto) {

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -18,12 +18,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"google.golang.org/genproto/googleapis/api/annotations"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"github.com/googleapis/gapic-generator-go/internal/txtdiff"
+	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/googleapis/longrunning"
 )
 
@@ -274,5 +273,23 @@ methods:
 		}
 
 		txtdiff.Diff(t, m.GetName(), g.pt.String(), filepath.Join("testdata", "method_"+m.GetName()+".want"))
+	}
+}
+
+func Test_buildAccessor(t *testing.T) {
+	tests := []struct {
+		name  string
+		field string
+		want  string
+	}{
+		{name: "simple", field: "foo_foo", want: ".GetFooFoo()"},
+		{name: "nested", field: "foo_foo.bar_bar", want: ".GetFooFoo().GetBarBar()"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := buildAccessor(tt.field); got != tt.want {
+				t.Errorf("buildAccessor() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/gengapic/testdata/method_GetBigThing.want
+++ b/internal/gengapic/testdata/method_GetBigThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetBigThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*GetBigThingOperation, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("field_name=%v", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("other=%v", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetBigThing[0:len(c.CallOptions.GetBigThing):len(c.CallOptions.GetBigThing)], opts...)
 	var resp *longrunningpb.Operation

--- a/internal/gengapic/testdata/method_GetBigThing.want
+++ b/internal/gengapic/testdata/method_GetBigThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetBigThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*GetBigThingOperation, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetBigThing[0:len(c.CallOptions.GetBigThing):len(c.CallOptions.GetBigThing)], opts...)
 	var resp *longrunningpb.Operation

--- a/internal/gengapic/testdata/method_GetEmptyThing.want
+++ b/internal/gengapic/testdata/method_GetEmptyThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetEmptyThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) error {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("field_name=%v", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("other=%v", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetEmptyThing[0:len(c.CallOptions.GetEmptyThing):len(c.CallOptions.GetEmptyThing)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_GetEmptyThing.want
+++ b/internal/gengapic/testdata/method_GetEmptyThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetEmptyThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) error {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetEmptyThing[0:len(c.CallOptions.GetEmptyThing):len(c.CallOptions.GetEmptyThing)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetManyThings[0:len(c.CallOptions.GetManyThings):len(c.CallOptions.GetManyThings)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("field_name=%v", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("other=%v", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetManyThings[0:len(c.CallOptions.GetManyThings):len(c.CallOptions.GetManyThings)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetOneThing.want
+++ b/internal/gengapic/testdata/method_GetOneThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetOneThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("field_name=%v", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("other=%v", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetOneThing[0:len(c.CallOptions.GetOneThing):len(c.CallOptions.GetOneThing)], opts...)
 	var resp *mypackagepb.OutputType

--- a/internal/gengapic/testdata/method_GetOneThing.want
+++ b/internal/gengapic/testdata/method_GetOneThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetOneThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetOneThing[0:len(c.CallOptions.GetOneThing):len(c.CallOptions.GetOneThing)], opts...)
 	var resp *mypackagepb.OutputType

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb._ServerThingsClient, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.ServerThings[0:len(c.CallOptions.ServerThings):len(c.CallOptions.ServerThings)], opts...)
 	var resp mypackagepb._ServerThingsClient

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb._ServerThingsClient, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("field_name=%v", req.GetFieldName()), "x-goog-request-params", fmt.Sprintf("other=%v", req.GetOther()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.ServerThings[0:len(c.CallOptions.ServerThings):len(c.CallOptions.ServerThings)], opts...)
 	var resp mypackagepb._ServerThingsClient


### PR DESCRIPTION
#114 did this incorrectly based on [aip/4222](https://aip.dev/client-libraries/4222). This PR fixes that.

* Multiple key-value pairs are concatenated with `&`
* The entire "query" is URL encoded (prevents stuff like https://github.com/googleapis/gax-nodejs/issues/520)
* Implements nested request parameter access