### PR TITLE
gapic: encode metadata pairs separately

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -449,12 +449,12 @@ func (g *generator) insertMetadata(m *descriptor.MethodDescriptorProto) error {
 			field := h[1]
 
 			formats.WriteString("%s=%v&")
-			fmt.Fprintf(&values, " %q, req%s,", field, buildAccessor(field))
+			fmt.Fprintf(&values, " url.QueryEscape(%q), url.QueryEscape(req%s),", field, buildAccessor(field))
 		}
 		f := formats.String()[:formats.Len()-1]
 		v := values.String()[:values.Len()-1]
 
-		g.printf("md := metadata.Pairs(\"x-goog-request-params\", url.QueryEscape(fmt.Sprintf(%q,%s)))", f, v)
+		g.printf("md := metadata.Pairs(\"x-goog-request-params\", fmt.Sprintf(%q,%s))", f, v)
 		g.printf("ctx = insertMetadata(ctx, c.xGoogMetadata, md)")
 
 		g.imports[pbinfo.ImportSpec{Path: "fmt"}] = true

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -16,6 +16,7 @@ package gengapic
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -448,8 +449,12 @@ func (g *generator) insertMetadata(m *descriptor.MethodDescriptorProto) error {
 		for _, h := range headers {
 			field := h[1]
 
+			// URL encode key & values separately per aip.dev/4222.
+			// Encode the key ahead of time to reduce clutter
+			// and because it will likely never be necessary
+			fmt.Fprintf(&values, " %q, url.QueryEscape(req%s),",
+				url.QueryEscape(field), buildAccessor(field))
 			formats.WriteString("%s=%v&")
-			fmt.Fprintf(&values, " url.QueryEscape(%q), url.QueryEscape(req%s),", field, buildAccessor(field))
 		}
 		f := formats.String()[:formats.Len()-1]
 		v := values.String()[:values.Len()-1]

--- a/internal/gengapic/testdata/method_GetBigThing.want
+++ b/internal/gengapic/testdata/method_GetBigThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetBigThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*GetBigThingOperation, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", url.QueryEscape("field_name"), url.QueryEscape(req.GetFieldName()), url.QueryEscape("other"), url.QueryEscape(req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", url.QueryEscape(req.GetFieldName()), "other", url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetBigThing[0:len(c.CallOptions.GetBigThing):len(c.CallOptions.GetBigThing)], opts...)
 	var resp *longrunningpb.Operation

--- a/internal/gengapic/testdata/method_GetBigThing.want
+++ b/internal/gengapic/testdata/method_GetBigThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetBigThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*GetBigThingOperation, error) {
-	md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", url.QueryEscape("field_name"), url.QueryEscape(req.GetFieldName()), url.QueryEscape("other"), url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetBigThing[0:len(c.CallOptions.GetBigThing):len(c.CallOptions.GetBigThing)], opts...)
 	var resp *longrunningpb.Operation

--- a/internal/gengapic/testdata/method_GetEmptyThing.want
+++ b/internal/gengapic/testdata/method_GetEmptyThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetEmptyThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) error {
-	md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", url.QueryEscape("field_name"), url.QueryEscape(req.GetFieldName()), url.QueryEscape("other"), url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetEmptyThing[0:len(c.CallOptions.GetEmptyThing):len(c.CallOptions.GetEmptyThing)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_GetEmptyThing.want
+++ b/internal/gengapic/testdata/method_GetEmptyThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetEmptyThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) error {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", url.QueryEscape("field_name"), url.QueryEscape(req.GetFieldName()), url.QueryEscape("other"), url.QueryEscape(req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", url.QueryEscape(req.GetFieldName()), "other", url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetEmptyThing[0:len(c.CallOptions.GetEmptyThing):len(c.CallOptions.GetEmptyThing)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", url.QueryEscape("field_name"), url.QueryEscape(req.GetFieldName()), url.QueryEscape("other"), url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetManyThings[0:len(c.CallOptions.GetManyThings):len(c.CallOptions.GetManyThings)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", url.QueryEscape("field_name"), url.QueryEscape(req.GetFieldName()), url.QueryEscape("other"), url.QueryEscape(req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", url.QueryEscape(req.GetFieldName()), "other", url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetManyThings[0:len(c.CallOptions.GetManyThings):len(c.CallOptions.GetManyThings)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetOneThing.want
+++ b/internal/gengapic/testdata/method_GetOneThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetOneThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
-	md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", url.QueryEscape("field_name"), url.QueryEscape(req.GetFieldName()), url.QueryEscape("other"), url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetOneThing[0:len(c.CallOptions.GetOneThing):len(c.CallOptions.GetOneThing)], opts...)
 	var resp *mypackagepb.OutputType

--- a/internal/gengapic/testdata/method_GetOneThing.want
+++ b/internal/gengapic/testdata/method_GetOneThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetOneThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", url.QueryEscape("field_name"), url.QueryEscape(req.GetFieldName()), url.QueryEscape("other"), url.QueryEscape(req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", url.QueryEscape(req.GetFieldName()), "other", url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetOneThing[0:len(c.CallOptions.GetOneThing):len(c.CallOptions.GetOneThing)], opts...)
 	var resp *mypackagepb.OutputType

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb._ServerThingsClient, error) {
-	md := metadata.Pairs("x-goog-request-params", url.QueryEscape(fmt.Sprintf("%s=%v&%s=%v", "field_name", req.GetFieldName(), "other", req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", url.QueryEscape("field_name"), url.QueryEscape(req.GetFieldName()), url.QueryEscape("other"), url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.ServerThings[0:len(c.CallOptions.ServerThings):len(c.CallOptions.ServerThings)], opts...)
 	var resp mypackagepb._ServerThingsClient

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb._ServerThingsClient, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", url.QueryEscape("field_name"), url.QueryEscape(req.GetFieldName()), url.QueryEscape("other"), url.QueryEscape(req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", url.QueryEscape(req.GetFieldName()), "other", url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.ServerThings[0:len(c.CallOptions.ServerThings):len(c.CallOptions.ServerThings)], opts...)
 	var resp mypackagepb._ServerThingsClient


### PR DESCRIPTION
Encodes the keys & values of `x-goog-request-params` pairs separately.

Fixes #144 