### PR TITLE
bazel: update repositories with latest

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -195,8 +195,8 @@ def com_googleapis_gapic_generator_go_repositories():
         go_repository,
         name = "org_golang_google_genproto",
         importpath = "google.golang.org/genproto",
-        sum = "h1:5aI3/f/3eCZps9xwoEnmgfDJDhMbnJpfqeGpjVNgVEI=",
-        version = "v0.0.0-20200319113533-08878b785e9c",
+        sum = "h1:j7CmVRD4Kec0+f8VuBAc2Ak2MFfXm5Q2/RxuJLL+76E=",
+        version = "v0.0.0-20200413115906-b5235f65be36",
     )
     _maybe(
         go_repository,

--- a/rules_go_gapic/go_gapic_repositories.bzl
+++ b/rules_go_gapic/go_gapic_repositories.bzl
@@ -26,8 +26,8 @@ def go_gapic_repositories():
         go_repository,
         name = "org_golang_google_api",
         importpath = "google.golang.org/api",
-        sum = "h1:jz2KixHX7EcCPiQrySzPdnYT7DbINAypCqKZ1Z7GM40=",
-        version = "v0.20.0",
+        sum = "h1:zS+Q/CJJnVlXpXQVIz+lH0ZT2lBuT2ac7XD8Y/3w6hY=",
+        version = "v0.21.0",
     )
     _maybe(
         go_repository,


### PR DESCRIPTION
Changes to Bazel respositories:
* updates go-genproto commit hash used in the generator (matches `go.mod`)
* updates the `google.golang.org/api` version used to compile the generated client libraries (matches `google-cloud-go` `go.mod`)

Note: tested locally against googleapis/googleapis