### PR TITLE
gapic: conditionally append pb to import alias

### DIFF
--- a/internal/gencli/gencli.go
+++ b/internal/gencli/gencli.go
@@ -622,6 +622,12 @@ func (g *gcli) getFieldBehavior(field *desc.FieldDescriptor) (output bool, requi
 
 func (g *gcli) getImport(m desc.Descriptor) (*pbinfo.ImportSpec, error) {
 	pkg := m.GetFile().GetFileOptions().GetGoPackage()
+	appendpb := func(n string) string {
+		if !strings.HasSuffix(n, "pb") {
+			n += "pb"
+		}
+		return n
+	}
 
 	// the below logic is copied from pbinfo.NameSpec()
 	if pkg == "" {
@@ -629,13 +635,13 @@ func (g *gcli) getImport(m desc.Descriptor) (*pbinfo.ImportSpec, error) {
 	}
 
 	if p := strings.IndexByte(pkg, ';'); p >= 0 {
-		return &pbinfo.ImportSpec{Path: pkg[:p], Name: pkg[p+1:] + "pb"}, nil
+		return &pbinfo.ImportSpec{Path: pkg[:p], Name: appendpb(pkg[p+1:])}, nil
 	}
 
 	for {
 		p := strings.LastIndexByte(pkg, '/')
 		if p < 0 {
-			return &pbinfo.ImportSpec{Path: pkg, Name: pkg + "pb"}, nil
+			return &pbinfo.ImportSpec{Path: pkg, Name: appendpb(pkg)}, nil
 		}
 		elem := pkg[p+1:]
 		if len(elem) >= 2 && elem[0] == 'v' && elem[1] >= '0' && elem[1] <= '9' {
@@ -643,7 +649,7 @@ func (g *gcli) getImport(m desc.Descriptor) (*pbinfo.ImportSpec, error) {
 			pkg = pkg[:p]
 			continue
 		}
-		return &pbinfo.ImportSpec{Path: pkg, Name: elem + "pb"}, nil
+		return &pbinfo.ImportSpec{Path: pkg, Name: appendpb(elem)}, nil
 	}
 }
 

--- a/internal/pbinfo/pbinfo.go
+++ b/internal/pbinfo/pbinfo.go
@@ -130,6 +130,13 @@ type ImportSpec struct {
 // The reported name is the same with how protoc-gen-go refers to e.
 // E.g. if type B is nested under A, then the name of type B is "A_B".
 func (in *Info) NameSpec(e ProtoType) (string, ImportSpec, error) {
+	appendpb := func(n string) string {
+		if !strings.HasSuffix(n, "pb") {
+			n += "pb"
+		}
+		return n
+	}
+
 	topLvl := e
 	var nameParts []string
 	for e2 := e; e2 != nil; e2 = in.ParentElement[e2] {
@@ -157,13 +164,13 @@ func (in *Info) NameSpec(e ProtoType) (string, ImportSpec, error) {
 	}
 
 	if p := strings.IndexByte(pkg, ';'); p >= 0 {
-		return name, ImportSpec{Path: pkg[:p], Name: pkg[p+1:] + "pb"}, nil
+		return name, ImportSpec{Path: pkg[:p], Name: appendpb(pkg[p+1:])}, nil
 	}
 
 	for {
 		p := strings.LastIndexByte(pkg, '/')
 		if p < 0 {
-			return name, ImportSpec{Path: pkg, Name: pkg + "pb"}, nil
+			return name, ImportSpec{Path: pkg, Name: appendpb(pkg)}, nil
 		}
 		elem := pkg[p+1:]
 		if len(elem) >= 2 && elem[0] == 'v' && elem[1] >= '0' && elem[1] <= '9' {
@@ -171,7 +178,7 @@ func (in *Info) NameSpec(e ProtoType) (string, ImportSpec, error) {
 			pkg = pkg[:p]
 			continue
 		}
-		return name, ImportSpec{Path: pkg, Name: elem + "pb"}, nil
+		return name, ImportSpec{Path: pkg, Name: appendpb(elem)}, nil
 	}
 }
 


### PR DESCRIPTION
Protobuf 3.14 changed the `go_package` of the well known types to reference those in the protobuf-go v2 project. The package names have a `pb` suffix already and our code was appending `pb` again. This stutter is a little annoying so let's not do it!

This change is also applied to the `gencli` pkg where some of the pbinfo code is copied for specific usage.