### PR TITLE
gapic: fix lro wait returns

### DIFF
--- a/internal/gengapic/example_test.go
+++ b/internal/gengapic/example_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"github.com/googleapis/gapic-generator-go/internal/txtdiff"
+	"google.golang.org/genproto/googleapis/longrunning"
 )
 
 func TestExample(t *testing.T) {
@@ -79,6 +80,18 @@ func TestExample(t *testing.T) {
 		},
 	}
 
+	emptyLRO := &longrunning.OperationInfo{
+		ResponseType: emptyValue,
+	}
+	emptyLROOpts := &descriptor.MethodOptions{}
+	proto.SetExtension(emptyLROOpts, longrunning.E_OperationInfo, emptyLRO)
+
+	respLRO := &longrunning.OperationInfo{
+		ResponseType: "my.pkg.OutputType",
+	}
+	respLROOpts := &descriptor.MethodOptions{}
+	proto.SetExtension(respLROOpts, longrunning.E_OperationInfo, respLRO)
+
 	commonTypes(&g)
 	for _, typ := range []*descriptor.DescriptorProto{
 		inputType, outputType, pageInputType, pageOutputType,
@@ -116,6 +129,18 @@ func TestExample(t *testing.T) {
 				OutputType:      proto.String(".my.pkg.OutputType"),
 				ServerStreaming: proto.Bool(true),
 				ClientStreaming: proto.Bool(true),
+			},
+			{
+				Name:       proto.String("EmptyLRO"),
+				InputType:  proto.String(".my.pkg.InputType"),
+				OutputType: proto.String(".google.longrunning.Operation"),
+				Options:    emptyLROOpts,
+			},
+			{
+				Name:       proto.String("RespLRO"),
+				InputType:  proto.String(".my.pkg.InputType"),
+				OutputType: proto.String(".google.longrunning.Operation"),
+				Options:    respLROOpts,
 			},
 		},
 	}

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -45,6 +45,8 @@ const (
 	emptyType = ".google.protobuf.Empty"
 	lroType   = ".google.longrunning.Operation"
 	// used when google.protobuf.Empty is the value of an annotation, which isn't resolved by protoc
+	//
+	// TODO(ndietz): https://github.com/googleapis/gapic-generator-go/issues/260
 	emptyValue = "google.protobuf.Empty"
 	paramError = "need parameter in format: go-gapic-package=client/import/path;packageName"
 	alpha      = "alpha"

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -42,8 +42,10 @@ import (
 
 const (
 	// protoc puts a dot in front of name, signaling that the name is fully qualified.
-	emptyType  = ".google.protobuf.Empty"
-	lroType    = ".google.longrunning.Operation"
+	emptyType = ".google.protobuf.Empty"
+	lroType   = ".google.longrunning.Operation"
+	// used when google.protobuf.Empty is the value of an annotation, which isn't resolved by protoc
+	emptyValue = "google.protobuf.Empty"
 	paramError = "need parameter in format: go-gapic-package=client/import/path;packageName"
 	alpha      = "alpha"
 	beta       = "beta"

--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -161,18 +161,23 @@ func (g *generator) lroType(servName string, serv *descriptor.ServiceDescriptorP
 		p("//")
 		p("// See documentation of Poll for error-handling information.")
 
-		// only return an error when response_type is google.protobuf.Empty
 		returnType := fmt.Sprintf("(*%s, error)", respType)
+		returnErr := "nil, err"
+		returnResp := "&resp, nil"
+
+		// only return an error when response_type is google.protobuf.Empty
 		if respType == "emptypb.Empty" {
 			returnType = "error"
+			returnErr = "err"
+			returnResp = "nil"
 		}
 
 		p("func (op *%s) Wait(ctx context.Context, opts ...gax.CallOption) %s {", lroType, returnType)
 		p("  var resp %s", respType)
 		p("  if err := op.lro.WaitWithInterval(ctx, &resp, time.Minute, opts...); err != nil {")
-		p("    return nil, err")
+		p("    return %s", returnErr)
 		p("  }")
-		p("  return &resp, nil")
+		p("  return %s", returnResp)
 		p("}")
 		p("")
 

--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -166,7 +166,7 @@ func (g *generator) lroType(servName string, serv *descriptor.ServiceDescriptorP
 		returnResp := "&resp, nil"
 
 		// only return an error when response_type is google.protobuf.Empty
-		if respType == "emptypb.Empty" {
+		if opInfo.GetResponseType() == emptyValue {
 			returnType = "error"
 			returnErr = "err"
 			returnResp = "nil"

--- a/internal/gengapic/testdata/empty_example.want
+++ b/internal/gengapic/testdata/empty_example.want
@@ -132,3 +132,51 @@ func ExampleClient_BidiThings() {
 	}
 }
 
+func ExampleClient_EmptyLRO() {
+	// import mypackagepb "mypackage"
+
+	ctx := context.Background()
+	c, err := Foo.NewClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	req := &mypackagepb.InputType{
+		// TODO: Fill request struct fields.
+	}
+	op, err := c.EmptyLRO(ctx, req)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	err = op.Wait(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+}
+
+func ExampleClient_RespLRO() {
+	// import mypackagepb "mypackage"
+
+	ctx := context.Background()
+	c, err := Foo.NewClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	req := &mypackagepb.InputType{
+		// TODO: Fill request struct fields.
+	}
+	op, err := c.RespLRO(ctx, req)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	// TODO: Use resp.
+	_ = resp
+}
+

--- a/internal/gengapic/testdata/foo_example.want
+++ b/internal/gengapic/testdata/foo_example.want
@@ -132,3 +132,51 @@ func ExampleFooClient_BidiThings() {
 	}
 }
 
+func ExampleFooClient_EmptyLRO() {
+	// import mypackagepb "mypackage"
+
+	ctx := context.Background()
+	c, err := Bar.NewFooClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	req := &mypackagepb.InputType{
+		// TODO: Fill request struct fields.
+	}
+	op, err := c.EmptyLRO(ctx, req)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	err = op.Wait(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+}
+
+func ExampleFooClient_RespLRO() {
+	// import mypackagepb "mypackage"
+
+	ctx := context.Background()
+	c, err := Bar.NewFooClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	req := &mypackagepb.InputType{
+		// TODO: Fill request struct fields.
+	}
+	op, err := c.RespLRO(ctx, req)
+	if err != nil {
+		// TODO: Handle error.
+	}
+
+	resp, err := op.Wait(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	// TODO: Use resp.
+	_ = resp
+}
+

--- a/internal/gengapic/testdata/method_EmptyLRO.want
+++ b/internal/gengapic/testdata/method_EmptyLRO.want
@@ -1,30 +1,29 @@
-func (c *FooClient) GetBigThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*GetBigThingOperation, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother())))
-	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
-	opts = append(c.CallOptions.GetBigThing[0:len(c.CallOptions.GetBigThing):len(c.CallOptions.GetBigThing)], opts...)
+func (c *FooClient) EmptyLRO(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*EmptyLROOperation, error) {
+	ctx = insertMetadata(ctx, c.xGoogMetadata)
+	opts = append(c.CallOptions.EmptyLRO[0:len(c.CallOptions.EmptyLRO):len(c.CallOptions.EmptyLRO)], opts...)
 	var resp *longrunningpb.Operation
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		var err error
-		resp, err = c.fooClient.GetBigThing(ctx, req, settings.GRPC...)
+		resp, err = c.fooClient.EmptyLRO(ctx, req, settings.GRPC...)
 		return err
 	}, opts...)
 	if err != nil {
 		return nil, err
 	}
-	return &GetBigThingOperation{
+	return &EmptyLROOperation{
 		lro: longrunning.InternalNewOperation(c.LROClient, resp),
 	}, nil
 }
 
-// GetBigThingOperation manages a long-running operation from GetBigThing.
-type GetBigThingOperation struct {
+// EmptyLROOperation manages a long-running operation from EmptyLRO.
+type EmptyLROOperation struct {
 	lro *longrunning.Operation
 }
 
-// GetBigThingOperation returns a new GetBigThingOperation from a given name.
-// The name must be that of a previously created GetBigThingOperation, possibly from a different process.
-func (c *MyServiceClient) GetBigThingOperation(name string) *GetBigThingOperation {
-	return &GetBigThingOperation{
+// EmptyLROOperation returns a new EmptyLROOperation from a given name.
+// The name must be that of a previously created EmptyLROOperation, possibly from a different process.
+func (c *MyServiceClient) EmptyLROOperation(name string) *EmptyLROOperation {
+	return &EmptyLROOperation{
 		lro: longrunning.InternalNewOperation(c.LROClient, &longrunningpb.Operation{Name: name}),
 	}
 }
@@ -32,12 +31,12 @@ func (c *MyServiceClient) GetBigThingOperation(name string) *GetBigThingOperatio
 // Wait blocks until the long-running operation is completed, returning the response and any errors encountered.
 //
 // See documentation of Poll for error-handling information.
-func (op *GetBigThingOperation) Wait(ctx context.Context, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
-	var resp mypackagepb.OutputType
+func (op *EmptyLROOperation) Wait(ctx context.Context, opts ...gax.CallOption) error {
+	var resp emptypb.Empty
 	if err := op.lro.WaitWithInterval(ctx, &resp, time.Minute, opts...); err != nil {
-		return nil, err
+		return err
 	}
-	return &resp, nil
+	return nil
 }
 
 // Poll fetches the latest state of the long-running operation.
@@ -47,8 +46,8 @@ func (op *GetBigThingOperation) Wait(ctx context.Context, opts ...gax.CallOption
 // If Poll succeeds and the operation has completed successfully,
 // op.Done will return true, and the response of the operation is returned.
 // If Poll succeeds and the operation has not completed, the returned response and error are both nil.
-func (op *GetBigThingOperation) Poll(ctx context.Context, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
-	var resp mypackagepb.OutputType
+func (op *EmptyLROOperation) Poll(ctx context.Context, opts ...gax.CallOption) (*emptypb.Empty, error) {
+	var resp emptypb.Empty
 	if err := op.lro.Poll(ctx, &resp, opts...); err != nil {
 		return nil, err
 	}
@@ -59,13 +58,13 @@ func (op *GetBigThingOperation) Poll(ctx context.Context, opts ...gax.CallOption
 }
 
 // Done reports whether the long-running operation has completed.
-func (op *GetBigThingOperation) Done() bool {
+func (op *EmptyLROOperation) Done() bool {
 	return op.lro.Done()
 }
 
 // Name returns the name of the long-running operation.
 // The name is assigned by the server and is unique within the service from which the operation is created.
-func (op *GetBigThingOperation) Name() string {
+func (op *EmptyLROOperation) Name() string {
 	return op.lro.Name()
 }
 

--- a/internal/gengapic/testdata/method_RespLRO.want
+++ b/internal/gengapic/testdata/method_RespLRO.want
@@ -1,0 +1,70 @@
+func (c *FooClient) RespLRO(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*RespLROOperation, error) {
+	ctx = insertMetadata(ctx, c.xGoogMetadata)
+	opts = append(c.CallOptions.RespLRO[0:len(c.CallOptions.RespLRO):len(c.CallOptions.RespLRO)], opts...)
+	var resp *longrunningpb.Operation
+	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+		var err error
+		resp, err = c.fooClient.RespLRO(ctx, req, settings.GRPC...)
+		return err
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return &RespLROOperation{
+		lro: longrunning.InternalNewOperation(c.LROClient, resp),
+	}, nil
+}
+
+// RespLROOperation manages a long-running operation from RespLRO.
+type RespLROOperation struct {
+	lro *longrunning.Operation
+}
+
+// RespLROOperation returns a new RespLROOperation from a given name.
+// The name must be that of a previously created RespLROOperation, possibly from a different process.
+func (c *MyServiceClient) RespLROOperation(name string) *RespLROOperation {
+	return &RespLROOperation{
+		lro: longrunning.InternalNewOperation(c.LROClient, &longrunningpb.Operation{Name: name}),
+	}
+}
+
+// Wait blocks until the long-running operation is completed, returning the response and any errors encountered.
+//
+// See documentation of Poll for error-handling information.
+func (op *RespLROOperation) Wait(ctx context.Context, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
+	var resp mypackagepb.OutputType
+	if err := op.lro.WaitWithInterval(ctx, &resp, time.Minute, opts...); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}
+
+// Poll fetches the latest state of the long-running operation.
+//
+// If Poll fails, the error is returned and op is unmodified. If Poll succeeds and
+// the operation has completed with failure, the error is returned and op.Done will return true.
+// If Poll succeeds and the operation has completed successfully,
+// op.Done will return true, and the response of the operation is returned.
+// If Poll succeeds and the operation has not completed, the returned response and error are both nil.
+func (op *RespLROOperation) Poll(ctx context.Context, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
+	var resp mypackagepb.OutputType
+	if err := op.lro.Poll(ctx, &resp, opts...); err != nil {
+		return nil, err
+	}
+	if !op.Done() {
+		return nil, nil
+	}
+	return &resp, nil
+}
+
+// Done reports whether the long-running operation has completed.
+func (op *RespLROOperation) Done() bool {
+	return op.lro.Done()
+}
+
+// Name returns the name of the long-running operation.
+// The name is assigned by the server and is unique within the service from which the operation is created.
+func (op *RespLROOperation) Name() string {
+	return op.lro.Name()
+}
+


### PR DESCRIPTION
#258 neglected to update the corresponding `return` statements based on the `response_type`. This fixes that.

It also neglected to fix the example files, which would fail to compile. This fixes that.

It also updates all of the relevant tests, adding more for the special cases.