### PR TITLE
fix: handle non-string header field types

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -631,7 +631,7 @@ func (g *generator) insertMetadata(m *descriptor.MethodDescriptorProto) error {
 				// QueryEscape the resulting string in case there is a '+' in the
 				// exponent.
 				// See golang.org/pkg/fmt for more information on formatting.
-				accessor = fmt.Sprintf("url.QueryEscape(fmt.Sprintf(\"%%g\", %s))", accessor)
+				accessor = fmt.Sprintf(`url.QueryEscape(fmt.Sprintf("%%g", %s))`, accessor)
 			}
 
 			// URL encode key & values separately per aip.dev/4222.
@@ -666,7 +666,8 @@ func buildAccessor(field string) string {
 	return ax.String()
 }
 
-func (g *generator) lookupFieldType(msgName, field string) (typ descriptor.FieldDescriptorProto_Type) {
+func (g *generator) lookupFieldType(msgName, field string) descriptor.FieldDescriptorProto_Type {
+	var typ descriptor.FieldDescriptorProto_Type
 	msg := g.descInfo.Type[msgName]
 	msgProto := msg.(*descriptor.DescriptorProto)
 	msgFields := msgProto.GetField()
@@ -690,7 +691,7 @@ func (g *generator) lookupFieldType(msgName, field string) (typ descriptor.Field
 			}
 		}
 	}
-	return
+	return typ
 }
 
 func (g *generator) appendCallOpts(m *descriptor.MethodDescriptorProto) {

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -628,7 +628,7 @@ func (g *generator) insertMetadata(m *descriptor.MethodDescriptorProto) error {
 			} else if typ == descriptor.FieldDescriptorProto_TYPE_DOUBLE || typ == descriptor.FieldDescriptorProto_TYPE_FLOAT {
 				// Format the floating point value with mode 'g' to allow for
 				// exponent formatting when necessary, and decimal when adequate.
-				// QueryEscape the resulting string incase there is a '+' in the
+				// QueryEscape the resulting string in case there is a '+' in the
 				// exponent.
 				// See golang.org/pkg/fmt for more information on formatting.
 				accessor = fmt.Sprintf("url.QueryEscape(fmt.Sprintf(%q, %s))", "%g", accessor)

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -638,7 +638,6 @@ func (g *generator) insertMetadata(m *descriptor.MethodDescriptorProto) error {
 			// Encode the key ahead of time to reduce clutter
 			// and because it will likely never be necessary
 			fmt.Fprintf(&values, " %q, %s,", url.QueryEscape(field), accessor)
-			// Produces either "%s=%v&" or "%s=%f&" depending on the field type.
 			formats.WriteString("%s=%v&")
 		}
 		f := formats.String()[:formats.Len()-1]

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -631,7 +631,7 @@ func (g *generator) insertMetadata(m *descriptor.MethodDescriptorProto) error {
 				// QueryEscape the resulting string in case there is a '+' in the
 				// exponent.
 				// See golang.org/pkg/fmt for more information on formatting.
-				accessor = fmt.Sprintf("url.QueryEscape(fmt.Sprintf(%q, %s))", "%g", accessor)
+				accessor = fmt.Sprintf("url.QueryEscape(fmt.Sprintf(\"%%g\", %s))", accessor)
 			}
 
 			// URL encode key & values separately per aip.dev/4222.

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -631,7 +631,7 @@ func (g *generator) insertMetadata(m *descriptor.MethodDescriptorProto) error {
 			// and because it will likely never be necessary
 			fmt.Fprintf(&values, " %q, %s,", url.QueryEscape(field), accessor)
 
-			// The defualt format specifiers for bool, string, and int are
+			// The default format specifiers for bool, string, and int are
 			// sufficient.
 			//
 			// TODO(noahdietz): need to handle []byte for TYPE_BYTES.

--- a/internal/gengapic/testdata/method_GetEmptyThing.want
+++ b/internal/gengapic/testdata/method_GetEmptyThing.want
@@ -4,7 +4,7 @@ func (c *FooClient) GetEmptyThing(ctx context.Context, req *mypackagepb.InputTyp
 		defer cancel()
 		ctx = cctx
 	}
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%f", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", req.GetBiz()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz()))))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetEmptyThing[0:len(c.CallOptions.GetEmptyThing):len(c.CallOptions.GetEmptyThing)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_GetEmptyThing.want
+++ b/internal/gengapic/testdata/method_GetEmptyThing.want
@@ -4,7 +4,7 @@ func (c *FooClient) GetEmptyThing(ctx context.Context, req *mypackagepb.InputTyp
 		defer cancel()
 		ctx = cctx
 	}
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(req.GetBiz())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%f", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", req.GetBiz()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetEmptyThing[0:len(c.CallOptions.GetEmptyThing):len(c.CallOptions.GetEmptyThing)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(req.GetBiz())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%f", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", req.GetBiz()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetManyThings[0:len(c.CallOptions.GetManyThings):len(c.CallOptions.GetManyThings)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%f", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", req.GetBiz()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz()))))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetManyThings[0:len(c.CallOptions.GetManyThings):len(c.CallOptions.GetManyThings)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetManyThingsOptional.want
+++ b/internal/gengapic/testdata/method_GetManyThingsOptional.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetManyThingsOptional(ctx context.Context, req *mypackagepb.PageInputTypeOptional, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(req.GetBiz())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%f", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", req.GetBiz()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetManyThingsOptional[0:len(c.CallOptions.GetManyThingsOptional):len(c.CallOptions.GetManyThingsOptional)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetManyThingsOptional.want
+++ b/internal/gengapic/testdata/method_GetManyThingsOptional.want
@@ -1,5 +1,5 @@
 func (c *FooClient) GetManyThingsOptional(ctx context.Context, req *mypackagepb.PageInputTypeOptional, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%f", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", req.GetBiz()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz()))))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetManyThingsOptional[0:len(c.CallOptions.GetManyThingsOptional):len(c.CallOptions.GetManyThingsOptional)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetOneThing.want
+++ b/internal/gengapic/testdata/method_GetOneThing.want
@@ -4,7 +4,7 @@ func (c *FooClient) GetOneThing(ctx context.Context, req *mypackagepb.InputType,
 		defer cancel()
 		ctx = cctx
 	}
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%f", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", req.GetBiz()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz()))))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetOneThing[0:len(c.CallOptions.GetOneThing):len(c.CallOptions.GetOneThing)], opts...)
 	var resp *mypackagepb.OutputType

--- a/internal/gengapic/testdata/method_GetOneThing.want
+++ b/internal/gengapic/testdata/method_GetOneThing.want
@@ -4,7 +4,7 @@ func (c *FooClient) GetOneThing(ctx context.Context, req *mypackagepb.InputType,
 		defer cancel()
 		ctx = cctx
 	}
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(req.GetBiz())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%f", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", req.GetBiz()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.GetOneThing[0:len(c.CallOptions.GetOneThing):len(c.CallOptions.GetOneThing)], opts...)
 	var resp *mypackagepb.OutputType

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb.Foo_ServerThingsClient, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(req.GetBiz())))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%f", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", req.GetBiz()))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.ServerThings[0:len(c.CallOptions.ServerThings):len(c.CallOptions.ServerThings)], opts...)
 	var resp mypackagepb.Foo_ServerThingsClient

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,5 +1,5 @@
 func (c *FooClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb.Foo_ServerThingsClient, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%f", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", req.GetBiz()))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz()))))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append(c.CallOptions.ServerThings[0:len(c.CallOptions.ServerThings):len(c.CallOptions.ServerThings)], opts...)
 	var resp mypackagepb.Foo_ServerThingsClient


### PR DESCRIPTION
This adds support for non-`string` field types that are declared as header request params. For non-`string` types, the value at runtime is not `url.QueryEscape`'d. For proto field types that translate to a `float64`, the `%g` formatter is used to format the value in either exponent or decimal form depending on what is best. See https://golang.org/pkg/fmt/ for more on format modes. The resulting formatted value is `QueryEscape`'d in case there is a `+` in the exponent section.

A helper `lookupFieldType` in order to learn the type of the field declared as a header request param.

Furthermore, the existing tests were updated to account for the new lookup of field types in header request param construction. New tests were also added to cover the new methods.

Open TODO to handle `[]byte`.

#514 