### PR TITLE
fix: better error message when 'go_gapic_opt' is not provided 

### DIFF
--- a/internal/gensample/plugin.go
+++ b/internal/gensample/plugin.go
@@ -41,6 +41,9 @@ func PluginEntry(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResp
 	nofmt := false
 
 	resp := plugin.CodeGeneratorResponse{}
+	if genReq.Parameter == nil {
+		return &resp, errors.E(nil, paramError)
+	}
 	for _, s := range strings.Split(*genReq.Parameter, ",") {
 		if e := strings.IndexByte(s, '='); e > 0 {
 			switch s[:e] {


### PR DESCRIPTION
Without this check, the generation will fail with SIGSEGV.

Fix #248 