### PR TITLE
gapic: fix lro handling Empty

### DIFF
--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -160,7 +160,14 @@ func (g *generator) lroType(servName string, serv *descriptor.ServiceDescriptorP
 		p("// Wait blocks until the long-running operation is completed, returning the response and any errors encountered.")
 		p("//")
 		p("// See documentation of Poll for error-handling information.")
-		p("func (op *%s) Wait(ctx context.Context, opts ...gax.CallOption) (*%s, error) {", lroType, respType)
+
+		// only return an error when response_type is google.protobuf.Empty
+		returnType := fmt.Sprintf("(*%s, error)", respType)
+		if respType == "emptypb.Empty" {
+			returnType = "error"
+		}
+
+		p("func (op *%s) Wait(ctx context.Context, opts ...gax.CallOption) %s {", lroType, returnType)
 		p("  var resp %s", respType)
 		p("  if err := op.lro.WaitWithInterval(ctx, &resp, time.Minute, opts...); err != nil {")
 		p("    return nil, err")


### PR DESCRIPTION
The monolith generated `Wait` methods with an `error` return type when `google.protobuf.Empty` was the `response_type`. To avoid a breaking change, this adopts that approach.

@jadekler