### PR TITLE
chore: run basic tests on Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,6 @@ workflows:
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+$|^v\d+\.\d+\.\d+-[a-z]+$/
-      - bazel-test:
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$|^v\d+\.\d+\.\d+-[a-z]+$/
       - release:
           requires:
             - build
@@ -38,10 +34,6 @@ jobs:
       - image: circleci/golang:1.13
     steps:
       - checkout
-      - run: go test ./...
-      - run:
-          name: Check license
-          command: go run ./util/cmd/license
       - run: go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
       - run: go install github.com/golang/protobuf/protoc-gen-go
       - run:
@@ -66,16 +58,6 @@ jobs:
             mv googleapis-master googleapis
             export PATH=$PATH:$(pwd)/protobuf/bin
             GOOGLEAPIS=googleapis OUT=$GOPATH/src ./test.sh
-  bazel-test:
-    docker:
-      - image: gcr.io/gapic-images/googleapis-bazel:20210105 
-    steps:
-      - checkout
-      - run:
-          name: Run tests for repo
-          no_output_timeout: 30m
-          command: |
-              bazel test --jobs 4 //...
   release:
     docker:
       - image: circleci/golang:1.13

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,63 @@
+---
+name: Generator tests
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    container: golang:1.13
+    steps:
+      - uses: actions/checkout@v2
+      - run: go test -p 1 ./...
+  bazel-build:
+    runs-on: ubuntu-latest
+    container: gcr.io/gapic-images/googleapis-bazel:20210105
+    # Dockerfile for this image: https://github.com/googleapis/googleapis-discovery/blob/master/Dockerfile
+    # If you update its version, please also update it below in
+    # 'Cache Bazel files' - unfortunately it cannot accept variables at this
+    # time.
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache Bazel files
+      id: cache-bazel
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/bazel
+        key: ${{ runner.os }}-bazel-20210105-${{ secrets.CACHE_VERSION }}
+
+    - name: Cache not found
+      if: steps.cache-bazel.outputs.cache-hit != 'true'
+      run: |
+        echo "No cache found."
+
+    - name: Cache found
+      if: steps.cache-bazel.outputs.cache-hit == 'true'
+      run: |
+        echo -n "Cache found. Cache size: "
+        du -sh ~/.cache/bazel
+        echo "If the cache seems broken, update the CACHE_VERSION secret in"
+        echo "https://github.com/googleapis/googleapis-discovery/settings/secrets/actions"
+        echo "(use any random string, any GUID will work)"
+        echo "and it will start over with a clean cache."
+        echo "The old one will disappear after 7 days."
+
+    - name: Run bazel build
+      run: bazel build '//...'
+
+    - name: Run bazel test
+      run: bazel test '//...'
+  lint:
+    runs-on: ubuntu-latest
+    container: golang:1.13
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install golangci-lint
+        run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
+      - name: Run golangci-lint
+        run: golangci-lint run ./...

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,14 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.13.1'
-    - name: Install golangci-lint
-      run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
-    - name: Run golangci-lint
-      run: golangci-lint run ./...
+
+    # TODO(noahdietz): fix all lint errors then enable this.
+    # - name: Install golangci-lint
+    #   run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
+    # - name: Run golangci-lint
+    #   run: golangci-lint run ./...
+    - name: Check format
+      run: "! go fmt ./... 2>&1 | read"
     - name: Check license
       run: go run ./util/cmd/license
   unit-tests:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,27 @@ on:
   pull_request:
 
 jobs:
-  unit-tests:
+  lint:
     runs-on: ubuntu-latest
-    container: golang:1.13
     steps:
       - uses: actions/checkout@v2
-      - run: go test -p 1 ./...
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.13.1'
+      - name: Install golangci-lint
+        run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
+      - name: Run golangci-lint
+        run: golangci-lint run ./...
+      - name: Check license
+        run: go run ./util/cmd/license
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.13.1'
+      - run: go test ./...
   bazel-build:
     runs-on: ubuntu-latest
     container: gcr.io/gapic-images/googleapis-bazel:20210105
@@ -52,14 +67,3 @@ jobs:
 
     - name: Run bazel test
       run: bazel test '//...'
-  lint:
-    runs-on: ubuntu-latest
-    container: golang:1.13
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install golangci-lint
-        run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
-      - name: Run golangci-lint
-        run: golangci-lint run ./...
-      - name: Check license
-        run: go run ./util/cmd/license

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,24 +10,24 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '^1.13.1'
-      - name: Install golangci-lint
-        run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
-      - name: Run golangci-lint
-        run: golangci-lint run ./...
-      - name: Check license
-        run: go run ./util/cmd/license
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.13.1'
+    - name: Install golangci-lint
+      run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
+    - name: Run golangci-lint
+      run: golangci-lint run ./...
+    - name: Check license
+      run: go run ./util/cmd/license
   unit-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '^1.13.1'
-      - run: go test ./...
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.13.1'
+    - run: go test ./...
   bazel-build:
     runs-on: ubuntu-latest
     container: gcr.io/gapic-images/googleapis-bazel:20210105

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,3 +61,5 @@ jobs:
         run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
       - name: Run golangci-lint
         run: golangci-lint run ./...
+      - name: Check license
+        run: go run ./util/cmd/license

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,38 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     container: gcr.io/gapic-images/googleapis-bazel:20210105
     # Dockerfile for this image: https://github.com/googleapis/googleapis-discovery/blob/master/Dockerfile
-    # If you update its version, please also update it below in
-    # 'Cache Bazel files' - unfortunately it cannot accept variables at this
-    # time.
-
     steps:
     - uses: actions/checkout@v2
-
-    - name: Cache Bazel files
-      id: cache-bazel
-      uses: actions/cache@v2
-      with:
-        path: ~/.cache/bazel
-        key: ${{ runner.os }}-bazel-20210105-${{ secrets.CACHE_VERSION }}
-
-    - name: Cache not found
-      if: steps.cache-bazel.outputs.cache-hit != 'true'
-      run: |
-        echo "No cache found."
-
-    - name: Cache found
-      if: steps.cache-bazel.outputs.cache-hit == 'true'
-      run: |
-        echo -n "Cache found. Cache size: "
-        du -sh ~/.cache/bazel
-        echo "If the cache seems broken, update the CACHE_VERSION secret in"
-        echo "https://github.com/googleapis/googleapis-discovery/settings/secrets/actions"
-        echo "(use any random string, any GUID will work)"
-        echo "and it will start over with a clean cache."
-        echo "The old one will disappear after 7 days."
-
     - name: Run bazel build
       run: bazel build '//...'
-
     - name: Run bazel test
       run: bazel test '//...'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,6 @@ jobs:
     #   run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
     # - name: Run golangci-lint
     #   run: golangci-lint run ./...
-    - name: Check format
-      run: "! go fmt ./... 2>&1 | read"
     - name: Check license
       run: go run ./util/cmd/license
   unit-tests:


### PR DESCRIPTION
Adds a GitHub Actions config for running basic linting, unit tests and bazel testing.

To remove circleci we'd need to port: 
- Showcase integration tests
- Docker image creation + publication
- release script execution (this should probably be ported to release-please)

Once Actions is confirmed to work, I will remove the duplicate jobs from the CircleCI config if possible

cc @alexander-fenster: thanks for the example to work from. I copied some of Luke's configs from the api-linter (a Go project) for basic testing/linting.