### PR TITLE
gapic: add module generator option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ The configuration supported by the plugin option includes:
     **Note:** Idiomatically the name is last element of the path but it need not be.
     For instance, the last element of the path might be the package's version, and the package would benefit
     from a more descriptive name.
+
+  * `module`: prefix to be stripped from the `go-gapic-package` used in the generated filenames.
+     * _Note: This option is not supported from the Bazel interface._
   
   * `grpc-service-config`: the path to a gRPC ServiceConfig JSON file.
     * This is used for client-side retry configuration in accordance with [AIP-4221](http://aip.dev/4221)

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -73,6 +73,10 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 		}
 
 		key, val := s[:e], s[e+1:]
+		if val == "" {
+			return &g.resp, errors.E(nil, "invalid plugin option value, missing value in key=value: %s", s)
+		}
+
 		switch key {
 		case "go-gapic-package":
 			p := strings.IndexByte(s, ';')


### PR DESCRIPTION
Adds a generator option to strip the given module prefix from the `go-gapic-package` value when used in the generated filenames. Similar to the [protoc-gen-go option](https://go-review.googlesource.com/c/protobuf/+/219298/). So, if the plugin output directory is the module root, the generated code will directly overwrite the existing files.

Fixes #447 