### PR TITLE
chore: port integration tests to Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,18 +3,11 @@ workflows:
   version: 2
   build_test_publish:
     jobs:
-      - build:
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$|^v\d+\.\d+\.\d+-[a-z]+$/
       - format:
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+$|^v\d+\.\d+\.\d+-[a-z]+$/
       - release:
-          requires:
-            - build
-            - format
           filters:
             branches:
               ignore: /.*/
@@ -29,18 +22,6 @@ jobs:
       - run:
           name: Check Format
           command: "! go fmt ./... 2>&1 | read"
-  build:
-    docker:
-      - image: circleci/golang:1.13
-    steps:
-      - checkout
-      - run: go install github.com/googleapis/gapic-generator-go/cmd/protoc-gen-go_gapic
-      - run: go install github.com/golang/protobuf/protoc-gen-go
-      - run:
-          name: verify error conformance
-          command: |
-            go install github.com/googleapis/gapic-config-validator/cmd/gapic-error-conformance
-            gapic-error-conformance -plugin=protoc-gen-go_gapic -plugin_opts="go-gapic-package=foo.com/bar/v1;bar"
   release:
     docker:
       - image: circleci/golang:1.13

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,23 +41,6 @@ jobs:
           command: |
             go install github.com/googleapis/gapic-config-validator/cmd/gapic-error-conformance
             gapic-error-conformance -plugin=protoc-gen-go_gapic -plugin_opts="go-gapic-package=foo.com/bar/v1;bar"
-      # Install protoc, showcase.bash needs it
-      - run:
-          name: Run Showcase
-          command: |
-            mkdir protobuf
-            curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-x86_64.zip > protobuf/protoc.zip
-            unzip -d protobuf protobuf/protoc.zip
-            export PATH=$PATH:$(pwd)/protobuf/bin            
-            make test
-      - run:
-          name: Run Google APIs test gen
-          command: |
-            curl -sSL https://github.com/googleapis/googleapis/archive/master.zip > googleapis.zip
-            unzip googleapis.zip
-            mv googleapis-master googleapis
-            export PATH=$PATH:$(pwd)/protobuf/bin
-            GOOGLEAPIS=googleapis OUT=$GOPATH/src ./test.sh
   release:
     docker:
       - image: circleci/golang:1.13

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,13 +43,14 @@ jobs:
         mkdir protobuf
         curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-x86_64.zip > protobuf/protoc.zip
         unzip -d protobuf protobuf/protoc.zip
-        export PATH=$PATH:$(pwd)/protobuf/bin
         curl -sSL https://github.com/googleapis/googleapis/archive/master.zip > googleapis.zip
         unzip googleapis.zip -x "google/ads/*"
         mv googleapis-master googleapis
-        export PATH=$PATH:$(pwd)/protobuf/bin
     - name: Run integration tests
-      run: GOOGLEAPIS=googleapis make test
+      run: |
+        export PATH=$PATH:$(pwd)/protobuf/bin
+        export GOOGLEAPIS=googleapis
+        make test
   bazel-build:
     runs-on: ubuntu-latest
     container: gcr.io/gapic-images/googleapis-bazel:20210105

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,17 +37,19 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.13.1'
-    - run: |
+    - name: Install tools and dependencies
+      run: |
         go install github.com/golang/protobuf/protoc-gen-go
         mkdir protobuf
         curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-x86_64.zip > protobuf/protoc.zip
         unzip -d protobuf protobuf/protoc.zip
         export PATH=$PATH:$(pwd)/protobuf/bin
         curl -sSL https://github.com/googleapis/googleapis/archive/master.zip > googleapis.zip
-        unzip googleapis.zip
+        unzip googleapis.zip -x "google/ads/*"
         mv googleapis-master googleapis
         export PATH=$PATH:$(pwd)/protobuf/bin
-        GOOGLEAPIS=googleapis make test
+    - name: Run integration tests
+      run: GOOGLEAPIS=googleapis make test
   bazel-build:
     runs-on: ubuntu-latest
     container: gcr.io/gapic-images/googleapis-bazel:20210105

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,6 +38,7 @@ jobs:
       with:
         go-version: '^1.13.1'
     - run: |
+        go install github.com/golang/protobuf/protoc-gen-go
         mkdir protobuf
         curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-x86_64.zip > protobuf/protoc.zip
         unzip -d protobuf protobuf/protoc.zip

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,8 +47,7 @@ jobs:
         unzip googleapis.zip
         mv googleapis-master googleapis
         export PATH=$PATH:$(pwd)/protobuf/bin
-        make test
-        GOOGLEAPIS=googleapis OUT=$GOPATH/src ./test.sh
+        GOOGLEAPIS=googleapis make test
   bazel-build:
     runs-on: ubuntu-latest
     container: gcr.io/gapic-images/googleapis-bazel:20210105

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,24 @@ jobs:
       with:
         go-version: '^1.13.1'
     - run: go test ./...
+  integration-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.13.1'
+    - run: |
+        mkdir protobuf
+        curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-x86_64.zip > protobuf/protoc.zip
+        unzip -d protobuf protobuf/protoc.zip
+        export PATH=$PATH:$(pwd)/protobuf/bin
+        curl -sSL https://github.com/googleapis/googleapis/archive/master.zip > googleapis.zip
+        unzip googleapis.zip
+        mv googleapis-master googleapis
+        export PATH=$PATH:$(pwd)/protobuf/bin
+        make test
+        GOOGLEAPIS=googleapis OUT=$GOPATH/src ./test.sh
   bazel-build:
     runs-on: ubuntu-latest
     container: gcr.io/gapic-images/googleapis-bazel:20210105

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
         mv googleapis-master googleapis
     - name: Run integration tests
       run: |
-        export PATH=$PATH:$(pwd)/protobuf/bin
+        export PATH=$PATH:protobuf/bin
         export GOOGLEAPIS=googleapis
         make test
   bazel-build:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
         curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-x86_64.zip > protobuf/protoc.zip
         unzip -d protobuf protobuf/protoc.zip
         curl -sSL https://github.com/googleapis/googleapis/archive/master.zip > googleapis.zip
-        unzip googleapis.zip -x "google/ads/*"
+        unzip googleapis.zip -x "googleapis-master/google/ads/*"
         mv googleapis-master googleapis
     - name: Run integration tests
       run: |

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ test:
 	go test ./...
 	go install ./cmd/protoc-gen-go_gapic
 	cd showcase; ./showcase.bash; cd ..
+	./test.sh
 
 install:
 	go install ./cmd/protoc-gen-go_gapic

--- a/test.sh
+++ b/test.sh
@@ -24,8 +24,8 @@
 set -e
 
 if [ -z $GOOGLEAPIS ]; then
-	echo >&2 "need GOOGLEAPIS variable"
-	exit 1
+	echo "Set GOOGLEAPIS to the location of github.com/googleapis/googleapis. Skipping."
+	exit 0
 fi
 
 OUT=${OUT:-testdata/out}


### PR DESCRIPTION
This PR includes the following:
- moves Showcase testing into Actions
- moves googleapis generation smoke test into Actions
- adds googleapis generation smoke test to `make test` target
- removes now obsolete `build` job from CircleCi

Remaining CircleCi jobs are:
- docker image building
- release publication
- format check

Note: I'm not doing anything fancy with Actions here, I just tried to port the existing CI scripts/commands to Actions to get off of CircleCI. We can come back around and make things "idiomatic" later.