### PR TITLE
bazel: update rules_go with version label

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,10 +15,10 @@ protobuf_deps()
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "d1ffd055969c8f8d431e2d439813e42326961d0942bdf734d2c95dc30c369566",
+    sha256 = "7904dbecbaffd068651916dce77ff3437679f9d20e1a7956bff43826e7645fcc",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.24.5/rules_go-v0.24.5.tar.gz",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.25.1/rules_go-v0.25.1.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.25.1/rules_go-v0.25.1.tar.gz",
     ],
 )
 
@@ -26,7 +26,9 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains()
+go_register_toolchains(
+    version = "1.13.15",
+)
 
 http_archive(
     name = "bazel_gazelle",


### PR DESCRIPTION
Updates the `rules_go` bazel dep to `v0.25.1` and adds the newly required `version` label for the Go SDK version used in `go_register_toolchains`. I picked Go 1.13.15 (the latest Go 1.13.x version to date) because the `go.mod` names 1.13 as the desired version.

This should allow us to merge #480 as there was a fix for Well-known types (WKT) in rules_go v0.25.x.