### PR TITLE
gapic: remove API service config scope support

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -47,9 +47,6 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 		var host string
 		if eHost, err := proto.GetExtension(serv.Options, annotations.E_DefaultHost); err == nil {
 			host = *eHost.(*string)
-		} else if g.serviceConfig != nil {
-			// TODO(ndietz) remove this once default_host annotation is acepted
-			host = g.serviceConfig.Name
 		} else {
 			fqn := g.descInfo.ParentFile[serv].GetPackage() + "." + serv.GetName()
 			return fmt.Errorf("service %q is missing option google.api.default_host", fqn)

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -149,11 +149,6 @@ func (g *generator) genDocFile(pkgPath, pkgName string, year int, scopes []strin
 func collectScopes(servs []*descriptor.ServiceDescriptorProto, config *serviceConfig) ([]string, error) {
 	scopeSet := map[string]bool{}
 	for _, s := range servs {
-		// TODO(ndietz) remove this once oauth scopes annotation is accepted
-		if s.GetOptions() == nil {
-			continue
-		}
-
 		eOauthScopes, err := proto.GetExtension(s.Options, annotations.E_OauthScopes)
 		if err == proto.ErrMissingExtension {
 			continue
@@ -164,25 +159,6 @@ func collectScopes(servs []*descriptor.ServiceDescriptorProto, config *serviceCo
 		scopes := strings.Split(*eOauthScopes.(*string), ",")
 		for _, sc := range scopes {
 			scopeSet[sc] = true
-		}
-	}
-
-	// TODO(ndietz) remove this once oauth scopes annotation is accepted
-	if len(scopeSet) == 0 && config != nil && config.Authentication != nil {
-		if len(config.Authentication.Rules) > 0 {
-			for _, rule := range config.Authentication.Rules {
-				if rule.Selector == "*" {
-					if rule.Oauth != nil {
-						if rule.Oauth.CanonicalScopes != "nil" {
-							scopes := strings.Split(rule.Oauth.CanonicalScopes, ",")
-							for _, sc := range scopes {
-								scopeSet[sc] = true
-							}
-							break
-						}
-					}
-				}
-			}
 		}
 	}
 

--- a/internal/gengapic/service_config.go
+++ b/internal/gengapic/service_config.go
@@ -17,33 +17,12 @@ package gengapic
 // serviceConfig represents a gapic service config
 // Deprecated: workaround for not having annotations yet; to be removed
 type serviceConfig struct {
-	Name           string
-	Title          string
-	Documentation  *configDocumentation
-	Authentication *configAuthentication
+	Title         string
+	Documentation *configDocumentation
 }
 
 // configDocumentation represents gapic service config documentation section
 // Deprecated: workaround for not having annotations yet; to be removed
 type configDocumentation struct {
 	Summary string
-}
-
-// configAuthentication represents gapic service config authentication section
-// Deprecated: workaround for not having annotations yet; to be removed
-type configAuthentication struct {
-	Rules []*configAuthRules
-}
-
-// configAuthRules represents gapic service config auth rules
-// Deprecated: workaround for not having annotations yet; to be removed
-type configAuthRules struct {
-	Selector string
-	Oauth    *configAuthRulesOauth
-}
-
-// configAuthRulesOauth represents a gapic service config oauth rule
-// Deprecated: workaround for not having annotations yet; to be removed
-type configAuthRulesOauth struct {
-	CanonicalScopes string `yaml:"canonical_scopes"`
 }


### PR DESCRIPTION
* remove use of API service config for:
  * host
  * oauth scopes

Both the `default_host` and `oauth_scopes` annotations are accepted. The `default_host` annotation is injected by proto publishing pipeline. The use of oauth_scopes from svc config will be confusing since we should have annotations and the svc config should only be used to capture documentation that only resides there.