### PR TITLE
gapic: avoid generating duplicate iterators

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -329,7 +329,7 @@ func (g *generator) gen(serv *descriptor.ServiceDescriptorProto, pkgName string)
 		// skip iterators that have already been generated in this package
 		//
 		// TODO(ndietz): investigate generating auxiliary types in a
-		// separate file in the same pacakge to avoid keeping this state
+		// separate file in the same package to avoid keeping this state
 		if iter.generated {
 			continue
 		}

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -377,7 +377,7 @@ func (g *generator) genMethod(servName string, serv *descriptor.ServiceDescripto
 		if err != nil {
 			return err
 		}
-		g.aux.iters[iter.iterTypeName] = iter
+
 		return g.pagingCall(servName, m, pf, iter)
 	}
 

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -305,6 +305,7 @@ func (g *generator) gen(serv *descriptor.ServiceDescriptorProto, pkgName string)
 		return err
 	}
 
+	// clear LRO types between services
 	g.aux.lros = []*descriptor.MethodDescriptorProto{}
 
 	for _, m := range serv.Method {

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -253,22 +253,22 @@ methods:
 			proto.SetExtension(m.Options, longrunning.E_OperationInfo, lroType)
 		}
 
-		aux := auxTypes{
-			iters: map[string]iterType{},
+		g.aux = &auxTypes{
+			iters: map[string]*iterType{},
 		}
-		if err := g.genMethod("Foo", serv, m, &aux); err != nil {
+		if err := g.genMethod("Foo", serv, m); err != nil {
 			t.Error(err)
 			continue
 		}
 
-		for _, m := range aux.lros {
+		for _, m := range g.aux.lros {
 			if err := g.lroType("MyService", serv, m); err != nil {
 				t.Error(err)
 				continue methods
 			}
 		}
 
-		for _, iter := range aux.iters {
+		for _, iter := range g.aux.iters {
 			g.pagingIter(iter)
 		}
 

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -72,6 +72,7 @@ func (g *generator) iterTypeOf(elemField *descriptor.FieldDescriptorProto) (*ite
 	if iter, ok := g.aux.iters[pt.iterTypeName]; ok {
 		return iter, nil
 	}
+	g.aux.iters[pt.iterTypeName] = &pt
 
 	return &pt, nil
 }

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -151,6 +151,9 @@ func TestIterTypeOf(t *testing.T) {
 		Name: proto.String("Foo"),
 	}
 	g := &generator{
+		aux: &auxTypes{
+			iters: map[string]*iterType{},
+		},
 		descInfo: pbinfo.Info{
 			Type: map[string]pbinfo.ProtoType{
 				msgType.GetName(): msgType,
@@ -204,7 +207,7 @@ func TestIterTypeOf(t *testing.T) {
 		got, err := g.iterTypeOf(tst.field)
 		if err != nil {
 			t.Error(err)
-		} else if diff := cmp.Diff(tst.want, got, cmp.AllowUnexported(got)); diff != "" {
+		} else if diff := cmp.Diff(tst.want, *got, cmp.AllowUnexported(*got)); diff != "" {
 			t.Errorf("%d: (got=-, want=+):\n%s", i, diff)
 		}
 	}


### PR DESCRIPTION
* adds a `generated` field to the `iterType` 
* makes the auxiliary types a generator field for tracking across services
* only generate an iterator once per **package**

Attempting to generate the Ads v2 GAPICs results in a iterator type naming collision.