### PR TITLE
bazel: fix go_library importpath & lro shading

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -165,13 +165,6 @@ def com_googleapis_gapic_generator_go_repositories():
     )
     _maybe(
         go_repository,
-        name = "com_google_cloud_go",
-        importpath = "cloud.google.com/go",
-        sum = "h1:EpMNVUorLiZIELdMZbCYX/ByTFCdoYopYAGxaGVz9ms=",
-        version = "v0.57.0",
-    )
-    _maybe(
-        go_repository,
         name = "in_gopkg_check_v1",
         importpath = "gopkg.in/check.v1",
         sum = "h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=",

--- a/rules_go_gapic/go_gapic.bzl
+++ b/rules_go_gapic/go_gapic.bzl
@@ -155,11 +155,15 @@ def go_gapic_library(
     extension = ".go",
   )
 
+  # Strip the trailing package alias so that this
+  # generated library can shade com_google_cloud_go
+  # go_library targets.
+  imp = importpath[:importpath.index(";")]
   go_library(
     name = name,
     srcs = [":%s" % main_dir],
     deps = actual_deps,
-    importpath = importpath,
+    importpath = imp,
   )
 
   test_file = ":%s-test.srcjar" % srcjar_name

--- a/rules_go_gapic/go_gapic_repositories.bzl
+++ b/rules_go_gapic/go_gapic_repositories.bzl
@@ -64,6 +64,18 @@ def go_gapic_repositories():
         sum = "h1:9dMLqhaibYONnDRcnHdUs9P8Mw64jLlZTYlDe3leBtQ=",
         version = "v1.0.3",
     )
+    # This is a pseudo-cycle, because Go GAPIC's depend on
+    # common packages in the same mono-repo, particularly the
+    # longrunning package.
+    _maybe(
+        go_repository,
+        name = "com_google_cloud_go",
+        importpath = "cloud.google.com/go",
+        sum = "h1:EpMNVUorLiZIELdMZbCYX/ByTFCdoYopYAGxaGVz9ms=",
+        version = "v0.57.0",
+        # This is part of a fix for https://github.com/googleapis/gapic-generator-go/issues/387.
+        build_extra_args = ["-exclude=longrunning/autogen/info.go"],
+    )
 
 def _maybe(repo_rule, name, strip_repo_prefix = "", **kwargs):
     if not name.startswith(strip_repo_prefix):


### PR DESCRIPTION
`go_gapic_library` compiles the generated package via `go_library` and uses a trimmed `importpath` that excludes the trailing package alias `;alias` component. This allows `go_gapic_library` targets to shade  dependencies on `com_google_cloud_go`. In particular, this allows `//google/longrunning:go_gapic` to overwrite the `@com_google_cloud_go//longrunning/autogen` dependency used by many `go_gapic_library` targets. To make this work, we need to exclude a manual file in the `longrunning/autogen` package. The code in the manual file is not used in any of the GAPIC's, so it is not an issue during compilation. 

This also adds `com_google_cloud_go` to the `go_gapic_repositories.bzl` macro instead of having it pulled in by a weak dependency in the `gapic-generator-go` `repositories.bzl`.

This was tested with all `go_gapic_library` targets in `googleapis`.

Fixes #387 