### PR TITLE
chore: update showcase tests to v0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ perf.data*
 /cover.prof
 showcase/gen
 showcase/gapic-showcase
+showcase/showcase_grpc_service_config.json
 
 # Jetbrains
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -32,3 +32,4 @@ clean:
 	rm -rf cmd/protoc-gen-go_cli/testdata	
 	rm -rf showcase/gen
 	rm -f showcase/gapic-showcase
+	rm -f showcase/showcase_grpc_service_config.json

--- a/utils/showcase.bash
+++ b/utils/showcase.bash
@@ -23,15 +23,18 @@ fi
 
 go install ./cmd/protoc-gen-go_gapic
 
-SHOWCASE_SEMVER=0.3.0
+SHOWCASE_SEMVER=0.6.0
 
 pushd showcase
 rm -rf gen
 mkdir gen
 
+curl -L -O https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/showcase_grpc_service_config.json
+
 protoc \
 	--go_gapic_out ./gen \
 	--go_gapic_opt 'go-gapic-package=cloud.google.com/go/showcase/apiv1beta1;showcase' \
+	--go_gapic_opt 'grpc-service-config=showcase_grpc_service_config.json' \
 	--descriptor_set_in=<(curl -sSL https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/gapic-showcase-$SHOWCASE_SEMVER.desc) \
 	google/showcase/v1beta1/echo.proto
 


### PR DESCRIPTION
* updates SHOWCASE_VERSION to `v0.6.0`
* `utils/showcase.bash` downloads `showcase_grpc_service_config.json` for GAPIC generation
* add retry config to clean target & .gitignore