### PR TITLE
gapic: simplify Empty LRO methods

### DIFF
--- a/internal/gengapic/testdata/method_EmptyLRO.want
+++ b/internal/gengapic/testdata/method_EmptyLRO.want
@@ -32,11 +32,7 @@ func (c *MyServiceClient) EmptyLROOperation(name string) *EmptyLROOperation {
 //
 // See documentation of Poll for error-handling information.
 func (op *EmptyLROOperation) Wait(ctx context.Context, opts ...gax.CallOption) error {
-	var resp emptypb.Empty
-	if err := op.lro.WaitWithInterval(ctx, &resp, time.Minute, opts...); err != nil {
-		return err
-	}
-	return nil
+	return op.lro.WaitWithInterval(ctx, nil, time.Minute, opts...)
 }
 
 // Poll fetches the latest state of the long-running operation.
@@ -47,14 +43,7 @@ func (op *EmptyLROOperation) Wait(ctx context.Context, opts ...gax.CallOption) e
 // op.Done will return true, and the response of the operation is returned.
 // If Poll succeeds and the operation has not completed, the returned response and error are both nil.
 func (op *EmptyLROOperation) Poll(ctx context.Context, opts ...gax.CallOption) error {
-	var resp emptypb.Empty
-	if err := op.lro.Poll(ctx, &resp, opts...); err != nil {
-		return err
-	}
-	if !op.Done() {
-		return nil
-	}
-	return nil
+	return op.lro.Poll(ctx, nil, opts...)
 }
 
 // Done reports whether the long-running operation has completed.


### PR DESCRIPTION
When the `gapic-generator` encountered an LRO response_type of google.protobuf.Empty, it would generate a very minimal implementation for `Wait` and `Poll`. Previously, the microgenerator aimed to keep the internals of these methods similar regardless of the LRO response_type. This produces some hard-to-read code. Rather than make it simpler in the generator, but harder to consume in the generated client, this PR takes the complexity into the generator and restores the monolith's simpler implementation for Empty LROs.