### PR TITLE
gapic: tighten reference link parser regexp

### DIFF
--- a/internal/gengapic/markdown.go
+++ b/internal/gengapic/markdown.go
@@ -27,7 +27,7 @@ import (
 )
 
 var linkParser = regexp.MustCompile(`<a href=["'](.+)["']`)
-var referenceParser = regexp.MustCompile(`\[(.+)\]\[(.*)\]`)
+var referenceParser = regexp.MustCompile(`\[([a-zA-Z1-9\.\_]+)\]\[[a-zA-Z1-9\.\_]*\]`)
 
 func MDPlain(s string) string {
 	var mdr mdRenderer

--- a/internal/gengapic/markdown.go
+++ b/internal/gengapic/markdown.go
@@ -27,7 +27,7 @@ import (
 )
 
 var linkParser = regexp.MustCompile(`<a href=["'](.+)["']`)
-var referenceParser = regexp.MustCompile(`\[([a-zA-Z1-9\.\_]+)\]\[[a-zA-Z1-9\.\_]*\]`)
+var referenceParser = regexp.MustCompile(`\[([a-zA-Z1-9._]+)\]\[[a-zA-Z1-9._]*\]`)
 
 func MDPlain(s string) string {
 	var mdr mdRenderer

--- a/internal/gengapic/markdown_test.go
+++ b/internal/gengapic/markdown_test.go
@@ -74,8 +74,8 @@ func TestMDPlain(t *testing.T) {
 			want: "html with a softbreak (at /link/to/some#thing) \n test",
 		},
 		{
-			in:   "link to [a search engine](https://www.google.com) with request type [Search][foo.bar.v1.Search].",
-			want: "link to a search engine (at https://www.google.com) with request type Search.",
+			in:   "link to [a search engine](https://www.google.com) with request type [Search][foo.bar_baz.v1.Search], [biz][].",
+			want: "link to a search engine (at https://www.google.com) with request type Search, biz.",
 		},
 	} {
 		got := MDPlain(tst.in)

--- a/internal/gengapic/markdown_test.go
+++ b/internal/gengapic/markdown_test.go
@@ -74,8 +74,8 @@ func TestMDPlain(t *testing.T) {
 			want: "html with a softbreak (at /link/to/some#thing) \n test",
 		},
 		{
-			in:   "link to [a search engine](https://www.google.com) with request type [Search][foo.bar_baz.v1.Search], [biz][].",
-			want: "link to a search engine (at https://www.google.com) with request type Search, biz.",
+			in:   "link to [a search engine](https://www.google.com) with request type [Search][foo.bar_baz.v1.Search], [biz][][buz][baz].",
+			want: "link to a search engine (at https://www.google.com) with request type Search, bizbuz.",
 		},
 	} {
 		got := MDPlain(tst.in)


### PR DESCRIPTION
I needed to tighten the regexp added in #341. It was capturing too much, incorrectly.