### PR TITLE
chore: refactor Empty type constants

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -41,13 +41,10 @@ import (
 )
 
 const (
-	// protoc puts a dot in front of name, signaling that the name is fully qualified.
-	emptyType = ".google.protobuf.Empty"
-	lroType   = ".google.longrunning.Operation"
-	// used when google.protobuf.Empty is the value of an annotation, which isn't resolved by protoc
-	//
-	// TODO(ndietz): https://github.com/googleapis/gapic-generator-go/issues/260
 	emptyValue = "google.protobuf.Empty"
+	// protoc puts a dot in front of name, signaling that the name is fully qualified.
+	emptyType  = "." + emptyValue
+	lroType = ".google.longrunning.Operation"
 	paramError = "need parameter in format: go-gapic-package=client/import/path;packageName"
 	alpha      = "alpha"
 	beta       = "beta"


### PR DESCRIPTION
After exploring consolidation of the `emptyType` and `emptyValue` constants, I think consolidating them doesn't make sense. They influence different code paths and the `.` prefix on `emptyType` has semantic meaning (it indicates protoc resolved it as a fully qualified name). It would be more confusing & brittle, imo, to write prefix stripping or addition code in multiple places if we got rid of one of them. Thus, I changed the `emptyType` to instead prefix the `emptyValue` directly.

Fixes #260 

Note: the `.` prefix business might be different if we move the plugin implementation to the protobuf v2 plugin API (just a guess, haven't looked at it).