### PR TITLE
 gencli: support map<string,string> fields

### DIFF
--- a/internal/gencli/cmd_file.go
+++ b/internal/gencli/cmd_file.go
@@ -177,7 +177,7 @@ var {{$methodCmdVar}} = &cobra.Command{
 		{{ end }}
 		{{ end }}
 		{{ range .Flags }}
-		{{ if and ( .IsMessage ) .Repeated }}
+		{{ if and ( .IsMessage ) .Repeated (not .IsMap)}}
 		// unmarshal JSON strings into slice of structs
 		for _, item := range {{ .VarName }} {
 			tmp := {{ .MessageImport.Name }}.{{ .Message }}{}
@@ -187,6 +187,17 @@ var {{$methodCmdVar}} = &cobra.Command{
 			}
 
 			{{ .SliceAccessor }} = append({{ .SliceAccessor }}, &tmp)
+		}
+		{{ end }}
+		{{ if .IsMap }}
+		for _, item := range {{ .VarName }} {
+			split := strings.Split(item, "=")
+			if len(split) < 2 {
+				err = fmt.Errorf("Invalid map item: %q", item)
+				return
+			}
+
+			{{ .SliceAccessor }}[split[0]] = split[1]
 		}
 		{{ end }}
 		{{ end }}

--- a/internal/gencli/flag.go
+++ b/internal/gencli/flag.go
@@ -41,6 +41,7 @@ type Flag struct {
 	SliceAccessor string
 	IsOneOfField  bool
 	IsNested      bool
+	IsMap         bool
 	Optional      bool
 
 	// Accessor is only set after calling GenFlag

--- a/internal/gencli/gencli.go
+++ b/internal/gencli/gencli.go
@@ -461,6 +461,7 @@ func (g *gcli) buildFieldFlags(cmd *Command, msg *desc.MessageDescriptor, parent
 			Name:         prefix + field.GetName(),
 			FieldName:    title(prefix + field.GetName()),
 			Type:         field.GetType(),
+			IsMap:        field.IsMap(),
 			Repeated:     field.GetLabel() == descriptor.FieldDescriptorProto_LABEL_REPEATED,
 			IsOneOfField: isOneOf,
 			IsNested:     isInNested,
@@ -485,6 +486,13 @@ func (g *gcli) buildFieldFlags(cmd *Command, msg *desc.MessageDescriptor, parent
 
 		cmd.HasOptional = cmd.HasOptional || flag.Optional
 		cmd.HasEnums = cmd.HasEnums || flag.IsEnum()
+
+		if flag.IsMap {
+			// add "strings" import for key=value string split
+			putImport(cmd.Imports, &pbinfo.ImportSpec{
+				Path: "strings",
+			})
+		}
 
 		// build the variable name this field belongs to
 		n := title(flag.Name)

--- a/internal/gencli/gencli.go
+++ b/internal/gencli/gencli.go
@@ -492,6 +492,7 @@ func (g *gcli) buildFieldFlags(cmd *Command, msg *desc.MessageDescriptor, parent
 			putImport(cmd.Imports, &pbinfo.ImportSpec{
 				Path: "strings",
 			})
+			flag.Usage = "key=value pairs. " + flag.Usage
 		}
 
 		// build the variable name this field belongs to


### PR DESCRIPTION
Support `map<string, string>` fields because it is often used for `labels` in `googleapis`. Explicitly choosing not to support other `map` types for now, until a need presents itself. 

This is kind of a workaround in that it piggy-backs on the `repeated Message` code, while suppressing the unmarshal part in place of a `key=value` string split and assignment. If other types are to be added, this will need to be redone.

Fixes #368 