### PR TITLE
gapic: fix paging criteria & nested message handling

### DIFF
--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -48,8 +48,17 @@ func (g *generator) iterTypeOf(elemField *descriptor.FieldDescriptorProto) (*ite
 			return &iterType{}, err
 		}
 
-		pt.elemTypeName = fmt.Sprintf("*%s.%s", imp.Name, eType.GetName())
-		pt.iterTypeName = eType.GetName() + "Iterator"
+		// Prepend parent Message name for nested Messages
+		// to match the generated Go type name.
+		typ := eType
+		typeName := typ.GetName()
+		for parent, ok := g.descInfo.ParentElement[typ]; ok; parent, ok = g.descInfo.ParentElement[typ] {
+			typeName = fmt.Sprintf("%s_%s", parent.GetName(), typeName)
+			typ = parent
+		}
+
+		pt.elemTypeName = fmt.Sprintf("*%s.%s", imp.Name, typeName)
+		pt.iterTypeName = typeName + "Iterator"
 
 		pt.elemImports = []pbinfo.ImportSpec{imp}
 

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -143,7 +143,7 @@ func (g *generator) pagingField(m *descriptor.MethodDescriptorProto) (*descripto
 		min := elemFields[0].GetNumber()
 		for _, elem := range elemFields {
 			if elem.GetNumber() < min {
-				return nil, fmt.Errorf("%s looks like paging method, but can't determine repeated field to use in %s", *m.Name, outType.GetName())
+				return nil, fmt.Errorf("%s: can't pick repeated field in %s based on aip.dev/4233", *m.Name, outType.GetName())
 			}
 		}
 	}

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -129,7 +129,14 @@ func (g *generator) pagingField(m *descriptor.MethodDescriptorProto) (*descripto
 		return nil, fmt.Errorf("%s looks like paging method, but can't find repeated field in %s", *m.Name, outType.GetName())
 	}
 	if len(elemFields) > 1 {
-		return nil, fmt.Errorf("%s looks like paging method, but too many repeated fields in %s", *m.Name, outType.GetName())
+		// ensure that the first repeated field visited has the lowest field number
+		// according to https://aip.dev/4233, and use that one.
+		min := elemFields[0].GetNumber()
+		for _, elem := range elemFields {
+			if elem.GetNumber() < min {
+				return nil, fmt.Errorf("%s looks like paging method, but can't determine repeated field to use in %s", *m.Name, outType.GetName())
+			}
+		}
 	}
 	return elemFields[0], nil
 }

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -32,9 +32,17 @@ func TestPagingField(t *testing.T) {
 	}
 
 	resField := &descriptor.FieldDescriptorProto{
-		Name:  proto.String("resource"),
-		Type:  typep(descriptor.FieldDescriptorProto_TYPE_STRING),
-		Label: labelp(descriptor.FieldDescriptorProto_LABEL_REPEATED),
+		Name:   proto.String("resource"),
+		Type:   typep(descriptor.FieldDescriptorProto_TYPE_STRING),
+		Label:  labelp(descriptor.FieldDescriptorProto_LABEL_REPEATED),
+		Number: proto.Int32(1),
+	}
+
+	otherRepField := &descriptor.FieldDescriptorProto{
+		Name:   proto.String("unreachable"),
+		Type:   typep(descriptor.FieldDescriptorProto_TYPE_STRING),
+		Label:  labelp(descriptor.FieldDescriptorProto_LABEL_REPEATED),
+		Number: proto.Int32(0),
 	}
 
 	g := &generator{}
@@ -87,9 +95,9 @@ func TestPagingField(t *testing.T) {
 					Type:  typep(descriptor.FieldDescriptorProto_TYPE_STRING),
 					Label: labelp(descriptor.FieldDescriptorProto_LABEL_OPTIONAL),
 				},
-				// Too many repeated field
+				// resource is not first repeated field in message
 				resField,
-				resField,
+				otherRepField,
 			},
 		},
 	}


### PR DESCRIPTION
* fixes auto-pagination criteria to allow multiple repeated fields if the first visited is the first repeated field by field number per aip.dev/4233
* fixes handling of nested message types in the auto-pagination logic