### PR TITLE
bazel: fix empty release-level param

### DIFF
--- a/rules_go_gapic/go_gapic.bzl
+++ b/rules_go_gapic/go_gapic.bzl
@@ -102,8 +102,10 @@ def go_gapic_library(
 
   plugin_args = [
     "go-gapic-package={}".format(importpath),
-    "release-level={}".format(release_level),
   ]
+
+  if release_level:
+    plugin_args.append("release-level={}".format(release_level))
 
   if sample_only:
     plugin_args.append("sample-only")


### PR DESCRIPTION
Recent changes to plugin param parsing made sending an empty `release-level` param an error. The bazel macro defaults the `release_level` attribute to `""` and was supplying `"release-level="` if it went unset, which would produce an error even though this attribute/param is optional. There is no bug in googleapis today as the param parsing changes haven't been released, but updating this generator in the WORKSPACE would've caused the error to happen.

Tested this fix against all of googleapis.