### PR TITLE
SampleGen: allow using `{}` to specify an empty object in request

### DIFF
--- a/cmd/gen-go-sample/inittree.go
+++ b/cmd/gen-go-sample/inittree.go
@@ -223,6 +223,11 @@ func (t *initTree) parseInit(txt string, info pbinfo.Info) error {
 		}
 		t.leafVal = tok
 
+	case '{':
+		if r := sc.Scan(); r != '}' {
+			return report(errors.E(nil, "bad format rhs: expecting '}', found %q", r))
+		}
+
 	default:
 		return report(errors.E(nil, "expected value, found %q", sc.TokenText()))
 	}
@@ -430,7 +435,11 @@ func (t *initTree) print(w *bufio.Writer, g *generator, ind int) error {
 		typPrefix = "&"
 	}
 
-	fmt.Fprintf(w, "%s%s.%s{\n", typPrefix, impSpec.Name, typName)
+	fmt.Fprintf(w, "%s%s.%s{", typPrefix, impSpec.Name, typName)
+	if len(t.keys) != 0 {
+		fmt.Fprintf(w, "\n")
+	}
+
 	for i, k := range t.keys {
 		indent(ind + 1)
 
@@ -457,7 +466,10 @@ func (t *initTree) print(w *bufio.Writer, g *generator, ind int) error {
 		}
 		w.WriteString(",\n")
 	}
-	indent(ind)
+
+	if len(t.keys) != 0 {
+		indent(ind)
+	}
 	w.WriteString("}")
 	return nil
 }

--- a/cmd/gen-go-sample/inittree.go
+++ b/cmd/gen-go-sample/inittree.go
@@ -225,7 +225,7 @@ func (t *initTree) parseInit(txt string, info pbinfo.Info) error {
 
 	case '{':
 		if r := sc.Scan(); r != '}' {
-			return report(errors.E(nil, "bad format rhs: expecting '}', found %q", r))
+			return report(errors.E(nil, "bad format: expected '}', found %q", r))
 		}
 
 	default:

--- a/cmd/gen-go-sample/main_test.go
+++ b/cmd/gen-go-sample/main_test.go
@@ -174,6 +174,32 @@ func TestLro(t *testing.T) {
 	compare(t, g, filepath.Join("testdata", "sample_lro.want"))
 }
 
+func TestEmptyObject(t *testing.T) {
+	t.Parallel()
+
+	g := initTestGenerator()
+	vs := SampleValueSet{
+		ID: "my_value_set",
+		Parameters: SampleParameter{
+			Defaults: []string{
+				`f2 = {}`,
+				`resource_field%foo="myfoo"`,
+				`resource_field%bar="mybar"`,
+			},
+		},
+	}
+
+	methConf := GAPICMethod{
+		Name:              "UnaryMethod",
+		FieldNamePatterns: map[string]string{"resource_field": "foobar_thing"},
+	}
+
+	if err := g.genSample("foo.FooService", methConf, "awesome_region", vs); err != nil {
+		t.Fatal(err)
+	}
+	compare(t, g, filepath.Join("testdata", "sample_empty_object.want"))
+}
+
 func TestEmpty(t *testing.T) {
 	t.Parallel()
 
@@ -298,6 +324,7 @@ func initTestGenerator() *generator {
 			{Name: proto.String("b"), Type: typep(descriptor.FieldDescriptorProto_TYPE_STRING)},
 			{Name: proto.String("e"), TypeName: proto.String(".foo.AType.EType")},
 			{Name: proto.String("f"), Type: typep(descriptor.FieldDescriptorProto_TYPE_STRING), OneofIndex: proto.Int32(0)},
+			{Name: proto.String("f2"), TypeName: proto.String(".foo.AType"), OneofIndex: proto.Int32(0)},
 			{Name: proto.String("data_alice"), Type: typep(descriptor.FieldDescriptorProto_TYPE_BYTES)},
 			{Name: proto.String("data_bob"), Type: typep(descriptor.FieldDescriptorProto_TYPE_BYTES)},
 			{Name: proto.String("r"), Type: typep(descriptor.FieldDescriptorProto_TYPE_STRING), Label: labelp(descriptor.FieldDescriptorProto_LABEL_REPEATED)},

--- a/cmd/gen-go-sample/testdata/sample_empty.want
+++ b/cmd/gen-go-sample/testdata/sample_empty.want
@@ -33,8 +33,7 @@ func sampleEmptyMethod() error {
 		return err
 	}
 
-	req := &foopb.PageInType{
-	}
+	req := &foopb.PageInType{}
 	if err := c.EmptyMethod(ctx, req); err != nil {
 		return err
 	}

--- a/cmd/gen-go-sample/testdata/sample_empty_object.want
+++ b/cmd/gen-go-sample/testdata/sample_empty_object.want
@@ -21,32 +21,30 @@ import(
  "fmt"
  "log"
 
- "google.golang.org/api/iterator"
 foo "path.to/client/foo"
 foopb "path.to/pb/foo"
 )
 // [START awesome_region]
 
-func samplePagingMethod() error {
+func sampleUnaryMethod() error {
 	ctx := context.Background()
 	c, err := foo.NewClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	req := &foopb.PageInType{}
-	it := c.PagingMethod(ctx, req)
-	for {
-		resp, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			return err
-		}
-		fmt.Println(resp)
+	req := &foopb.InputType{
+		ResourceField: fmt.Sprintf("foos/%s/bars/%s", "myfoo", "mybar"),
+		Group: &foopb.InputType_F2{
+			F2: &foopb.AType{},
+		},
+	}
+	resp, err := c.UnaryMethod(ctx, req)
+	if err != nil {
+		return err
 	}
 
+	fmt.Println(resp)
 	return nil
 }
 
@@ -54,7 +52,7 @@ func samplePagingMethod() error {
 
 func main() {
 	flag.Parse()
-	if err := samplePagingMethod(); err != nil {
+	if err := sampleUnaryMethod(); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmd/gen-go-sample/testdata/sample_lro.want
+++ b/cmd/gen-go-sample/testdata/sample_lro.want
@@ -33,8 +33,7 @@ func sampleLroMethod() error {
 		return err
 	}
 
-	req := &foopb.LroInType{
-	}
+	req := &foopb.LroInType{}
 	op, err := c.LroMethod(ctx, req)
 	if err != nil {
 		return err

--- a/cmd/gen-go-sample/testdata/sample_map_out.want
+++ b/cmd/gen-go-sample/testdata/sample_map_out.want
@@ -33,8 +33,7 @@ func sampleUnaryMethod() error {
 		return err
 	}
 
-	req := &foopb.InputType{
-	}
+	req := &foopb.InputType{}
 	resp, err := c.UnaryMethod(ctx, req)
 	if err != nil {
 		return err

--- a/cmd/gen-go-sample/testdata/sample_write_file.want
+++ b/cmd/gen-go-sample/testdata/sample_write_file.want
@@ -34,8 +34,7 @@ func sampleUnaryMethod() error {
 		return err
 	}
 
-	req := &foopb.InputType{
-	}
+	req := &foopb.InputType{}
 	resp, err := c.UnaryMethod(ctx, req)
 	if err != nil {
 		return err


### PR DESCRIPTION
Similar to https://github.com/googleapis/gapic-generator/pull/2844 in gapic-generator.