### PR TITLE
gapic: fix parsing nested request params

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -49,7 +49,7 @@ const (
 	beta       = "beta"
 )
 
-var headerParamRegexp = regexp.MustCompile(`{([_\.a-z]+)=`)
+var headerParamRegexp = regexp.MustCompile(`{([_.a-z]+)=`)
 
 func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, error) {
 	var pkgPath, pkgName, outDir string

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -49,7 +49,7 @@ const (
 	beta       = "beta"
 )
 
-var headerParamRegexp = regexp.MustCompile(`{([_a-z]+)=`)
+var headerParamRegexp = regexp.MustCompile(`{([_\.a-z]+)=`)
 
 func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, error) {
 	var pkgPath, pkgName, outDir string

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -166,7 +166,7 @@ func TestGenMethod(t *testing.T) {
 	}
 
 	opts := &descriptor.MethodOptions{}
-	ext := &annotations.HttpRule{Pattern: &annotations.HttpRule_Get{Get: "/v1/{field_name=projects/*/foo/*}/bars/{other=bar/*/baz/*}/buz"}}
+	ext := &annotations.HttpRule{Pattern: &annotations.HttpRule_Get{Get: "/v1/{field_name.nested=projects/*/foo/*}/bars/{other=bar/*/baz/*}/buz"}}
 	proto.SetExtension(opts, annotations.E_Http, ext)
 
 	file := &descriptor.FileDescriptorProto{

--- a/internal/gengapic/testdata/method_GetBigThing.want
+++ b/internal/gengapic/testdata/method_GetBigThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetBigThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*GetBigThingOperation, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", url.QueryEscape(req.GetFieldName()), "other", url.QueryEscape(req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetBigThing[0:len(c.CallOptions.GetBigThing):len(c.CallOptions.GetBigThing)], opts...)
 	var resp *longrunningpb.Operation

--- a/internal/gengapic/testdata/method_GetEmptyThing.want
+++ b/internal/gengapic/testdata/method_GetEmptyThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetEmptyThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) error {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", url.QueryEscape(req.GetFieldName()), "other", url.QueryEscape(req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetEmptyThing[0:len(c.CallOptions.GetEmptyThing):len(c.CallOptions.GetEmptyThing)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", url.QueryEscape(req.GetFieldName()), "other", url.QueryEscape(req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetManyThings[0:len(c.CallOptions.GetManyThings):len(c.CallOptions.GetManyThings)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetOneThing.want
+++ b/internal/gengapic/testdata/method_GetOneThing.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetOneThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", url.QueryEscape(req.GetFieldName()), "other", url.QueryEscape(req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetOneThing[0:len(c.CallOptions.GetOneThing):len(c.CallOptions.GetOneThing)], opts...)
 	var resp *mypackagepb.OutputType

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb._ServerThingsClient, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name", url.QueryEscape(req.GetFieldName()), "other", url.QueryEscape(req.GetOther())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.ServerThings[0:len(c.CallOptions.ServerThings):len(c.CallOptions.ServerThings)], opts...)
 	var resp mypackagepb._ServerThingsClient


### PR DESCRIPTION
Nested field names for header request params were not being recognized by the parsing regex. This fixes the regex and updates the test.