### PR TITLE
chore: change plugin use of Unmarshal

### DIFF
--- a/cmd/protoc-gen-go_cli/main.go
+++ b/cmd/protoc-gen-go_cli/main.go
@@ -30,7 +30,7 @@ func main() {
 		log.Fatal(err)
 	}
 	var genReq plugin.CodeGeneratorRequest
-	if err := genReq.Unmarshal(reqBytes); err != nil {
+	if err := proto.Unmarshal(reqBytes, &genReq); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmd/protoc-gen-go_gapic/main.go
+++ b/cmd/protoc-gen-go_gapic/main.go
@@ -31,7 +31,7 @@ func main() {
 		log.Fatal(err)
 	}
 	var genReq plugin.CodeGeneratorRequest
-	if err := genReq.Unmarshal(reqBytes); err != nil {
+	if err := proto.Unmarshal(reqBytes, &genReq); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
This changes the use of `Unmarshal` from the `CodeGeneratorRequest` to the general `proto.Unmarshal`. The former is removed in golang/protobuf v1.4.0 and it is breaking builds that are pulling this tool and latest golang/protobuf. 