### PR TITLE
gapic: add gapic_metadata.json generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The configuration supported by the plugin option includes:
   * `module`: prefix to be stripped from the `go-gapic-package` used in the generated filenames.
      * _Note: This option is not supported from the Bazel interface._
 
-  * `metadata`: enable generation of [GapicMetadata](https://github.com/googleapis/googleapis/blob/master/gapic/metadata/gapic_metadata.proto) in JSON form.
+  * `metadata`: enable generation of [GapicMetadata](https://github.com/googleapis/googleapis/blob/master/gapic/metadata/gapic_metadata.proto) in JSON form. The default is `false`.
   
   * `grpc-service-config`: the path to a gRPC ServiceConfig JSON file.
     * This is used for client-side retry configuration in accordance with [AIP-4221](http://aip.dev/4221)
@@ -161,7 +161,7 @@ following attributes:
 
   * `sample_only`: if present, directs the generator to forgo client generation and generate only samples.
 
-  * `metadata`: if `True`, [GapicMetadata](https://github.com/googleapis/googleapis/blob/master/gapic/metadata/gapic_metadata.proto) will be generated in JSON form.
+  * `metadata`: if `True`, [GapicMetadata](https://github.com/googleapis/googleapis/blob/master/gapic/metadata/gapic_metadata.proto) will be generated in JSON form. The default is `False`.
 
 Docker Wrapper
 --------------

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ The configuration supported by the plugin option includes:
 
   * `module`: prefix to be stripped from the `go-gapic-package` used in the generated filenames.
      * _Note: This option is not supported from the Bazel interface._
+
+  * `metadata`: enable generation of [GapicMetadata](https://github.com/googleapis/googleapis/blob/master/gapic/metadata/gapic_metadata.proto) in JSON form.
   
   * `grpc-service-config`: the path to a gRPC ServiceConfig JSON file.
     * This is used for client-side retry configuration in accordance with [AIP-4221](http://aip.dev/4221)
@@ -158,6 +160,8 @@ following attributes:
     * _Note: This config is only used to generate samples._
 
   * `sample_only`: if present, directs the generator to forgo client generation and generate only samples.
+
+  * `metadata`: if `True`, [GapicMetadata](https://github.com/googleapis/googleapis/blob/master/gapic/metadata/gapic_metadata.proto) will be generated in JSON form.
 
 Docker Wrapper
 --------------

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,14 +22,6 @@ http_archive(
     ],
 )
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
-
-go_rules_dependencies()
-
-go_register_toolchains(
-    version = "1.15.6",
-)
-
 http_archive(
     name = "bazel_gazelle",
     sha256 = "b85f48fa105c4403326e9525ad2b2cc437babaa6e15a3fc0b1dbab0ab064bc7c",
@@ -39,8 +31,25 @@ http_archive(
     ],
 )
 
+load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 # gazelle:repo bazel_gazelle
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+# TODO(noahdietz): remove with next rules_go release.
+# https://github.com/googleapis/gapic-generator-go/issues/529
+go_repository(
+    name = "org_golang_google_genproto",
+    build_file_proto_mode = "disable_global",
+    importpath = "google.golang.org/genproto",
+    sum = "h1:N98SvVh7Hdle2lgUVFuIkf0B3u29CUakMUQa7Hwz8Wc=",
+    version = "v0.0.0-20210207032614-bba0dbe2a9ea",
+)
+
+go_rules_dependencies()
+
+go_register_toolchains(
+    version = "1.15.6",
+)
 
 gazelle_dependencies()
 

--- a/internal/gengapic/BUILD.bazel
+++ b/internal/gengapic/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "imports.go",
         "lro.go",
         "markdown.go",
+        "metadata.go",
         "options.go",
         "paging.go",
         "stream.go",
@@ -33,6 +34,8 @@ go_library(
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
+        "@org_golang_google_genproto//googleapis/gapic/metadata",
+        "@org_golang_google_protobuf//encoding/protojson",
     ],
 )
 
@@ -45,6 +48,7 @@ go_test(
         "gengapic_test.go",
         "helpers_test.go",
         "markdown_test.go",
+        "metadata_test.go",
         "options_test.go",
         "paging_test.go",
     ],
@@ -63,6 +67,7 @@ go_test(
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
         "@io_bazel_rules_go//proto/wkt:duration_go_proto",
         "@io_bazel_rules_go//proto/wkt:wrappers_go_proto",
+        "@org_golang_google_genproto//googleapis/gapic/metadata",
         "@org_golang_google_protobuf//encoding/protojson",
     ],
 )

--- a/internal/gengapic/generator.go
+++ b/internal/gengapic/generator.go
@@ -27,6 +27,7 @@ import (
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"github.com/googleapis/gapic-generator-go/internal/printer"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
+	metadatapb "google.golang.org/genproto/googleapis/gapic/metadata"
 )
 
 type generator struct {
@@ -63,10 +64,20 @@ type generator struct {
 	// Options for the generator determining module names, transports,
 	// config file paths, etc.
 	opts *options
+
+	// GapicMetadata for recording proto-to-code mappings in a
+	// gapic_metadata.json file.
+	metadata *metadatapb.GapicMetadata
 }
 
 func (g *generator) init(files []*descriptor.FileDescriptorProto) {
 	g.descInfo = pbinfo.Of(files)
+	g.metadata = &metadatapb.GapicMetadata{
+		Schema:   "1.0",
+		Language: "go",
+		Comment:  "This file maps proto services/RPCs to the corresponding library clients/methods.",
+		Services: make(map[string]*metadatapb.GapicMetadata_ServiceForTransport),
+	}
 
 	g.comments = map[proto.Message]string{}
 	g.imports = map[pbinfo.ImportSpec]bool{}

--- a/internal/gengapic/metadata.go
+++ b/internal/gengapic/metadata.go
@@ -1,0 +1,52 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gengapic
+
+import (
+	"google.golang.org/genproto/googleapis/gapic/metadata"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func (g *generator) genGapicMetadataFile() error {
+	data, err := protojson.MarshalOptions{Multiline: true}.Marshal(g.metadata)
+	if err != nil {
+		return err
+	}
+
+	g.pt.Printf("%s", data)
+	return nil
+}
+
+func (g *generator) addMetadataServiceForTransport(service, transport, lib string) {
+	s, ok := g.metadata.GetServices()[service]
+	if !ok {
+		s = &metadata.GapicMetadata_ServiceForTransport{
+			Clients: make(map[string]*metadata.GapicMetadata_ServiceAsClient),
+		}
+		g.metadata.Services[service] = s
+	}
+
+	s.Clients[transport] = &metadata.GapicMetadata_ServiceAsClient{
+		LibraryClient: lib,
+		Rpcs:          make(map[string]*metadata.GapicMetadata_MethodList),
+	}
+}
+
+func (g *generator) addMetadataMethod(service, transport, rpc string) {
+	// There is only one method per RPC on a generated Go client, with the same name as the RPC.
+	g.metadata.GetServices()[service].GetClients()[transport].GetRpcs()[rpc] = &metadata.GapicMetadata_MethodList{
+		Methods: []string{rpc},
+	}
+}

--- a/internal/gengapic/metadata_test.go
+++ b/internal/gengapic/metadata_test.go
@@ -1,0 +1,172 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gengapic
+
+import (
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genproto/googleapis/gapic/metadata"
+	metadatapb "google.golang.org/genproto/googleapis/gapic/metadata"
+)
+
+func TestAddMetadataServiceForTransport(t *testing.T) {
+	for _, tst := range []struct {
+		service, lib string
+		init, want   *metadatapb.GapicMetadata
+	}{
+		{
+			service: "LibraryService",
+			lib:     "LibraryServiceClient",
+			init: &metadatapb.GapicMetadata{
+				Services: make(map[string]*metadatapb.GapicMetadata_ServiceForTransport),
+			},
+			want: &metadatapb.GapicMetadata{
+				Services: map[string]*metadatapb.GapicMetadata_ServiceForTransport{
+					"LibraryService": {
+						Clients: map[string]*metadatapb.GapicMetadata_ServiceAsClient{
+							"grpc": {
+								LibraryClient: "LibraryServiceClient",
+								Rpcs:          make(map[string]*metadata.GapicMetadata_MethodList),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			service: "LibraryService",
+			lib:     "LibraryServiceClient",
+			init: &metadatapb.GapicMetadata{
+				Services: map[string]*metadatapb.GapicMetadata_ServiceForTransport{
+					"LibraryService": {
+						Clients: map[string]*metadatapb.GapicMetadata_ServiceAsClient{
+							"rest": {
+								LibraryClient: "LibraryServiceRestClient",
+								Rpcs:          make(map[string]*metadata.GapicMetadata_MethodList),
+							},
+						},
+					},
+				},
+			},
+			want: &metadatapb.GapicMetadata{
+				Services: map[string]*metadatapb.GapicMetadata_ServiceForTransport{
+					"LibraryService": {
+						Clients: map[string]*metadatapb.GapicMetadata_ServiceAsClient{
+							"grpc": {
+								LibraryClient: "LibraryServiceClient",
+								Rpcs:          make(map[string]*metadata.GapicMetadata_MethodList),
+							},
+							"rest": {
+								LibraryClient: "LibraryServiceRestClient",
+								Rpcs:          make(map[string]*metadata.GapicMetadata_MethodList),
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		g := generator{
+			metadata: tst.init,
+		}
+		g.addMetadataServiceForTransport(tst.service, "grpc", tst.lib)
+
+		if diff := cmp.Diff(g.metadata, tst.want, cmp.Comparer(proto.Equal)); diff != "" {
+			t.Errorf("addMetadataServiceForTransport(%q, %q, %q): got(-),want(+):\n%s", tst.service, "grpc", tst.lib, diff)
+		}
+	}
+}
+
+func TestAddMetadataMethod(t *testing.T) {
+	for _, tst := range []struct {
+		service, rpc string
+		init, want   *metadatapb.GapicMetadata
+	}{
+		{
+			service: "LibraryService",
+			rpc:     "GetBook",
+			init: &metadatapb.GapicMetadata{
+				Services: map[string]*metadatapb.GapicMetadata_ServiceForTransport{
+					"LibraryService": {
+						Clients: map[string]*metadatapb.GapicMetadata_ServiceAsClient{
+							"grpc": {
+								LibraryClient: "LibraryServiceClient",
+								Rpcs:          make(map[string]*metadata.GapicMetadata_MethodList),
+							},
+						},
+					},
+				},
+			},
+			want: &metadatapb.GapicMetadata{
+				Services: map[string]*metadatapb.GapicMetadata_ServiceForTransport{
+					"LibraryService": {
+						Clients: map[string]*metadatapb.GapicMetadata_ServiceAsClient{
+							"grpc": {
+								LibraryClient: "LibraryServiceClient",
+								Rpcs: map[string]*metadata.GapicMetadata_MethodList{
+									"GetBook": {Methods: []string{"GetBook"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			service: "LibraryService",
+			rpc:     "GetBook",
+			init: &metadatapb.GapicMetadata{
+				Services: map[string]*metadatapb.GapicMetadata_ServiceForTransport{
+					"LibraryService": {
+						Clients: map[string]*metadatapb.GapicMetadata_ServiceAsClient{
+							"grpc": {
+								LibraryClient: "LibraryServiceClient",
+								Rpcs: map[string]*metadata.GapicMetadata_MethodList{
+									"ListBooks": {Methods: []string{"ListBooks"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: &metadatapb.GapicMetadata{
+				Services: map[string]*metadatapb.GapicMetadata_ServiceForTransport{
+					"LibraryService": {
+						Clients: map[string]*metadatapb.GapicMetadata_ServiceAsClient{
+							"grpc": {
+								LibraryClient: "LibraryServiceClient",
+								Rpcs: map[string]*metadata.GapicMetadata_MethodList{
+									"GetBook":   {Methods: []string{"GetBook"}},
+									"ListBooks": {Methods: []string{"ListBooks"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	} {
+		g := generator{
+			metadata: tst.init,
+		}
+		g.addMetadataMethod(tst.service, "grpc", tst.rpc)
+
+		if diff := cmp.Diff(g.metadata, tst.want, cmp.Comparer(proto.Equal)); diff != "" {
+			t.Errorf("addMetadataMethod(%q, %q, %q): got(-),want(+):\n%s", tst.service, "grpc", tst.rpc, diff)
+		}
+	}
+}

--- a/internal/gengapic/options.go
+++ b/internal/gengapic/options.go
@@ -74,7 +74,8 @@ func parseOptions(parameter *string) (*options, error) {
 		// check for the boolean flag, sample-only, that disables client generation
 		if s == "sample-only" {
 			return &options{sampleOnly: true}, nil
-		} else if s == "metadata" {
+		}
+		if s == "metadata" {
 			opts.metadata = true
 			continue
 		}

--- a/internal/gengapic/options.go
+++ b/internal/gengapic/options.go
@@ -40,6 +40,7 @@ type options struct {
 	serviceConfigPath string
 	sampleOnly        bool
 	transports        []transport
+	metadata          bool
 }
 
 // parseOptions takes a string and parses it into a struct defining
@@ -53,6 +54,7 @@ type options struct {
 // * module (name)
 // * release-level (one of 'alpha', 'beta', or empty)
 // * transport ('+' separated list of transport backends to generate)
+// * metadata (enable GAPIC metadata generation)
 // The only required option is 'go-gapic-package'.
 //
 // Valid parameter example:
@@ -72,6 +74,9 @@ func parseOptions(parameter *string) (*options, error) {
 		// check for the boolean flag, sample-only, that disables client generation
 		if s == "sample-only" {
 			return &options{sampleOnly: true}, nil
+		} else if s == "metadata" {
+			opts.metadata = true
+			continue
 		}
 
 		e := strings.IndexByte(s, '=')

--- a/internal/gengapic/options_test.go
+++ b/internal/gengapic/options_test.go
@@ -55,6 +55,16 @@ func TestParseOptions(t *testing.T) {
 			},
 		},
 		{
+			param: "metadata,go-gapic-package=path;pkg",
+			expectedOpts: &options{
+				transports: []transport{grpc},
+				pkgPath:    "path",
+				pkgName:    "pkg",
+				outDir:     "path",
+				metadata:   true,
+			},
+		},
+		{
 			param: "module=path,go-gapic-package=path/to/out;pkg",
 			expectedOpts: &options{
 				transports:   []transport{grpc},

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -233,12 +233,15 @@ def com_googleapis_gapic_generator_go_repositories():
         sum = "h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=",
         version = "v1.4.0",
     )
-    go_repository(
-        name = "org_golang_google_genproto",
-        importpath = "google.golang.org/genproto",
-        sum = "h1:N98SvVh7Hdle2lgUVFuIkf0B3u29CUakMUQa7Hwz8Wc=",
-        version = "v0.0.0-20210207032614-bba0dbe2a9ea",
-    )
+    # TODO(noahdietz): replace with next rules_go release.
+    # https://github.com/googleapis/gapic-generator-go/issues/529
+    #
+    # go_repository(
+    #     name = "org_golang_google_genproto",
+    #     importpath = "google.golang.org/genproto",
+    #     sum = "h1:N98SvVh7Hdle2lgUVFuIkf0B3u29CUakMUQa7Hwz8Wc=",
+    #     version = "v0.0.0-20210207032614-bba0dbe2a9ea",
+    # )
     go_repository(
         name = "org_golang_google_grpc",
         importpath = "google.golang.org/grpc",

--- a/rules_go_gapic/go_gapic.bzl
+++ b/rules_go_gapic/go_gapic.bzl
@@ -86,6 +86,7 @@ def go_gapic_library(
   gapic_yaml = None,
   samples = [],
   sample_only = False,
+  metadata = False,
   **kwargs):
 
   file_args = {}
@@ -112,6 +113,9 @@ def go_gapic_library(
 
   if sample_only:
     plugin_args.append("sample-only")
+
+  if metadata:
+    plugin_args.append("metadata")
 
   srcjar_name = name+"_srcjar"
   raw_srcjar_name = srcjar_name+"_raw"


### PR DESCRIPTION
Adds generation of  the `gapic_metadata.json` file containing the proto-to-client mapping of the generated code.

The schema for GAPIC Metadata is defined in [googleapis](https://github.com/googleapis/googleapis/blob/master/gapic/metadata/gapic_metadata.proto).

Enable generation via the plugin option `metadata`. See README for more info.

Note: I needed to override the `go-genproto` dependency because `rules_go` brings an older version that is missing the `GapicMetadata` proto. See #529.