### PR TITLE
gapic: fix naive retry related imports

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -137,11 +137,6 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 			}
 		}
 
-		if len(policies) > 0 {
-			g.imports[pbinfo.ImportSpec{Path: "time"}] = true
-			g.imports[pbinfo.ImportSpec{Path: "google.golang.org/grpc/codes"}] = true
-		}
-
 		// read retry params from gRPC ServiceConfig
 		p("func default%[1]sCallOptions() *%[1]sCallOptions {", servName)
 		p("  return &%sCallOptions{", servName)
@@ -177,6 +172,10 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 				p("		Multiplier: %.2f,", rp.GetBackoffMultiplier())
 				p("	 })")
 				p("}),")
+
+				// include imports necessary for retry configuration
+				g.imports[pbinfo.ImportSpec{Path: "time"}] = true
+				g.imports[pbinfo.ImportSpec{Path: "google.golang.org/grpc/codes"}] = true
 			}
 			p("},")
 		}


### PR DESCRIPTION
Fixes #316 by moving the retry-related import inclusion into the condition where we are generating a populated retry config. It is added to a loop so the generated import map could be accessed a lot, but it's preferred to nesting the code in another conditional check or a separate loop.