### PR TITLE
gencli: JSON output of paged responsed

### DIFF
--- a/internal/gencli/cmd_file.go
+++ b/internal/gencli/cmd_file.go
@@ -276,32 +276,16 @@ var {{$methodCmdVar}} = &cobra.Command{
 		{{ end }}
 		{{ end }}
 		{{ else if and .Paged (not .IsLRO ) }}
-		// get requested page
-		var items []interface{}
-		data := make(map[string]interface{})
-
-		// PageSize could be an integer with a specific precision.
-		// Doing standard i := 0; i < PageSize; i++ creates i as
-		// an int, creating a potential type mismatch. 
-		for i := {{ .InputMessageVar }}.PageSize; i > 0; i-- {
-			item, err := iter.Next()
-			if err == iterator.Done {
-				err = nil
-				break
-			} else if err != nil {
-				return err
-			}
-
-			items = append(items, item)
+		// populate iterator with a page
+		_, err = iter.Next()
+		if err != nil && err != iterator.Done {
+			return err
 		}
-
-		data["page"] = items
-		data["nextToken"] = iter.PageInfo().Token
 
 		if Verbose {
 			fmt.Print("Output: ")
 		}
-		printMessage(data)
+		printMessage(iter.Response)
 		{{ else if not .IsLRO }}
 		if Verbose {
 			fmt.Print("Output: ")

--- a/internal/gencli/root_file.go
+++ b/internal/gencli/root_file.go
@@ -79,8 +79,6 @@ func printMessage(data interface{}) {
 			marshaler.Marshal(&b, msg)
 			s = b.String()
 		}
-	} else if page, ok := data.(map[string]interface{}); ok {
-		s = fmt.Sprintf("%v", page)
 	}
 
 	fmt.Println(s)

--- a/internal/gencli/testdata/root_file.want
+++ b/internal/gencli/testdata/root_file.want
@@ -55,8 +55,6 @@ func printMessage(data interface{}) {
 			marshaler.Marshal(&b, msg)
 			s = b.String()
 		}
-	} else if page, ok := data.(map[string]interface{}); ok {
-		s = fmt.Sprintf("%v", page)
 	}
 
 	fmt.Println(s)


### PR DESCRIPTION
Paged responses does not implemented `proto.Message` and the output was not JSON encoded.