### PR TITLE
gapic: fix acronym handling in camelToSnake

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -598,9 +598,17 @@ func upperFirst(s string) string {
 
 func camelToSnake(s string) string {
 	var sb strings.Builder
-	for i, r := range s {
+	runes := []rune(s)
+
+	for i, r := range runes {
 		if unicode.IsUpper(r) && i != 0 {
-			sb.WriteByte('_')
+			// An uppercase rune followed by a lowercase
+			// rune indicates the start of a word,
+			// keeping uppercase acronyms together.
+			next := i + 1
+			if len(runes) > next && !unicode.IsUpper(runes[next]) {
+				sb.WriteByte('_')
+			}
 		}
 		sb.WriteRune(unicode.ToLower(r))
 	}

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -95,6 +95,9 @@ func TestReduceServName(t *testing.T) {
 		{"FooServiceV2", "foo", ""},
 
 		{"FooV2Bar", "", "FooV2Bar"},
+
+		// IAM should be replaced with Iam
+		{"IAMCredentials", "credentials", "IamCredentials"},
 	} {
 		if got := pbinfo.ReduceServName(tst.in, tst.pkg); got != tst.want {
 			t.Errorf("pbinfo.ReduceServName(%q, %q) = %q, want %q", tst.in, tst.pkg, got, tst.want)
@@ -365,5 +368,19 @@ func Test_buildAccessor(t *testing.T) {
 				t.Errorf("buildAccessor() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_camelToSnake(t *testing.T) {
+	for _, tst := range []struct {
+		in, want string
+	}{
+		{"IAMCredentials", "iam_credentials"},
+		{"DLP", "dlp"},
+		{"OsConfig", "os_config"},
+	} {
+		if got := camelToSnake(tst.in); got != tst.want {
+			t.Errorf("camelToSnake(%q) = %q, want %q", tst.in, got, tst.want)
+		}
 	}
 }

--- a/internal/pbinfo/pbinfo.go
+++ b/internal/pbinfo/pbinfo.go
@@ -202,5 +202,16 @@ func ReduceServName(svc, pkg string) string {
 	if strings.EqualFold(svc, pkg) {
 		svc = ""
 	}
+
+	// This is a special case for IAM and should not be
+	// extended to support any new API name containing
+	// an acronym.
+	//
+	// In order to avoid a breaking change for IAM
+	// clients, we must keep consistent identifier casing.
+	if strings.Contains(svc, "IAM") {
+		svc = strings.ReplaceAll(svc, "IAM", "Iam")
+	}
+
 	return svc
 }


### PR DESCRIPTION
Currently, `camelToSnake` will split a name like `IAMCredentials` into `i_a_m_credentials` which is incorrect. With this change `camelToSnake` respects upper case acronyms in conversion.

Furthermore, a special case is added during proto service name reduction for `IAM` APIs in order to avoid a breaking change. 

Fixes #282 