### PR TITLE
gencli: fix handling deeply nested msg in oneof

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ image:
 
 test-go-cli:
 	go test github.com/googleapis/gapic-generator-go/internal/gencli
-	./cmd/protoc-gen-go_cli/test.sh
 
 test-gapic:
 	go test github.com/googleapis/gapic-generator-go/internal/gengapic

--- a/internal/gencli/cmd_file.go
+++ b/internal/gencli/cmd_file.go
@@ -143,7 +143,7 @@ var {{$methodCmdVar}} = &cobra.Command{
 			{{ end }}
 			{{ if .HasEnums }}
 			{{ range .Flags }}
-			{{ if ( .IsEnum ) }}{{ $enumType := (print .MessageImport.Name "." .Message ) }}{{ $requestField := (print $.InputMessageVar "." .FieldName ) }}
+			{{ if ( .IsEnum ) }}{{ $enumType := (print .MessageImport.Name "." .Message ) }}{{ $requestField := ( .EnumFieldAccess $.InputMessageVar ) }}
 			{{ if .Repeated }}
 			for _, in := range {{ .VarName }} {
 				val := {{ $enumType }}({{ $enumType }}_value[strings.ToUpper(in)])

--- a/internal/gencli/flag.go
+++ b/internal/gencli/flag.go
@@ -107,3 +107,13 @@ func (f *Flag) IsEnum() bool {
 func (f *Flag) IsBytes() bool {
 	return f.Type == descriptor.FieldDescriptorProto_TYPE_BYTES
 }
+
+// EnumFieldAccess constructs the input message field accessor for an enum
+// assignment.
+func (f *Flag) EnumFieldAccess(inputVar string) string {
+	if f.IsOneOfField {
+		seg := strings.LastIndex(f.FieldName, ".")
+		inputVar = strings.TrimSuffix(f.VarName, f.FieldName[seg+1:])
+	}
+	return fmt.Sprintf("%s.%s", inputVar, f.FieldName)
+}

--- a/internal/gencli/gencli.go
+++ b/internal/gencli/gencli.go
@@ -59,6 +59,8 @@ type Command struct {
 	ServerStreaming   bool
 	ClientStreaming   bool
 	Paged             bool
+	HasPageSize       bool
+	HasPageToken      bool
 	IsLRO             bool
 	HasEnums          bool
 	SubCommands       []*Command
@@ -539,9 +541,13 @@ func (g *gcli) buildFieldFlags(cmd *Command, msg *desc.MessageDescriptor, prefix
 			flag.MessageImport = *pkg
 		}
 
-		if name := field.GetName(); name == "page_token" || name == "page_size" {
-			cmd.Paged = true
+		if name := field.GetName(); name == "page_token" {
+			cmd.HasPageToken = true
+		} else if name == "page_size" {
+			cmd.HasPageSize = true
 		}
+
+		cmd.Paged = cmd.HasPageSize && cmd.HasPageToken
 
 		flags = append(flags, &flag)
 	}

--- a/internal/gencli/gencli.go
+++ b/internal/gencli/gencli.go
@@ -521,7 +521,7 @@ func (g *gcli) buildFieldFlags(cmd *Command, msg *desc.MessageDescriptor, parent
 				if isOneOf {
 					fieldName := title(strings.TrimPrefix(flag.Name, flag.OneOfSelector+"."))
 
-					// nested message fields that belong to a nested message
+					// Nested message fields that belong to a nested message
 					// oneof but aren't a oneof themselves don't have a
 					// OneOfSelector to TrimPrefix.
 					//


### PR DESCRIPTION
Fixes variable name generation for `enum` fields belonging to a nested `oneof`: the `enum` field's name was being stripped incorrectly. 

Fixes variable name referencing in flag generation for nested messages that belong to nested messages that are a `oneof` field: the name of the nested messages following that of the nested message `oneof` field shouldn't be included.

Fixes pagination detection, requiring both `page_size` and `page_token` request message fields in stead of just one or the other (naively). 

Fixes a missing `fmt` import when there is `oneof`, which is used for `fmt.Errorf` in the `default` case of the `switch` that sets the `oneof` field based on the selector value.

Fixes #344 

Also disables the integration testing script for protoc-gen-go_cli in the `test-go-cli` Make target, to be fixed in #345. This was tested with `google/cloud/bigquery/connection/v1beta1` and `gapic-showcase`.