### PR TITLE
gapic: use DefaultEndpoint and DefaultMTLSEndpoint for default options

### DIFF
--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -109,7 +109,7 @@ func TestClientOpt(t *testing.T) {
 		},
 		Options: &descriptor.ServiceOptions{},
 	}
-	if err := proto.SetExtension(serv.Options, annotations.E_DefaultHost, proto.String("foo.bar.com")); err != nil {
+	if err := proto.SetExtension(serv.Options, annotations.E_DefaultHost, proto.String("foo.googleapis.com")); err != nil {
 		t.Fatal(err)
 	}
 
@@ -143,7 +143,7 @@ func TestClientOpt(t *testing.T) {
 		},
 		Options: &descriptor.ServiceOptions{},
 	}
-	if err := proto.SetExtension(servHostPort.Options, annotations.E_DefaultHost, proto.String("foo.bar.com:1234")); err != nil {
+	if err := proto.SetExtension(servHostPort.Options, annotations.E_DefaultHost, proto.String("foo.googleapis.com:1234")); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/gengapic/testdata/empty_opt.want
+++ b/internal/gengapic/testdata/empty_opt.want
@@ -7,7 +7,8 @@ type CallOptions struct {
 
 func defaultClientOptions() []option.ClientOption {
 	return []option.ClientOption{
-		option.WithEndpoint("foo.bar.com:443"),
+		internaloption.WithDefaultEndpoint("foo.googleapis.com:443"),
+		internaloption.WithDefaultMTLSEndpoint("foo.mtls.googleapis.com:443"),
 		option.WithGRPCDialOption(grpc.WithDisableServiceConfig()),
 		option.WithScopes(DefaultAuthScopes()...),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(

--- a/internal/gengapic/testdata/foo_opt.want
+++ b/internal/gengapic/testdata/foo_opt.want
@@ -7,7 +7,8 @@ type FooCallOptions struct {
 
 func defaultFooClientOptions() []option.ClientOption {
 	return []option.ClientOption{
-		option.WithEndpoint("foo.bar.com:443"),
+		internaloption.WithDefaultEndpoint("foo.googleapis.com:443"),
+		internaloption.WithDefaultMTLSEndpoint("foo.mtls.googleapis.com:443"),
 		option.WithGRPCDialOption(grpc.WithDisableServiceConfig()),
 		option.WithScopes(DefaultAuthScopes()...),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(

--- a/internal/gengapic/testdata/host_port_opt.want
+++ b/internal/gengapic/testdata/host_port_opt.want
@@ -5,7 +5,8 @@ type BarCallOptions struct {
 
 func defaultBarClientOptions() []option.ClientOption {
 	return []option.ClientOption{
-		option.WithEndpoint("foo.bar.com:1234"),
+		internaloption.WithDefaultEndpoint("foo.googleapis.com:1234"),
+		internaloption.WithDefaultMTLSEndpoint("foo.mtls.googleapis.com:1234"),
 		option.WithGRPCDialOption(grpc.WithDisableServiceConfig()),
 		option.WithScopes(DefaultAuthScopes()...),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(


### PR DESCRIPTION
The option "WithEndpoint" is intended for user override only, and specifying it will interfere with mTLS endpoint selection. See details regarding mTLS at https://google.aip.dev/auth/4114