### PR TITLE
chore: ignore blackfriday dep & have bot tidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,11 @@
   ],
   "ignorePaths": [
     "showcase"
-  ]
+  ],
+  "golang": {
+    "ignoreDeps": [
+      "github.com/russross/blackfriday"
+    ],
+    "postUpdateOptions": ["gomodTidy"]
+  }
 }


### PR DESCRIPTION
The `blackfriday` dep is an indirect dep of `github.com/golang-commonmark/markdown` and it actually moved to gitlab, from github. When updating the parent dep we will see if an update to `blackfriday` is necessary. But we shouldn't try to update it independently because the owner has kind of borked the import path as shown in #166 