### PR TITLE
gencli: set default for page_size to 10

### DIFF
--- a/internal/gencli/flag.go
+++ b/internal/gencli/flag.go
@@ -65,6 +65,13 @@ func (f *Flag) GenFlag() string {
 		case "string":
 			def = `""`
 		case "int32", "int64", "int", "uint32", "uint64":
+			// set default page_size to 10 because 0 seems to short circuit the RPC
+			if f.FieldName == "PageSize" {
+				def = "10"
+				f.Usage = fmt.Sprintf("Default is %s. %s", def, f.Usage)
+				break
+			}
+
 			def = "0"
 		case "float32", "float64":
 			def = "0.0"


### PR DESCRIPTION
This sets the default flag value for instances of the `page_size` field to `10` instead of `0`. It also prepends the default to the flag usage documentation.

I tested this with [gapic-showcase](https://github.com/googleapis/gapic-showcase).

Fixes #315 

cc: @odsod