### PR TITLE
gencli: fix oneof naming collision

### DIFF
--- a/internal/gencli/cmd_file.go
+++ b/internal/gencli/cmd_file.go
@@ -52,7 +52,7 @@ var {{ $pollingOperationVar }} string
 {{ range $key, $val := .OneOfSelectors }}
 var {{ $val.VarName }} string
 {{ range $oneOfKey, $oneOfVal := $val.OneOfs}}
-var {{$oneOfVal.VarName}} {{if $oneOfVal.IsNested }}{{ $oneOfVal.MessageImport.Name }}.{{ $oneOfVal.Message }}{{ else }}{{ $.InputMessage }}{{ end }}_{{ ( title $oneOfKey ) }}
+var {{$oneOfVal.VarName}} {{ ( oneofTypeName $oneOfKey $.InputMessage $oneOfVal ) }}
 {{ end }}
 {{ end }}
 {{ range .Flags }}
@@ -387,6 +387,7 @@ var cmdTemplateCompiled *template.Template
 func init() {
 	helpers := make(template.FuncMap)
 	helpers["title"] = title
+	helpers["oneofTypeName"] = oneofTypeName
 
 	cmdTemplateCompiled = template.Must(template.New("cmd").Funcs(helpers).Parse(cmdTemplate))
 }

--- a/internal/gencli/flag.go
+++ b/internal/gencli/flag.go
@@ -42,7 +42,10 @@ type Flag struct {
 	IsOneOfField  bool
 	IsNested      bool
 	Optional      bool
-	MsgDesc       *desc.MessageDescriptor
+
+	// Accessor is only set after calling GenFlag
+	Accessor string
+	MsgDesc  *desc.MessageDescriptor
 }
 
 // GenFlag generates the pflag API call for this flag
@@ -92,6 +95,8 @@ func (f *Flag) GenFlag() string {
 	if len(f.OneOfs) > 0 || f.IsEnum() {
 		name = f.VarName
 	}
+
+	f.Accessor = name
 
 	if f.Optional && !f.IsEnum() {
 		name = f.OptionalVarName()

--- a/internal/gencli/flag.go
+++ b/internal/gencli/flag.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
+	"github.com/jhump/protoreflect/desc"
 )
 
 // Flag is used to represent fields as flags
@@ -41,9 +42,7 @@ type Flag struct {
 	IsOneOfField  bool
 	IsNested      bool
 	Optional      bool
-
-	// Accessor is only set after calling GenFlag
-	Accessor string
+	MsgDesc       *desc.MessageDescriptor
 }
 
 // GenFlag generates the pflag API call for this flag
@@ -93,8 +92,6 @@ func (f *Flag) GenFlag() string {
 	if len(f.OneOfs) > 0 || f.IsEnum() {
 		name = f.VarName
 	}
-
-	f.Accessor = name
 
 	if f.Optional && !f.IsEnum() {
 		name = f.OptionalVarName()

--- a/internal/gencli/gencli.go
+++ b/internal/gencli/gencli.go
@@ -381,6 +381,7 @@ func (g *gcli) buildOneOfFlag(cmd *Command, msg *desc.MessageDescriptor, field *
 			return
 		}
 		flag.MessageImport = *pkg
+		flag.MsgDesc = nested
 
 		cmd.NestedMessages = append(cmd.NestedMessages, &NestedMessage{
 			FieldName: flag.VarName + "." + flag.FieldName,

--- a/internal/gencli/util.go
+++ b/internal/gencli/util.go
@@ -16,6 +16,7 @@ package gencli
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
@@ -99,10 +100,11 @@ func dotToCamel(name string) (s string) {
 func oneofTypeName(field, inputMsgType string, flag *Flag) string {
 	upperField := title(field)
 	if flag.IsNested {
-		tname := fmt.Sprintf("%s.%s_%s", flag.MessageImport.Name, flag.Message, title(field))
+		tname := fmt.Sprintf("%s.%s_%s", flag.MessageImport.Name, flag.Message, upperField)
 		
 		if flag.IsMessage() {
-			tnested := fmt.Sprintf("%s.%s_%s", flag.MessageImport.Name, flag.Message, upperField)
+			selector := flag.OneOfSelector[strings.LastIndex(flag.OneOfSelector, ".")+1:]
+			tnested := fmt.Sprintf("%s.%s_%s", flag.MessageImport.Name, title(selector), upperField)
 			if tname == tnested {
 				tname += "_"
 			}

--- a/internal/gencli/util.go
+++ b/internal/gencli/util.go
@@ -16,7 +16,6 @@ package gencli
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"

--- a/internal/gencli/util.go
+++ b/internal/gencli/util.go
@@ -15,6 +15,7 @@
 package gencli
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
@@ -93,4 +94,22 @@ func dotToCamel(name string) (s string) {
 	}
 
 	return
+}
+
+func oneofTypeName(field, inputMsgType string, flag *Flag) string {
+	upperField := title(field)
+	if flag.IsNested {
+		tname := fmt.Sprintf("%s.%s_%s", flag.MessageImport.Name, flag.Message, title(field))
+		
+		if flag.IsMessage() {
+			tnested := fmt.Sprintf("%s.%s_%s", flag.MessageImport.Name, flag.Message, upperField)
+			if tname == tnested {
+				tname += "_"
+			}
+		}
+
+		return tname
+	}
+	
+	return fmt.Sprintf("%s_%s", inputMsgType, upperField)
 }


### PR DESCRIPTION
Addresses part of #368 

Tested with showcase and the afflicted secretmanager api