### PR TITLE
gapic: support proto3_optional in paging helper

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -672,3 +672,15 @@ func parseRequestHeaders(m *descriptor.MethodDescriptorProto) ([][]string, error
 
 	return matches, nil
 }
+
+// isOptional returns true if the named Field in the given Message
+// is proto3_optional.
+func isOptional(m *descriptor.DescriptorProto, n string) bool {
+	for _, f := range m.GetField() {
+		if f.GetName() == n {
+			return f.GetProto3Optional()
+		}
+	}
+
+	return false
+}

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -151,6 +151,23 @@ func TestGenMethod(t *testing.T) {
 			},
 		},
 	}
+	pageInputTypeOptional := &descriptor.DescriptorProto{
+		Name: proto.String("PageInputTypeOptional"),
+		Field: []*descriptor.FieldDescriptorProto{
+			{
+				Name:           proto.String("page_size"),
+				Type:           typep(descriptor.FieldDescriptorProto_TYPE_INT32),
+				Label:          labelp(descriptor.FieldDescriptorProto_LABEL_OPTIONAL),
+				Proto3Optional: proto.Bool(true),
+			},
+			{
+				Name:           proto.String("page_token"),
+				Type:           typep(descriptor.FieldDescriptorProto_TYPE_STRING),
+				Label:          labelp(descriptor.FieldDescriptorProto_LABEL_OPTIONAL),
+				Proto3Optional: proto.Bool(true),
+			},
+		},
+	}
 	paginatedField := &descriptor.FieldDescriptorProto{
 		Name:  proto.String("items"),
 		Type:  typep(descriptor.FieldDescriptorProto_TYPE_STRING),
@@ -201,7 +218,7 @@ func TestGenMethod(t *testing.T) {
 
 	commonTypes(&g)
 	for _, typ := range []*descriptor.DescriptorProto{
-		inputType, outputType, pageInputType, pageOutputType,
+		inputType, outputType, pageInputType, pageInputTypeOptional, pageOutputType,
 	} {
 		g.descInfo.Type[".my.pkg."+*typ.Name] = typ
 		g.descInfo.ParentFile[typ] = file
@@ -227,6 +244,12 @@ func TestGenMethod(t *testing.T) {
 		{
 			Name:       proto.String("GetManyThings"),
 			InputType:  proto.String(".my.pkg.PageInputType"),
+			OutputType: proto.String(".my.pkg.PageOutputType"),
+			Options:    opts,
+		},
+		{
+			Name:       proto.String("GetManyThingsOptional"),
+			InputType:  proto.String(".my.pkg.PageInputTypeOptional"),
 			OutputType: proto.String(".my.pkg.PageOutputType"),
 			Options:    opts,
 		},

--- a/internal/gengapic/testdata/method_GetManyThingsOptional.want
+++ b/internal/gengapic/testdata/method_GetManyThingsOptional.want
@@ -1,20 +1,20 @@
-func (c *FooClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
+func (c *FooClient) GetManyThingsOptional(ctx context.Context, req *mypackagepb.PageInputTypeOptional, opts ...gax.CallOption) *StringIterator {
 	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(req.GetBiz())))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
-	opts = append(c.CallOptions.GetManyThings[0:len(c.CallOptions.GetManyThings):len(c.CallOptions.GetManyThings)], opts...)
+	opts = append(c.CallOptions.GetManyThingsOptional[0:len(c.CallOptions.GetManyThingsOptional):len(c.CallOptions.GetManyThingsOptional)], opts...)
 	it := &StringIterator{}
-	req = proto.Clone(req).(*mypackagepb.PageInputType)
+	req = proto.Clone(req).(*mypackagepb.PageInputTypeOptional)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
 		var resp *mypackagepb.PageOutputType
-		req.PageToken = pageToken
+		req.PageToken = proto.String(pageToken)
 		if pageSize > math.MaxInt32 {
-			req.PageSize = math.MaxInt32
+			req.PageSize = proto.Int32(math.MaxInt32)
 		} else {
-			req.PageSize = int32(pageSize)
+			req.PageSize = proto.Int32(int32(pageSize))
 		}
 		err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 			var err error
-			resp, err = c.fooClient.GetManyThings(ctx, req, settings.GRPC...)
+			resp, err = c.fooClient.GetManyThingsOptional(ctx, req, settings.GRPC...)
 			return err
 		}, opts...)
 		if err != nil {


### PR DESCRIPTION
It is not recommended, but possible that an API produce will use the `proto3_optional` label on `page_size` or `page_token`. The generated Iterator implementation referenced these fields on the request message directly in spots. If `proto3_optional`, these primitive types become pointers and the generated code would break.

This updates that code to be aware of `proto3_optional` in assignments (i.e. use the `proto.{Type}` wrapper) and it changes direct accesses to getters (i.e. `req.GetPageSize()` rather than `req.PageSize`).

Note: the Iterator design does not account for `proto3_optional` `page_size` and `page_token` fields and by switching to getters (which return the type's default value i.e. `0` for `int32` when unset), the Iterator effectively renders the effect of `proto3_optional` useless on these fields by always sending the type's default in the outgoing request. This seems OK because https://aip.dev/158 says that the server must handle `0` for `page_size` the same as if it is unset. Should that guidance change, then we'd need to update Iterator to support `proto3_optional`.

Fixes #384 