### PR TITLE
fix: include time import with deadline

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -42,11 +42,11 @@ import (
 const (
 	emptyValue = "google.protobuf.Empty"
 	// protoc puts a dot in front of name, signaling that the name is fully qualified.
-	emptyType  = "." + emptyValue
-	lroType    = ".google.longrunning.Operation"
-	paramError = "need parameter in format: go-gapic-package=client/import/path;packageName"
-	alpha      = "alpha"
-	beta       = "beta"
+	emptyType           = "." + emptyValue
+	lroType             = ".google.longrunning.Operation"
+	paramError          = "need parameter in format: go-gapic-package=client/import/path;packageName"
+	alpha               = "alpha"
+	beta                = "beta"
 	disableDeadlinesVar = "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_DEFAULT_DEADLINE"
 )
 
@@ -501,6 +501,8 @@ func (g *generator) deadline(s, m string) {
 	g.printf("  defer cancel()")
 	g.printf("  ctx = cctx")
 	g.printf("}")
+
+	g.imports[pbinfo.ImportSpec{Path: "time"}] = true
 }
 
 func (g *generator) insertMetadata(m *descriptor.MethodDescriptorProto) error {


### PR DESCRIPTION
This fixes a bug where the `time` stdlib is not being imported but necessary for the default deadline logic. It was not caught before because `time` was imported by other parts of the client (retry, lro, etc.).