### PR TITLE
gencli: proto3_optional support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ image:
 
 test-go-cli:
 	go test github.com/googleapis/gapic-generator-go/internal/gencli
+	./cmd/protoc-gen-go_cli/test.sh
 
 test-gapic:
 	go test github.com/googleapis/gapic-generator-go/internal/gengapic

--- a/cmd/protoc-gen-go_cli/main.go
+++ b/cmd/protoc-gen-go_cli/main.go
@@ -38,6 +38,7 @@ func main() {
 	if err != nil {
 		genResp.Error = proto.String(err.Error())
 	}
+	genResp.SupportedFeatures = proto.Uint64(uint64(plugin.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL))
 
 	outBytes, err := proto.Marshal(genResp)
 	if err != nil {

--- a/internal/gencli/cmd_file_test.go
+++ b/internal/gencli/cmd_file_test.go
@@ -58,6 +58,7 @@ func TestCommandFile(t *testing.T) {
 				VarName:   "CreateTodoInput",
 				Type:      descriptor.FieldDescriptorProto_TYPE_BOOL,
 				Usage:     "task completion status",
+				Optional:  true,
 			},
 			&Flag{
 				Name:          "priority",
@@ -67,9 +68,11 @@ func TestCommandFile(t *testing.T) {
 				Message:       "Priority",
 				MessageImport: pbinfo.ImportSpec{Name: "todopb"},
 				VarName:       "CreateTodoInputPriority",
+				Optional:      true,
 			},
 		},
-		HasEnums: true,
+		HasEnums:    true,
+		HasOptional: true,
 	}
 
 	// LRO

--- a/internal/gencli/testdata/create-todo.want
+++ b/internal/gencli/testdata/create-todo.want
@@ -12,6 +12,8 @@ var CreateTodoInput todopb.Todo
 
 var CreateTodoFromFile string
 
+var createTodoInputDone bool
+
 var CreateTodoInputPriority string
 
 func init() {
@@ -19,7 +21,7 @@ func init() {
 
 	CreateTodoCmd.Flags().StringVar(&CreateTodoInput.Task, "task", "", "task to complete")
 
-	CreateTodoCmd.Flags().BoolVar(&CreateTodoInput.Done, "done", false, "task completion status")
+	CreateTodoCmd.Flags().BoolVar(&createTodoInputDone, "done", false, "task completion status")
 
 	CreateTodoCmd.Flags().StringVar(&CreateTodoInputPriority, "priority", "", "importance of the task")
 
@@ -57,7 +59,14 @@ var CreateTodoCmd = &cobra.Command{
 
 		} else {
 
-			CreateTodoInput.Priority = todopb.Priority(todopb.Priority_value[strings.ToUpper(CreateTodoInputPriority)])
+			if cmd.Flags().Changed("priority") {
+				e := todopb.Priority(todopb.Priority_value[strings.ToUpper(CreateTodoInputPriority)])
+				CreateTodoInput.Priority = &e
+			}
+
+			if cmd.Flags().Changed("done") {
+				CreateTodoInput.Done = &createTodoInputDone
+			}
 
 		}
 


### PR DESCRIPTION
Adds support for proto3_optional to the `go_cli` plugin. Fixes #378 

* Primitives and enums are supported, while optional messages aren't generated differently by protoc-gen-go.
* Adds a diff test for each case
* Simplifies `go_cli` integration testing script - strips it down to just a gapic-showcase gen/build test (Fixes #345)
* replaces `go_cli` testing script in `test-go-cli` Makefile target