### PR TITLE
fix: relax paging missing repeated

### DIFF
--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -141,12 +141,13 @@ func (g *generator) pagingField(m *descriptor.MethodDescriptorProto) (*descripto
 			elemFields = append(elemFields, f)
 		}
 	}
-	if !hasSize || !hasToken || !hasNextToken {
+
+	// If any of the required pagination fields are missing or if the response
+	// has no repeated fields, it is not a fully conforming paginated method.
+	if !hasSize || !hasToken || !hasNextToken || len(elemFields) == 0 {
 		return nil, nil
 	}
-	if len(elemFields) == 0 {
-		return nil, fmt.Errorf("%s looks like paging method, but can't find repeated field in %s", *m.Name, outType.GetName())
-	}
+
 	if len(elemFields) > 1 {
 		// ensure that the first repeated field visited has the lowest field number
 		// according to https://aip.dev/4233, and use that one.

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -76,8 +76,8 @@ func TestPagingField(t *testing.T) {
 				resField,
 			},
 		},
-		"NoPageOut": &descriptor.DescriptorProto{
-			Name: proto.String("NoPageOut"),
+		"NoRepeatedOut": &descriptor.DescriptorProto{
+			Name: proto.String("NoRepeatedOut"),
 			Field: []*descriptor.FieldDescriptorProto{
 				{
 					Name:  proto.String("next_page_token"),
@@ -126,7 +126,7 @@ func TestPagingField(t *testing.T) {
 		},
 		{
 			in:  "PageIn",
-			out: "NoPageOut",
+			out: "NoRepeatedOut",
 		},
 		{
 			in:  "PageIn",

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -76,8 +76,8 @@ func TestPagingField(t *testing.T) {
 				resField,
 			},
 		},
-		"BadPageOut1": &descriptor.DescriptorProto{
-			Name: proto.String("BadPageOut1"),
+		"NoPageOut": &descriptor.DescriptorProto{
+			Name: proto.String("NoPageOut"),
 			Field: []*descriptor.FieldDescriptorProto{
 				{
 					Name:  proto.String("next_page_token"),
@@ -87,8 +87,8 @@ func TestPagingField(t *testing.T) {
 				// No repeated field
 			},
 		},
-		"BadPageOut2": &descriptor.DescriptorProto{
-			Name: proto.String("BadPageOut2"),
+		"BadPageOut": &descriptor.DescriptorProto{
+			Name: proto.String("BadPageOut"),
 			Field: []*descriptor.FieldDescriptorProto{
 				{
 					Name:  proto.String("next_page_token"),
@@ -126,12 +126,11 @@ func TestPagingField(t *testing.T) {
 		},
 		{
 			in:  "PageIn",
-			out: "BadPageOut1",
-			err: true,
+			out: "NoPageOut",
 		},
 		{
 			in:  "PageIn",
-			out: "BadPageOut2",
+			out: "BadPageOut",
 			err: true,
 		},
 	} {

--- a/internal/gensample/paging.go
+++ b/internal/gensample/paging.go
@@ -67,6 +67,8 @@ func pagingField(info pbinfo.Info, m *descriptor.MethodDescriptorProto) (*descri
 	if !hasSize || !hasToken || !hasNextToken {
 		return nil, nil
 	}
+	// TODO(noahdietz) relax this requirement and treat the method as non-paging.
+	// See https://github.com/googleapis/gapic-generator-go/issues/493.
 	if len(elemFields) == 0 {
 		return nil, fmt.Errorf("%s looks like paging method, but can't find repeated field in %s", *m.Name, outType.GetName())
 	}


### PR DESCRIPTION
Previously, if an RPC had all of the necessary Pagination fields according to AIP-4233, but was missing a repeated field, the generator would fail. This is not a requirement of AIP-4233, instead it should treat the RPC as if it wasn't paginated, and generate a standard method.

Fixes #493 