### PR TITLE
fix: include numbers in header name regexp

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -49,7 +49,7 @@ const (
 	disableDeadlinesVar = "GOOGLE_API_GO_EXPERIMENTAL_DISABLE_DEFAULT_DEADLINE"
 )
 
-var headerParamRegexp = regexp.MustCompile(`{([_.a-z]+)`)
+var headerParamRegexp = regexp.MustCompile(`{([_.a-z0-9]+)`)
 
 type Transport int
 

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -630,12 +630,14 @@ func Test_parseRequestHeaders(t *testing.T) {
 			}
 		}
 
-		if got, err := parseRequestHeaders(m); err != nil {
+		got, err := parseRequestHeaders(m)
+		if err != nil {
 			t.Error(err)
 			continue
 		}
+
 		if diff := cmp.Diff(got, tst.want); diff != "" {
-			t.Errorf("parseRequestHeaders(%s) = %v, want %v, diff %s", tst.name, got, tst.want, diff)
+			t.Errorf("parseRequestHeaders(%s) = got(-), want(+):\n%s", tst.name, diff)
 		}
 	}
 }

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -632,7 +632,9 @@ func Test_parseRequestHeaders(t *testing.T) {
 
 		if got, err := parseRequestHeaders(m); err != nil {
 			t.Error(err)
-		} else if diff := cmp.Diff(got, tst.want); diff != "" {
+			continue
+		}
+		if diff := cmp.Diff(got, tst.want); diff != "" {
 			t.Errorf("parseRequestHeaders(%s) = %v, want %v, diff %s", tst.name, got, tst.want, diff)
 		}
 	}


### PR DESCRIPTION
Addresses first part of #514 - capturing numbers in field names defined in `google.api.http` patterns for use in building the field accessor.