### PR TITLE
bazel: use WKT for extra gapic deps

### DIFF
--- a/rules_go_gapic/go_gapic.bzl
+++ b/rules_go_gapic/go_gapic.bzl
@@ -139,13 +139,11 @@ def go_gapic_library(
     "@org_golang_google_grpc//:go_default_library",
     "@org_golang_google_grpc//codes:go_default_library",
     "@org_golang_google_grpc//metadata:go_default_library",
-    "@com_github_golang_protobuf//proto:go_default_library",
-    "@com_github_golang_protobuf//ptypes:go_default_library",
-    "@com_github_golang_protobuf//ptypes/empty:go_default_library",
-    "@com_github_golang_protobuf//ptypes/timestamp:go_default_library",
-    "@org_golang_google_genproto//protobuf/field_mask:go_default_library",
-    "@com_google_googleapis//google/rpc:status_go_proto",
     "@org_golang_google_grpc//status:go_default_library",
+    "@com_github_golang_protobuf//proto:go_default_library",
+    "@com_github_golang_protobuf//ptypes:go_default_library_gen",
+    "@io_bazel_rules_go//proto/wkt:empty_go_proto",
+    "@io_bazel_rules_go//proto/wkt:field_mask_go_proto",
   ]
 
   main_file = ":%s" % srcjar_name + output_suffix


### PR DESCRIPTION
Use the rules_go WKT for some common types instead of directly depending on the Go module that owns them for deps included by the generator on behalf of the generated client.

Cleans up some import conflict warnings.