### PR TITLE
chore: port GitHub release to Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,13 +29,6 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
-          name: Make GitHub Release
-          command: |
-            go run ./util/cmd/release \
-              -version=${CIRCLE_TAG} \
-              -commitish=${CIRCLE_SHA1} \
-              -token=${GITHUB_TOKEN}
-      - run:
           name: Build Docker image.
           command: make image
       - run:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,17 @@
+---
+name: release
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    container: golang:1.13
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create release
+        run: go run ./util/cmd/release \
+              -version=${GITHUB_REF#refs/tags/} \
+              -commitish=${{ github.sha }} \
+              -token=${{ github.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,10 +7,12 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    container: golang:1.13
     steps:
       - uses: actions/checkout@v2
-      - name: Create release
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.13.1'
+      - name: Create GitHub release
         run: go run ./util/cmd/release \
               -version=${GITHUB_REF#refs/tags/} \
               -commitish=${{ github.sha }} \


### PR DESCRIPTION
This moves the GitHub release script from CircleCI to Actions.