### PR TITLE
chore: set renovatebot timezone to PST

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
     ],
     "postUpdateOptions": ["gomodTidy"]
   },
-  "assignees": [
+  "reviewers": [
     "noahdietz"
   ],
   "rebaseWhen": "behind-base-branch",
@@ -21,5 +21,6 @@
       "packageNames": ["google.golang.org/genproto"],
       "schedule": "after 12pm on monday"
     }
-  ]
+  ],
+  "timezone": "America/Los_Angeles"
 }


### PR DESCRIPTION
Change renovatebot timezone to Pacific and `assignees` to `reviewers` for the generated PR.