### PR TITLE
gapic: fix spelling of canceled

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,10 +16,10 @@ protobuf_deps()
 http_archive(
     name = "io_bazel_rules_go",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.21.2/rules_go-v0.21.2.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.21.2/rules_go-v0.21.2.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.21.3/rules_go-v0.21.3.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.21.3/rules_go-v0.21.3.tar.gz",
     ],
-    sha256 = "f99a9d76e972e0c8f935b2fe6d0d9d778f67c760c6d2400e23fc2e469016e2bd",
+    sha256 = "af04c969321e8f428f63ceb73463d6ea817992698974abeff0161e069cd08bd6",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")

--- a/internal/gengapic/BUILD.bazel
+++ b/internal/gengapic/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "@com_github_golang_protobuf//jsonpb:go_default_library_gen",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@go_googleapis//google/api:annotations_go_proto",
+        "@go_googleapis//google/rpc:code_go_proto",
         "@go_googleapis//google/longrunning:longrunning_go_proto",
         "@in_gopkg_yaml_v2//:go_default_library",
         "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -24,6 +24,7 @@ import (
 	conf "github.com/googleapis/gapic-generator-go/internal/grpc_service_config"
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/genproto/googleapis/rpc/code"
 )
 
 func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servName string) error {
@@ -160,13 +161,14 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 				p("gax.WithRetry(func() gax.Retryer {")
 				p("  return gax.OnCodes([]codes.Code{")
 				for _, c := range rp.GetRetryableStatusCodes() {
+					cstr := c.String()
+
 					// Go uses the American-English spelling with a single "L"
-					code := c.String()
-					if code == "CANCELLED" {
-						code = "CANCELED"
+					if c == code.Code_CANCELLED {
+						cstr = "Canceled"
 					}
 
-					p("    codes.%s,", snakeToCamel(code))
+					p("    codes.%s,", snakeToCamel(cstr))
 				}
 				p("	 }, gax.Backoff{")
 				// this ignores max_attempts

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -160,7 +160,13 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 				p("gax.WithRetry(func() gax.Retryer {")
 				p("  return gax.OnCodes([]codes.Code{")
 				for _, c := range rp.GetRetryableStatusCodes() {
-					p("    codes.%s,", snakeToCamel(c.String()))
+					// Go uses the American-English spelling with a single "L"
+					code := c.String()
+					if code == "CANCELLED" {
+						code = "CANCELED"
+					}
+
+					p("    codes.%s,", snakeToCamel(code))
 				}
 				p("	 }, gax.Backoff{")
 				// this ignores max_attempts


### PR DESCRIPTION
Go uses the American-English spelling `CANCELED`, while the gRPC code name uses the British-English spelling `CANCELLED`.