### PR TITLE
Rename `validPrims`

### DIFF
--- a/internal/gensample/inittree.go
+++ b/internal/gensample/inittree.go
@@ -284,11 +284,11 @@ func (t *initTree) parseInit(path string, value string, comment string, info pbi
 		if pType == descriptor.FieldDescriptorProto_TYPE_STRING {
 			value = fmt.Sprintf("%q", value)
 		}
-		validPrim := validPrims[pType]
-		if validPrim == nil {
+		validate := primitiveValidator[pType]
+		if validate == nil {
 			return report(errors.E(nil, "not a primitive type: %q", pType))
 		}
-		if !validPrim(value) {
+		if !validate(value) {
 			return report(errors.E(nil, "invalid value for type %q: %s", pType, value))
 		}
 	}
@@ -370,8 +370,8 @@ func (t *initTree) parsePathRest(sc *scanner.Scanner, info pbinfo.Info) (*initTr
 				// as a map key. scanner.Ident is here to handle the case when key is a bool value, as
 				// `true` and `false` (without quote) are parsed as scanner.Ident.
 				tokVal = sc.TokenText()
-				validPrim := validPrims[t.typ.keyType.prim]
-				if !validPrim(tokVal) {
+				validate := primitiveValidator[t.typ.keyType.prim]
+				if !validate(tokVal) {
 					return nil, r, errors.E(nil, "invalid value for type %q: %s", t.typ.keyType.prim, tokVal)
 				}
 			} else {

--- a/internal/gensample/primval.go
+++ b/internal/gensample/primval.go
@@ -20,10 +20,10 @@ import (
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 )
 
-// validPrims contains functions to check value-validity for primitive types.
+// primitiveValidator contains functions to check value-validity for primitive types.
 // Functions only perform cursory checking; since we use scanner for tokenizing,
 // they must already be a valid token of some type.
-var validPrims = [...]func(string) bool{
+var primitiveValidator = [...]func(string) bool{
 	descriptor.FieldDescriptorProto_TYPE_BOOL: func(s string) bool { return s == "true" || s == "false" },
 
 	descriptor.FieldDescriptorProto_TYPE_BYTES:  validStrings,


### PR DESCRIPTION
We were using both `validPrim` and `validPrims`, which differ by one letter. Changed them to be, respectively, `validate` (variable holding a validator function) and `primitiveValidator` (array of validators)

Fixes #190 