### PR TITLE
chore: remove -mod=readonly in CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - image: circleci/golang:1.13
     steps:
       - checkout
-      - run: go test -mod=readonly ./...
+      - run: go test ./...
       - run:
           name: Check license
           command: |


### PR DESCRIPTION
Having `-mod=readonly` blocks the tests for PRs sometimes and it is annoying.