### PR TITLE
chore: update CI to protoc stable v3.12.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,13 +50,11 @@ jobs:
             go install github.com/googleapis/gapic-config-validator/cmd/gapic-error-conformance
             gapic-error-conformance -plugin=protoc-gen-go_gapic -plugin_opts="go-gapic-package=foo.com/bar/v1;bar"
       # Install protoc, showcase.bash needs it
-      #
-      # TODO(ndietz) change to depend on stable 3.12.0 once released.
       - run:
           name: Run Showcase
           command: |
             mkdir protobuf
-            curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0-rc1/protoc-3.12.0-rc-1-linux-x86_64.zip > protobuf/protoc.zip
+            curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-x86_64.zip > protobuf/protoc.zip
             unzip -d protobuf protobuf/protoc.zip
             export PATH=$PATH:$(pwd)/protobuf/bin            
             make test

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,11 +2,6 @@ workspace(name = "com_googleapis_gapic_generator_go")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-# We depend on a release candidate because it contains the proto3_optional
-# feature.
-#
-# TODO(ndietz) Replace this with stable 3.12.0 version when it is released so as
-# to not depend on a release candidate.
 http_archive(
     name = "com_google_protobuf",
     strip_prefix = "protobuf-3.12.0",


### PR DESCRIPTION
* Updates CI `protoc` version to stable `v3.12.0`, removing TODO for this
* Removes TODO comment to update `WORKSPACE` version of `protoc` to stable `v3.12.0` (update actually done by renovatebot previously)