### PR TITLE
gapic: fix godoc link in pkg docs

### DIFF
--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -72,7 +72,7 @@ func (g *generator) genDocFile(pkgPath, pkgName string, year int, scopes []strin
 	p("// To close the open connection, use the Close() method.")
 	p("//")
 	p("// For information about setting deadlines, reusing contexts, and more")
-	p("// please visit godoc.org/cloud.google.com/go.")
+	p("// please visit pkg.go.dev/cloud.google.com/go.")
 	p("package %s // import %q", pkgName, pkgPath)
 	p("")
 

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -29,7 +29,7 @@
 // To close the open connection, use the Close() method.
 //
 // For information about setting deadlines, reusing contexts, and more
-// please visit godoc.org/cloud.google.com/go.
+// please visit pkg.go.dev/cloud.google.com/go.
 package awesome // import "path/to/awesome"
 
 import (

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -31,7 +31,7 @@
 // To close the open connection, use the Close() method.
 //
 // For information about setting deadlines, reusing contexts, and more
-// please visit godoc.org/cloud.google.com/go.
+// please visit pkg.go.dev/cloud.google.com/go.
 package awesome // import "path/to/awesome"
 
 import (

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -31,7 +31,7 @@
 // To close the open connection, use the Close() method.
 //
 // For information about setting deadlines, reusing contexts, and more
-// please visit godoc.org/cloud.google.com/go.
+// please visit pkg.go.dev/cloud.google.com/go.
 package awesome // import "path/to/awesome"
 
 import (


### PR DESCRIPTION
Updates the generated `doc.go` package documentation to reference pkg.go.dev/cloud.google.com/go rather than godoc.org.