### PR TITLE
feat: add an abstract client interface

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -206,7 +206,7 @@ func (g *generator) grpcClientInit(serv *descriptor.ServiceDescriptorProto, serv
 
 	// client struct
 	p("// %sClient is a client for interacting with %s over gRPC transport.", servName, g.apiName)
-	p("// It satisfies the %sAbstractClient interface", servName)
+	p("// It satisfies the %sAbstractClient interface.", servName)
 	p("//")
 	p("// Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.")
 	p("type %sClient struct {", servName)

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -135,9 +135,208 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 	return nil
 }
 
-func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName string) error {
+func (g *generator) abstractClientIntfInit(serv *descriptor.ServiceDescriptorProto, servName string) error {
+	p := g.printf
+	p("// %sAbstractClient is an interface that defines the methods availaible from %s.", servName, g.apiName)
+	p("// It is agnostic as to the underlying transport, i.e. json+http, gRPC, or other.")
+	p("type %sAbstractClient interface {", servName)
+	for _, m := range serv.Method {
+		inType := g.descInfo.Type[*m.InputType]
+		inSpec, err := g.descInfo.ImportSpec(inType)
+		if err != nil {
+			return err
+		}
+		outType := g.descInfo.Type[*m.OutputType]
+		outSpec, err := g.descInfo.ImportSpec(outType)
+		if err != nil {
+			return err
+		}
+
+		if m.GetOutputType() == emptyType {
+			p("%s(context.Context, *%s.%s, ...gax.CallOption) error",
+				m.GetName(),
+				inSpec.Name,
+				inType.GetName())
+			continue
+		}
+
+		if pf, err := g.pagingField(m); err != nil {
+			return err
+		} else if pf != nil {
+			iter, err := g.iterTypeOf(pf)
+			if err != nil {
+				return err
+			}
+			p("%s(context.Context, *%s.%s, ...gax.CallOption) *%s",
+				m.GetName(),
+				inSpec.Name,
+				inType.GetName(),
+				iter.iterTypeName)
+			continue
+		}
+
+		switch {
+		case g.isLRO(m):
+			// Unary call where the return type is a wrapper of
+			// longrunning.Operation and more precise types
+			p("%s(context.Context, *%s.%s, ...gax.CallOption) (*%s, error)",
+				m.GetName(), inSpec.Name, inType.GetName(), lroTypeName(m.GetName()))
+		case m.GetClientStreaming():
+			// Handles both client-streaming and bidi-streaming
+			p("%s(context.Context, ...gax.CallOption) (%s.%s_%sClient, error)",
+				m.GetName(), inSpec.Name, serv.GetName(), m.GetName())
+		case m.GetServerStreaming():
+			// Handles _just_ server streaming
+			p("%s(context.Context, *%s.%s, ...gax.CallOption) (%s.%s_%sClient, error)",
+				m.GetName(), inSpec.Name, inType.GetName(), inSpec.Name, serv.GetName(), m.GetName())
+		default:
+			// Regular, unary call
+			p("%s(context.Context, *%s.%s, ...gax.CallOption) (*%s.%s, error)",
+				m.GetName(), inSpec.Name, inType.GetName(), outSpec.Name, outType.GetName())
+		}
+	}
+	p("}")
+	p("")
+
+	return nil
+}
+
+func (g *generator) grpcClientInit(serv *descriptor.ServiceDescriptorProto, servName string, imp pbinfo.ImportSpec, hasLRO bool) {
 	p := g.printf
 
+	// client struct
+	p("// %sClient is a client for interacting with %s.", servName, g.apiName)
+	p("//")
+	p("// Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.")
+	p("type %sClient struct {", servName)
+
+	p("// Connection pool of gRPC connections to the service.")
+	p("connPool gtransport.ConnPool")
+	p("")
+
+	p("// flag to opt out of default deadlines via %s", disableDeadlinesVar)
+	p("disableDeadlines bool")
+	p("")
+
+	p("// The gRPC API client.")
+	p("%s %s.%sClient", grpcClientField(servName), imp.Name, serv.GetName())
+	p("")
+
+	if hasLRO {
+		p("// LROClient is used internally to handle longrunning operations.")
+		p("// It is exposed so that its CallOptions can be modified if required.")
+		p("// Users should not Close this client.")
+		p("LROClient *lroauto.OperationsClient")
+		p("")
+
+		g.imports[pbinfo.ImportSpec{Name: "lroauto", Path: "cloud.google.com/go/longrunning/autogen"}] = true
+	}
+
+	p("// The call options for this service.")
+	p("CallOptions *%sCallOptions", servName)
+	p("")
+
+	p("// The x-goog-* metadata to be sent with each request.")
+	p("xGoogMetadata metadata.MD")
+	p("}")
+	p("")
+
+	g.imports[pbinfo.ImportSpec{Path: "google.golang.org/grpc"}] = true
+	g.imports[pbinfo.ImportSpec{Path: "google.golang.org/grpc/metadata"}] = true
+
+	g.grpcClientUtilities(serv, servName, imp, hasLRO)
+}
+
+func (g *generator) grpcClientUtilities(serv *descriptor.ServiceDescriptorProto, servName string, imp pbinfo.ImportSpec, hasLRO bool) {
+	p := g.printf
+
+	clientName := camelToSnake(serv.GetName())
+	clientName = strings.Replace(clientName, "_", " ", -1)
+
+	// Factory function
+	p("// New%sClient creates a new %s client.", servName, clientName)
+	p("//")
+	g.comment(g.comments[serv])
+	p("func New%[1]sClient(ctx context.Context, opts ...option.ClientOption) (*%[1]sClient, error) {", servName)
+	p("  clientOpts := default%sClientOptions()", servName)
+	p("")
+	p("  if new%sClientHook != nil {", servName)
+	p("    hookOpts, err := new%sClientHook(ctx, clientHookParams{})", servName)
+	p("    if err != nil {")
+	p("      return nil, err")
+	p("    }")
+	p("    clientOpts = append(clientOpts, hookOpts...)")
+	p("  }")
+	p("")
+	p("  disableDeadlines, err := checkDisableDeadlines()")
+	p("  if err != nil {")
+	p("    return nil, err")
+	p("  }")
+	p("")
+	p("  connPool, err := gtransport.DialPool(ctx, append(clientOpts, opts...)...)")
+	p("  if err != nil {")
+	p("    return nil, err")
+	p("  }")
+	p("  c := &%sClient{", servName)
+	p("    connPool:    connPool,")
+	p("    disableDeadlines: disableDeadlines,")
+	p("    CallOptions: default%sCallOptions(),", servName)
+	p("")
+	p("    %s: %s.New%sClient(connPool),", grpcClientField(servName), imp.Name, serv.GetName())
+	p("  }")
+	p("  c.setGoogleClientInfo()")
+	p("")
+
+	if hasLRO {
+		p("  c.LROClient, err = lroauto.NewOperationsClient(ctx, gtransport.WithConnPool(connPool))")
+		p("  if err != nil {")
+		p("    // This error \"should not happen\", since we are just reusing old connection pool")
+		p("    // and never actually need to dial.")
+		p("    // If this does happen, we could leak connp. However, we cannot close conn:")
+		p("    // If the user invoked the constructor with option.WithGRPCConn,")
+		p("    // we would close a connection that's still in use.")
+		p("    // TODO: investigate error conditions.")
+		p("    return nil, err")
+		p("  }")
+	}
+
+	p("  return c, nil")
+	p("}")
+	p("")
+
+	g.imports[pbinfo.ImportSpec{Name: "gtransport", Path: "google.golang.org/api/transport/grpc"}] = true
+	g.imports[pbinfo.ImportSpec{Path: "context"}] = true
+
+	// Connection method
+	p("// Connection returns a connection to the API service.")
+	p("//")
+	p("// Deprecated.")
+	p("func (c *%sClient) Connection() *grpc.ClientConn {", servName)
+	p("  return c.connPool.Conn()")
+	p("}")
+	p("")
+
+	// Close method
+	p("// Close closes the connection to the API service. The user should invoke this when")
+	p("// the client is no longer required.")
+	p("func (c *%sClient) Close() error {", servName)
+	p("  return c.connPool.Close()")
+	p("}")
+	p("")
+
+	// setGoogleClientInfo method
+	p("// setGoogleClientInfo sets the name and version of the application in")
+	p("// the `x-goog-api-client` header passed on each request. Intended for")
+	p("// use by Google-written clients.")
+	p("func (c *%sClient) setGoogleClientInfo(keyval ...string) {", servName)
+	p(`  kv := append([]string{"gl-go", versionGo()}, keyval...)`)
+	p(`  kv = append(kv, "gapic", versionClient, "gax", gax.Version, "grpc", grpc.Version)`)
+	p(`  c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))`)
+	p("}")
+	p("")
+}
+
+func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName string) error {
 	var hasLRO bool
 	for _, m := range serv.Method {
 		if g.isLRO(m) {
@@ -151,139 +350,21 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 		return err
 	}
 
-	// client struct
-	{
-		p("// %sClient is a client for interacting with %s.", servName, g.apiName)
-		p("//")
-		p("// Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.")
-		p("type %sClient struct {", servName)
+	err = g.abstractClientIntfInit(serv, servName)
+	if err != nil {
+		return err
+	}
 
-		p("// Connection pool of gRPC connections to the service.")
-		p("connPool gtransport.ConnPool")
-		p("")
-
-		p("// flag to opt out of default deadlines via %s", disableDeadlinesVar)
-		p("disableDeadlines bool")
-		p("")
-
-		p("// The gRPC API client.")
-		p("%s %s.%sClient", grpcClientField(servName), imp.Name, serv.GetName())
-		p("")
-
-		if hasLRO {
-			p("// LROClient is used internally to handle longrunning operations.")
-			p("// It is exposed so that its CallOptions can be modified if required.")
-			p("// Users should not Close this client.")
-			p("LROClient *lroauto.OperationsClient")
-			p("")
-
-			g.imports[pbinfo.ImportSpec{Name: "lroauto", Path: "cloud.google.com/go/longrunning/autogen"}] = true
+	for _, v := range g.opts.transports {
+		switch v {
+		case grpc:
+			g.grpcClientInit(serv, servName, imp, hasLRO)
+		case rest:
+			// TODO(dovs): add rest client struct initialization
+			continue
+		default:
+			return fmt.Errorf("unexpected transport variant: %d", v)
 		}
-
-		p("// The call options for this service.")
-		p("CallOptions *%sCallOptions", servName)
-		p("")
-
-		p("// The x-goog-* metadata to be sent with each request.")
-		p("xGoogMetadata metadata.MD")
-		p("}")
-		p("")
-
-		g.imports[pbinfo.ImportSpec{Path: "google.golang.org/grpc"}] = true
-		g.imports[pbinfo.ImportSpec{Path: "google.golang.org/grpc/metadata"}] = true
-	}
-
-	// Client constructor
-	{
-		clientName := camelToSnake(serv.GetName())
-		clientName = strings.Replace(clientName, "_", " ", -1)
-
-		p("// New%sClient creates a new %s client.", servName, clientName)
-		p("//")
-		g.comment(g.comments[serv])
-		p("func New%[1]sClient(ctx context.Context, opts ...option.ClientOption) (*%[1]sClient, error) {", servName)
-		p("  clientOpts := default%sClientOptions()", servName)
-		p("")
-		p("  if new%sClientHook != nil {", servName)
-		p("    hookOpts, err := new%sClientHook(ctx, clientHookParams{})", servName)
-		p("    if err != nil {")
-		p("      return nil, err")
-		p("    }")
-		p("    clientOpts = append(clientOpts, hookOpts...)")
-		p("  }")
-		p("")
-		p("  disableDeadlines, err := checkDisableDeadlines()")
-		p("  if err != nil {")
-		p("    return nil, err")
-		p("  }")
-		p("")
-		p("  connPool, err := gtransport.DialPool(ctx, append(clientOpts, opts...)...)")
-		p("  if err != nil {")
-		p("    return nil, err")
-		p("  }")
-		p("  c := &%sClient{", servName)
-		p("    connPool:    connPool,")
-		p("    disableDeadlines: disableDeadlines,")
-		p("    CallOptions: default%sCallOptions(),", servName)
-		p("")
-		p("    %s: %s.New%sClient(connPool),", grpcClientField(servName), imp.Name, serv.GetName())
-		p("  }")
-		p("  c.setGoogleClientInfo()")
-		p("")
-
-		if hasLRO {
-			p("  c.LROClient, err = lroauto.NewOperationsClient(ctx, gtransport.WithConnPool(connPool))")
-			p("  if err != nil {")
-			p("    // This error \"should not happen\", since we are just reusing old connection pool")
-			p("    // and never actually need to dial.")
-			p("    // If this does happen, we could leak connp. However, we cannot close conn:")
-			p("    // If the user invoked the constructor with option.WithGRPCConn,")
-			p("    // we would close a connection that's still in use.")
-			p("    // TODO: investigate error conditions.")
-			p("    return nil, err")
-			p("  }")
-		}
-
-		p("  return c, nil")
-		p("}")
-		p("")
-
-		g.imports[pbinfo.ImportSpec{Name: "gtransport", Path: "google.golang.org/api/transport/grpc"}] = true
-		g.imports[pbinfo.ImportSpec{Path: "context"}] = true
-	}
-
-	// Connection()
-	{
-		p("// Connection returns a connection to the API service.")
-		p("//")
-		p("// Deprecated.")
-		p("func (c *%sClient) Connection() *grpc.ClientConn {", servName)
-		p("  return c.connPool.Conn()")
-		p("}")
-		p("")
-	}
-
-	// Close()
-	{
-		p("// Close closes the connection to the API service. The user should invoke this when")
-		p("// the client is no longer required.")
-		p("func (c *%sClient) Close() error {", servName)
-		p("  return c.connPool.Close()")
-		p("}")
-		p("")
-	}
-
-	// setGoogleClientInfo
-	{
-		p("// setGoogleClientInfo sets the name and version of the application in")
-		p("// the `x-goog-api-client` header passed on each request. Intended for")
-		p("// use by Google-written clients.")
-		p("func (c *%sClient) setGoogleClientInfo(keyval ...string) {", servName)
-		p(`  kv := append([]string{"gl-go", versionGo()}, keyval...)`)
-		p(`  kv = append(kv, "gapic", versionClient, "gax", gax.Version, "grpc", grpc.Version)`)
-		p(`  c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))`)
-		p("}")
-		p("")
 	}
 
 	return nil

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -160,6 +160,11 @@ func ParseOptions(parameter *string) (*options, error) {
 	if opts.transports == nil {
 		opts.transports = []Transport{grpc}
 	}
+	// Deterministic ordering potentially makes code deltas smaller.
+	sort.Slice(
+		opts.transports,
+		func(i, j int) bool { return opts.transports[i] < opts.transports[j] },
+	)
 
 	return &opts, nil
 }

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -70,6 +70,19 @@ type options struct {
 	transports        []Transport
 }
 
+// Utility function for stringifying the Transport enum
+func (t Transport) String() string {
+	switch t {
+	case grpc:
+		return "grpc"
+	case rest:
+		return "rest"
+	default:
+		// Add new transport variants as need be.
+		return fmt.Sprintf("%d", int(t))
+	}
+}
+
 // ParseOptions takes a string and parses it into a struct defining
 // customizations on the target gapic surface.
 // Options are comma-separated key/value pairs which are in turn delimited with '='.
@@ -139,7 +152,8 @@ func ParseOptions(parameter *string) (*options, error) {
 				case "rest":
 					opts.transports = append(opts.transports, rest)
 				default:
-					return nil, errors.E(nil, "invalid transport option: %s", t)
+					return nil, errors.E(nil, "invalid transport option (valid options are '%s', '%s'): %s",
+						t, grpc, rest)
 				}
 			}
 		}

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -522,7 +522,7 @@ func Test_optionsParse(t *testing.T) {
 		{
 			param: "transport=rest+grpc,go-gapic-package=path;pkg",
 			expectedOpts: &options{
-				transports: []Transport{rest, grpc},
+				transports: []Transport{grpc, rest},
 				pkgPath:    "path",
 				pkgName:    "pkg",
 				outDir:     "path",

--- a/internal/gengapic/testdata/empty_client_init.want
+++ b/internal/gengapic/testdata/empty_client_init.want
@@ -4,7 +4,8 @@ type AbstractClient interface {
 	Zip(context.Context, *mypackagepb.Bar, ...gax.CallOption) (*mypackagepb.Foo, error)
 }
 
-// Client is a client for interacting with Awesome Foo API.
+// Client is a client for interacting with Awesome Foo API over gRPC transport.
+// It satisfies the AbstractClient interface.
 //
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.
 type Client struct {

--- a/internal/gengapic/testdata/empty_client_init.want
+++ b/internal/gengapic/testdata/empty_client_init.want
@@ -1,3 +1,9 @@
+// AbstractClient is an interface that defines the methods availaible from Awesome Foo API.
+// It is agnostic as to the underlying transport, i.e. json+http, gRPC, or other.
+type AbstractClient interface {
+	Zip(context.Context, *mypackagepb.Bar, ...gax.CallOption) (*mypackagepb.Foo, error)
+}
+
 // Client is a client for interacting with Awesome Foo API.
 //
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.

--- a/internal/gengapic/testdata/foo_client_init.want
+++ b/internal/gengapic/testdata/foo_client_init.want
@@ -1,3 +1,9 @@
+// FooAbstractClient is an interface that defines the methods availaible from Awesome Foo API.
+// It is agnostic as to the underlying transport, i.e. json+http, gRPC, or other.
+type FooAbstractClient interface {
+	Zip(context.Context, *mypackagepb.Bar, ...gax.CallOption) (*mypackagepb.Foo, error)
+}
+
 // FooClient is a client for interacting with Awesome Foo API.
 //
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.

--- a/internal/gengapic/testdata/foo_client_init.want
+++ b/internal/gengapic/testdata/foo_client_init.want
@@ -4,7 +4,8 @@ type FooAbstractClient interface {
 	Zip(context.Context, *mypackagepb.Bar, ...gax.CallOption) (*mypackagepb.Foo, error)
 }
 
-// FooClient is a client for interacting with Awesome Foo API.
+// FooClient is a client for interacting with Awesome Foo API over gRPC transport.
+// It satisfies the FooAbstractClient interface.
 //
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.
 type FooClient struct {

--- a/internal/gengapic/testdata/lro_client_init.want
+++ b/internal/gengapic/testdata/lro_client_init.want
@@ -4,7 +4,8 @@ type FooAbstractClient interface {
 	Zip(context.Context, *mypackagepb.Bar, ...gax.CallOption) (*ZipOperation, error)
 }
 
-// FooClient is a client for interacting with Awesome Foo API.
+// FooClient is a client for interacting with Awesome Foo API over gRPC transport.
+// It satisfies the FooAbstractClient interface.
 //
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.
 type FooClient struct {
@@ -17,7 +18,7 @@ type FooClient struct {
 	// The gRPC API client.
 	fooClient mypackagepb.FooClient
 
-	// LROClient is used internally to handle longrunning operations.
+	// LROClient is used internally to handle long-running operations.
 	// It is exposed so that its CallOptions can be modified if required.
 	// Users should not Close this client.
 	LROClient *lroauto.OperationsClient

--- a/internal/gengapic/testdata/lro_client_init.want
+++ b/internal/gengapic/testdata/lro_client_init.want
@@ -1,3 +1,9 @@
+// FooAbstractClient is an interface that defines the methods availaible from Awesome Foo API.
+// It is agnostic as to the underlying transport, i.e. json+http, gRPC, or other.
+type FooAbstractClient interface {
+	Zip(context.Context, *mypackagepb.Bar, ...gax.CallOption) (*ZipOperation, error)
+}
+
 // FooClient is a client for interacting with Awesome Foo API.
 //
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.

--- a/showcase/go.mod
+++ b/showcase/go.mod
@@ -11,3 +11,5 @@ require (
 	google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e
 	google.golang.org/grpc v1.33.2
 )
+
+replace github.com/googleapis/gapic-showcase => ./gen/github.com/googleapis/gapic-showcase

--- a/showcase/go.mod
+++ b/showcase/go.mod
@@ -11,5 +11,3 @@ require (
 	google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e
 	google.golang.org/grpc v1.33.2
 )
-
-replace github.com/googleapis/gapic-showcase => ./gen/github.com/googleapis/gapic-showcase


### PR DESCRIPTION
The grpc client currently implements this interface, and the eventual
rest+json client will implement it as well.

The purpose of this interface is to allow runtime selection and/or
fallback between different transport types.

Further PRs will add an implementation for a rest+json client that adheres to the interface.