### PR TITLE
chore: renovatebot rebase when behind

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,9 @@
     ],
     "postUpdateOptions": ["gomodTidy"]
   },
-  "assignees": [
+  "reviewers": [
     "noahdietz"
-  ]
+  ],
+  "rebaseWhen": "behind-base-branch",
+  "labels": ["automerge"]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -15,5 +15,11 @@
     "noahdietz"
   ],
   "rebaseWhen": "behind-base-branch",
-  "labels": ["automerge"]
+  "labels": ["automerge"],
+  "packageRules": [
+    {
+      "packageNames": ["google.golang.org/genproto"],
+      "extends": ["schedule:on friday after 12pm"]
+    }
+  ]
 }


### PR DESCRIPTION
Instructs renovatebot to rebase when the branch is behind
Changes `assignees` to `reviewers`
Adds label `automerge` on PR creation