### PR TITLE
bazel: update rules_go v0.23.0 and gazelle v0.21.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,23 +18,20 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-# Depend on this rules_go commit because it contains unreleased patches that
-# allow us to override com_github_golang_protobuf to v1.4.1.
-#
-# TODO(ndietz) replace this with the next version (v0.23.0) of rules_go
-# that contains github.com/golang/protobuf v1.4.1 and google.golang.org/protobuf
-# v1.22.0: https://github.com/bazelbuild/rules_go/issues/2471
 http_archive(
     name = "io_bazel_rules_go",
-    # master as of 5pm PST on 5/04/2020
     urls = [
-        "https://github.com/bazelbuild/rules_go/archive/695da5906684ab96e558c3159f7d88a20a6a1703.zip",
+        "https://github.com/bazelbuild/rules_go/archive/v0.23.0.zip",
     ],
-    strip_prefix = "rules_go-695da5906684ab96e558c3159f7d88a20a6a1703",
-    sha256 = "b5f8747b60f5b3d02125b5c9a69ed5ad59a46fce637b3073ff0576f152e2354c",
+    strip_prefix = "rules_go-0.23.0",
+    sha256 = "4707e6ba7c01fcfc4f0d340d123bc16e43c2b8ea3f307663d95712b36d2a0e88",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
+
+go_rules_dependencies()
+
+go_register_toolchains()
 
 http_archive(
     name = "bazel_gazelle",
@@ -46,40 +43,7 @@ http_archive(
 )
 
 # gazelle:repo bazel_gazelle
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
-
-# These golang protobuf dependencies are added here to override those provided
-# by rules_go. This is done to capture the proto3_optional changes necessary
-# to build the go_gapic plugin.
-#
-# TODO(ndietz) remove these overrides once rules_go v0.23.0 is released
-# https://github.com/bazelbuild/rules_go/issues/2471
-go_repository(
-    name = "org_golang_google_protobuf",
-    build_file_proto_mode = "disable_global",
-    importpath = "google.golang.org/protobuf",
-    sum = "h1:cJv5/xdbk1NnMPR1VP9+HU6gupuG9MLBoH1r6RHZ2MY=",
-    version = "v1.22.0",
-)
-
-go_repository(
-    name = "com_github_golang_protobuf",
-    build_file_proto_mode = "disable_global",
-    importpath = "github.com/golang/protobuf",
-    patch_args = ["-p1"],
-    patches = ["@io_bazel_rules_go//third_party:com_github_golang_protobuf-extras.patch"],
-    sum = "h1:ZFgWrT+bLgsYPirOnRfKLYJLvssAegOj/hgyMFdJZe0=",
-    version = "v1.4.1",
-)
-
-# These repository macros are invoked after the golang protobuf dependencies
-# so as to override them with the desired version for this repo.
-#
-# TODO(ndietz) move these back to where they were next to their corresponding
-# dependency
-go_rules_dependencies()
-
-go_register_toolchains()
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -167,8 +167,8 @@ def com_googleapis_gapic_generator_go_repositories():
         go_repository,
         name = "com_google_cloud_go",
         importpath = "cloud.google.com/go",
-        sum = "h1:e0WKqKTd5BnrG8aKH3J3h+QvEIQtSUcf2n5UZ5ZgLtQ=",
-        version = "v0.26.0",
+        sum = "h1:EpMNVUorLiZIELdMZbCYX/ByTFCdoYopYAGxaGVz9ms=",
+        version = "v0.57.0",
     )
     _maybe(
         go_repository,


### PR DESCRIPTION
Update rules_go v0.23.0 and gazelle v0.21.0
Update indirect dependency on com_google_cloud_go to latest release v0.57.0 (in relation to #387)