### PR TITLE
chore: remove extraneous quotes on release notes

### DIFF
--- a/util/cmd/release/main.go
+++ b/util/cmd/release/main.go
@@ -109,7 +109,7 @@ func main() {
 		"ghr",
 		"-t="+token,
 		"-n="+version,
-		"-b='"+notes(version)+"'",
+		"-b="+notes(version),
 		"-u=googleapis",
 		"-r=gapic-generator-go",
 		"-c="+commitish,


### PR DESCRIPTION
Creating `v0.13.0` was the first release with automated release notes. It worked great except for the extraneous single quotes I wrapped the generated notes in thinking it was necessary to escape the generated text block in the `exec`'d command. The single quotes actually just ended up in the release notes, making the leading header malformed (`'# gapic`), and trailing the last commit message.