### PR TITLE
gapic: add release-level flag to docker entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,6 +18,7 @@
 GO_GAPIC_PACKAGE=
 GAPIC_SERVICE_CONFIG=
 GRPC_SERVICE_CONFIG=
+RELEASE_LEVEL=
 
 # enable extended globbing for flag pattern matching
 shopt -s extglob
@@ -28,6 +29,7 @@ while true; do
     --go-gapic-package ) GO_GAPIC_PACKAGE="go-gapic-package=$2"; shift 2 ;;
     --gapic-service-config ) GAPIC_SERVICE_CONFIG="gapic-service-config=/conf/$2"; shift 2;;
     --grpc-service-config ) GRPC_SERVICE_CONFIG="grpc-service-config=/conf/$2"; shift 2;;
+    --release-level ) RELEASE_LEVEL="release-level=$2"; shift 2 ;; 
     --go-gapic* ) echo "Skipping unrecognized go-gapic flag: $1" >&2; shift ;;
     --* | +([[:word:][:punct:]]) ) shift ;;
     * ) break ;;
@@ -39,10 +41,13 @@ if [ -z "$GO_GAPIC_PACKAGE" ]; then
   exit 64
 fi
 
+echo "$RELEASE_LEVEL"
+
 protoc --proto_path=/protos/ --proto_path=/in/ \
                   --gapic-validator_out=. \
                   --go_gapic_out=/out/ \
                   --go_gapic_opt="$GO_GAPIC_PACKAGE" \
+                  --go_gapic_opt="$RELEASE_LEVEL" \
                   --go_gapic_opt="$GAPIC_SERVICE_CONFIG" \
                   --go_gapic_opt="$GRPC_SERVICE_CONFIG" \
                   `find /in/ -name *.proto`

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -41,8 +41,6 @@ if [ -z "$GO_GAPIC_PACKAGE" ]; then
   exit 64
 fi
 
-echo "$RELEASE_LEVEL"
-
 protoc --proto_path=/protos/ --proto_path=/in/ \
                   --gapic-validator_out=. \
                   --go_gapic_out=/out/ \


### PR DESCRIPTION
I forgot to add the release level flag to the docker entrypoint