### PR TITLE
chore: change docker dep on common-protos to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,6 @@ FROM debian:stable-slim
 COPY --from=gcr.io/gapic-images/api-common-protos:latest /usr/local/bin/protoc /usr/local/bin/protoc
 COPY --from=gcr.io/gapic-images/api-common-protos:latest /protos/ /protos/
 
-# Add gapic-config-validator plugin
-COPY --from=gcr.io/gapic-images/gapic-config-validator /usr/local/bin/protoc-gen-gapic-validator /usr/local/bin/protoc-gen-gapic-validator
-
 # Add protoc-gen-go_gapic binary
 COPY protoc-gen-go_gapic /usr/local/bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:stable-slim
 
 # Add protoc and our common protos.
-COPY --from=gcr.io/gapic-images/api-common-protos:0.1.0 /usr/local/bin/protoc /usr/local/bin/protoc
-COPY --from=gcr.io/gapic-images/api-common-protos:0.1.0 /protos/ /protos/
+COPY --from=gcr.io/gapic-images/api-common-protos:latest /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=gcr.io/gapic-images/api-common-protos:latest /protos/ /protos/
 
 # Add gapic-config-validator plugin
 COPY --from=gcr.io/gapic-images/gapic-config-validator /usr/local/bin/protoc-gen-gapic-validator /usr/local/bin/protoc-gen-gapic-validator

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -21,7 +21,6 @@ GRPC_SERVICE_CONFIG=
 GAPIC_CONFIG=
 SAMPLES=
 SAMPLE_ONLY=
-GAPIC_VALIDATOR_OUT=
 RELEASE_LEVEL=
 
 # enable extended globbing for flag pattern matching
@@ -53,13 +52,7 @@ if [ ! -z "$SAMPLES" ]; then
   SAMPLES=${SAMPLES::-1}
 fi
 
-# Do not validate proto annotations if --sample-only is set
-if [ -z "$SAMPLE_ONLY" ]; then
-  GAPIC_VALIDATOR_OUT="--gapic_validator_out=."
-fi
-
 protoc --proto_path=/protos/ --proto_path=/in/ \
-                  $GAPIC_VALIDATOR_OUT \
                   --go_gapic_out=/out/ \
                   --go_gapic_opt="$GO_GAPIC_PACKAGE" \
                   --go_gapic_opt="$RELEASE_LEVEL" \


### PR DESCRIPTION
* change api-common-protos docker dep to `latest` tag to pick up `master` changes
* remove gapic-config-validator plugin from Docker image as it throws errors on things that are irrelevant to Go GAPICs