### PR TITLE
gapic: fix LRO handling for longrunning pkg

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -189,7 +189,7 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 
 	var hasLRO bool
 	for _, m := range serv.Method {
-		if *m.OutputType == lroType {
+		if g.isLRO(m) {
 			hasLRO = true
 			break
 		}

--- a/internal/gengapic/example.go
+++ b/internal/gengapic/example.go
@@ -104,7 +104,7 @@ func (g *generator) exampleMethod(pkgName, servName string, m *descriptor.Method
 
 	if pf != nil {
 		g.examplePagingCall(m)
-	} else if *m.OutputType == lroType {
+	} else if g.isLRO(m) {
 		g.exampleLROCall(m)
 	} else if *m.OutputType == emptyType {
 		g.exampleEmptyCall(m)

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -377,7 +377,7 @@ type auxTypes struct {
 // genMethod generates a single method from a client. m must be a method declared in serv.
 // If the generated method requires an auxillary type, it is added to aux.
 func (g *generator) genMethod(servName string, serv *descriptor.ServiceDescriptorProto, m *descriptor.MethodDescriptorProto) error {
-	if m.GetOutputType() == lroType {
+	if g.isLRO(m) {
 		g.aux.lros = append(g.aux.lros, m)
 		return g.lroCall(servName, m)
 	}
@@ -566,6 +566,12 @@ func (g *generator) comment(s string) {
 			g.printf("// %s", l)
 		}
 	}
+}
+
+// isLRO determines if a given Method is a longrunning operation, ignoring
+// those defined by the longrunning proto package.
+func (g *generator) isLRO(m *descriptor.MethodDescriptorProto) bool {
+	return m.GetOutputType() == lroType && g.descInfo.ParentFile[m].GetPackage() != "google.longrunning"
 }
 
 // grpcClientField reports the field name to store gRPC client.

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -384,3 +384,37 @@ func Test_camelToSnake(t *testing.T) {
 		}
 	}
 }
+
+func Test_isLRO(t *testing.T) {
+	lroGetOp := &descriptor.MethodDescriptorProto{
+		Name:       proto.String("GetOperation"),
+		OutputType: proto.String(".google.longrunning.Operation"),
+	}
+
+	actualLRO := &descriptor.MethodDescriptorProto{
+		Name:       proto.String("SuperLongRPC"),
+		OutputType: proto.String(".google.longrunning.Operation"),
+	}
+
+	var g generator
+	g.descInfo.ParentFile = map[proto.Message]*descriptor.FileDescriptorProto{
+		lroGetOp: &descriptor.FileDescriptorProto{
+			Package: proto.String("google.longrunning"),
+		},
+		actualLRO: &descriptor.FileDescriptorProto{
+			Package: proto.String("my.pkg"),
+		},
+	}
+
+	for _, tst := range []struct {
+		in   *descriptor.MethodDescriptorProto
+		want bool
+	}{
+		{lroGetOp, false},
+		{actualLRO, true},
+	} {
+		if got := g.isLRO(tst.in); got != tst.want {
+			t.Errorf("isLRO(%v) = %v, want %v", tst.in, got, tst.want)
+		}
+	}
+}

--- a/internal/pbinfo/pbinfo.go
+++ b/internal/pbinfo/pbinfo.go
@@ -75,6 +75,9 @@ func Of(files []*descriptor.FileDescriptorProto) Info {
 		}
 		for _, s := range f.Service {
 			info.ParentFile[s] = f
+			for _, m := range s.Method {
+				info.ParentFile[m] = f
+			}
 		}
 
 		// Type


### PR DESCRIPTION
RPCs for the `google.longrunning`package shouldn't be generated with the LRO helpers because they are ordinary RPCs. This makes inference of LRO-help generation ignore the `google.longrunning` package.

This also adds tracking of the method-to-parent file mapping to `pbinfo`.