### PR TITLE
gencli: support repeated enums

### DIFF
--- a/internal/gencli/cmd_file.go
+++ b/internal/gencli/cmd_file.go
@@ -59,7 +59,7 @@ var {{$oneOfVal.VarName}} {{if $oneOfVal.IsNested }}{{ $oneOfVal.MessageImport.N
 {{ if and ( .IsMessage ) .Repeated }}
 var {{ .VarName }} []string
 {{ else if ( .IsEnum ) }}
-var {{ .VarName }} string
+var {{ .VarName }} {{if .Repeated }}[]{{ end }}string
 {{ end }}
 {{ end }}
 
@@ -144,7 +144,13 @@ var {{$methodCmdVar}} = &cobra.Command{
 			{{ if .HasEnums }}
 			{{ range .Flags }}
 			{{ if ( .IsEnum ) }}{{ $enumType := (print .MessageImport.Name "." .Message ) }}
+			{{ if .Repeated }}
+			for _, val := range {{ .VarName }} {
+				{{ $.InputMessageVar }}.{{ .FieldName }} = append({{ $enumType }}({{ $enumType }}_value[strings.ToUpper(val)]))
+			}
+			{{ else }}
 			{{ $.InputMessageVar }}.{{ .FieldName }} = {{ $enumType }}({{ $enumType }}_value[strings.ToUpper({{ .VarName }})])
+			{{ end }}
 			{{ end }} 
 			{{ end }}
 			{{ end }}

--- a/internal/gencli/cmd_file.go
+++ b/internal/gencli/cmd_file.go
@@ -145,8 +145,9 @@ var {{$methodCmdVar}} = &cobra.Command{
 			{{ range .Flags }}
 			{{ if ( .IsEnum ) }}{{ $enumType := (print .MessageImport.Name "." .Message ) }}
 			{{ if .Repeated }}
-			for _, val := range {{ .VarName }} {
-				{{ $.InputMessageVar }}.{{ .FieldName }} = append({{ $enumType }}({{ $enumType }}_value[strings.ToUpper(val)]))
+			for _, in := range {{ .VarName }} {
+				val := {{ $enumType }}({{ $enumType }}_value[strings.ToUpper(in)])
+				{{ $.InputMessageVar }}.{{ .FieldName }} = append({{ $.InputMessageVar }}.{{ .FieldName }}, val)
 			}
 			{{ else }}
 			{{ $.InputMessageVar }}.{{ .FieldName }} = {{ $enumType }}({{ $enumType }}_value[strings.ToUpper({{ .VarName }})])

--- a/internal/gencli/cmd_file.go
+++ b/internal/gencli/cmd_file.go
@@ -143,14 +143,14 @@ var {{$methodCmdVar}} = &cobra.Command{
 			{{ end }}
 			{{ if .HasEnums }}
 			{{ range .Flags }}
-			{{ if ( .IsEnum ) }}{{ $enumType := (print .MessageImport.Name "." .Message ) }}
+			{{ if ( .IsEnum ) }}{{ $enumType := (print .MessageImport.Name "." .Message ) }}{{ $requestField := (print $.InputMessageVar "." .FieldName ) }}
 			{{ if .Repeated }}
 			for _, in := range {{ .VarName }} {
 				val := {{ $enumType }}({{ $enumType }}_value[strings.ToUpper(in)])
-				{{ $.InputMessageVar }}.{{ .FieldName }} = append({{ $.InputMessageVar }}.{{ .FieldName }}, val)
+				{{ $requestField }} = append({{ $requestField }}, val)
 			}
 			{{ else }}
-			{{ $.InputMessageVar }}.{{ .FieldName }} = {{ $enumType }}({{ $enumType }}_value[strings.ToUpper({{ .VarName }})])
+			{{ $requestField }} = {{ $enumType }}({{ $enumType }}_value[strings.ToUpper({{ .VarName }})])
 			{{ end }}
 			{{ end }} 
 			{{ end }}


### PR DESCRIPTION
Adds support for `repeated` fields using an `enum` type.

Fixes #319 

cc: @ericwenn @odsod