### PR TITLE
Support sample_type field in sample config.

### DIFF
--- a/internal/gensample/gensample_sampleconfig_test.go
+++ b/internal/gensample/gensample_sampleconfig_test.go
@@ -15,9 +15,10 @@
 package gensample
 
 import (
-	yaml "gopkg.in/yaml.v2"
 	"strings"
 	"testing"
+
+	yaml "gopkg.in/yaml.v2"
 
 	"github.com/googleapis/gapic-generator-go/internal/errors"
 	"github.com/googleapis/gapic-generator-go/internal/gensample/schema_v1p2"
@@ -58,14 +59,14 @@ func TestDisambiguateRepeatedSampleIDs(t *testing.T) {
 	}
 
 	gen.disambiguateSampleIDs()
-	if gen.sampleConfig.Samples[0].ID != "sample0WRAP2GEJ" {
-		t.Fatal(errors.E(nil, `expected "sample0WRAP2GEJ", got %q`, gen.sampleConfig.Samples[0].ID))
+	if expected := "sample0C57ISC5Q"; gen.sampleConfig.Samples[0].ID != expected {
+		t.Fatal(errors.E(nil, `expected %q, got %q`, expected, gen.sampleConfig.Samples[0].ID))
 	}
-	if gen.sampleConfig.Samples[1].ID != "sample05ITXN42C" {
-		t.Fatal(errors.E(nil, `expected "sample05ITXN42C", got %q`, gen.sampleConfig.Samples[1].ID))
+	if expected := "sample05L2GRN22"; gen.sampleConfig.Samples[1].ID != expected {
+		t.Fatal(errors.E(nil, `expected %q, got %q`, expected, gen.sampleConfig.Samples[1].ID))
 	}
-	if gen.sampleConfig.Samples[2].ID != "sample1" {
-		t.Fatal(errors.E(nil, `expected "sample1", got %q`, gen.sampleConfig.Samples[2].ID))
+	if expected := "sample1"; gen.sampleConfig.Samples[2].ID != expected {
+		t.Fatal(errors.E(nil, `expected %q, got %q`, expected, gen.sampleConfig.Samples[2].ID))
 	}
 }
 
@@ -81,14 +82,14 @@ func TestDisambiguateRepeatedSampleIDsFromRegionTags(t *testing.T) {
 	}
 
 	gen.disambiguateSampleIDs()
-	if gen.sampleConfig.Samples[0].ID != "sample0WRAP2GEJ" {
-		t.Fatal(errors.E(nil, `expected "sample0WRAP2GEJ", got %q`, gen.sampleConfig.Samples[0].ID))
+	if expected := "sample0C57ISC5Q"; gen.sampleConfig.Samples[0].ID != expected {
+		t.Fatal(errors.E(nil, `expected %q, got %q`, expected, gen.sampleConfig.Samples[0].ID))
 	}
-	if gen.sampleConfig.Samples[1].ID != "sample0QAE76E4S" {
-		t.Fatal(errors.E(nil, `expected "sample0QAE76E4S", got %q`, gen.sampleConfig.Samples[1].ID))
+	if expected := "sample0MHV4NHU4"; gen.sampleConfig.Samples[1].ID != expected {
+		t.Fatal(errors.E(nil, `expected %q, got %q`, expected, gen.sampleConfig.Samples[1].ID))
 	}
-	if gen.sampleConfig.Samples[2].ID != "sample1" {
-		t.Fatal(errors.E(nil, `expected "sample2", got %q`, gen.sampleConfig.Samples[2].ID))
+	if expected := "sample1"; gen.sampleConfig.Samples[2].ID != expected {
+		t.Fatal(errors.E(nil, `expected %q, got %q`, expected, gen.sampleConfig.Samples[2].ID))
 	}
 }
 

--- a/internal/gensample/schema_v1p2/schema.go
+++ b/internal/gensample/schema_v1p2/schema.go
@@ -30,6 +30,7 @@ type Sample struct {
 	CallingPatterns []string `yaml:"calling_patterns"`
 	Request         []RequestConfig
 	Response        []ResponseConfig
+	SampleType      []string `yaml:"sample_type"`
 }
 
 type RequestConfig struct {

--- a/internal/gensample/schema_v1p2/schema.go
+++ b/internal/gensample/schema_v1p2/schema.go
@@ -14,6 +14,14 @@
 
 package schema_v1p2
 
+const (
+	// These values are used in Sample.SampleType to denote taht
+	// the config applies to standalone samples or to in-code
+	// (language doc) samples.
+	sampleTypeStandalone = "standalone"
+	sampleTypeDoc        = "incode"
+)
+
 type SampleConfig struct {
 	Type    string
 	Version string `yaml:"schema_version"`
@@ -61,4 +69,29 @@ type LoopSpec struct {
 type WriteFileSpec struct {
 	Contents string
 	FileName []string `yaml: file_name`
+}
+
+// IsStandaloneSample returns true iff s.SampleType specifies s should
+// generate standalone samples.
+func (s *Sample) IsStandaloneSample() bool {
+	if len(s.SampleType) == 0 {
+		return true
+	}
+	for _, t := range s.SampleType {
+		if t == sampleTypeStandalone {
+			return true
+		}
+	}
+	return false
+}
+
+// IsDocSample returns true iff s.SampleType specifies s should
+// generate in-code (language doc) samples.
+func (s *Sample) IsDocSample() bool {
+	for _, t := range s.SampleType {
+		if t == sampleTypeDoc {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/gensample/schema_v1p2/schema_test.go
+++ b/internal/gensample/schema_v1p2/schema_test.go
@@ -1,0 +1,71 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema_v1p2
+
+import "testing"
+
+func TestDetermineSampleType(t *testing.T) {
+	for idx, tcase := range []struct {
+		sampleType           []string
+		expectTypeStandalone bool
+		expectTypeDoc        bool
+	}{
+		{
+			sampleType:           nil,
+			expectTypeStandalone: true,
+		},
+		{
+			sampleType:           []string{},
+			expectTypeStandalone: true,
+		},
+		{
+			sampleType:           []string{sampleTypeStandalone},
+			expectTypeStandalone: true,
+		},
+		{
+			sampleType:           []string{"foo", sampleTypeStandalone},
+			expectTypeStandalone: true,
+		},
+		{
+			sampleType:    []string{sampleTypeDoc},
+			expectTypeDoc: true,
+		},
+		{
+			sampleType:    []string{"bar", sampleTypeDoc},
+			expectTypeDoc: true,
+		},
+		{
+			sampleType:           []string{sampleTypeDoc, sampleTypeStandalone},
+			expectTypeStandalone: true,
+			expectTypeDoc:        true,
+		},
+		{
+			sampleType:           []string{"foo", sampleTypeStandalone, "bar", sampleTypeDoc, "baz"},
+			expectTypeStandalone: true,
+			expectTypeDoc:        true,
+		},
+		{
+			sampleType: []string{"foo"},
+		},
+	} {
+		conf := Sample{SampleType: tcase.sampleType}
+		if actual := conf.IsStandaloneSample(); actual != tcase.expectTypeStandalone {
+			t.Errorf("case %d standalone sample type: expected %v, got %v", idx, tcase.expectTypeStandalone, actual)
+		}
+		if actual := conf.IsDocSample(); actual != tcase.expectTypeDoc {
+			t.Errorf("case %d doc sample type: expected %v, got %v", idx, tcase.expectTypeDoc, actual)
+		}
+	}
+}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -79,3 +79,7 @@ func (p *P) Bytes() []byte {
 func (p *P) String() string {
 	return p.buf.String()
 }
+
+func (p *P) Len() int {
+	return p.buf.Len()
+}


### PR DESCRIPTION
This ensures we do not generate standalone samples for a sample config that only requests in-code samples.
This adds utility functions to determine whether a sample config requests standalone samples or in-code samples (it can request both, of course).
Includes tests.

This fixes #244.