### PR TITLE
bazel: ignore metadata.srcjar if disabled

### DIFF
--- a/rules_go_gapic/go_gapic.bzl
+++ b/rules_go_gapic/go_gapic.bzl
@@ -194,12 +194,13 @@ def go_gapic_library(
     **kwargs
   )
 
-  metadata_file = ":%s-metadata.srcjar" % srcjar_name
-  metadata_dir = "%s_metadata" % srcjar_name
+  if metadata:
+    metadata_file = ":%s-metadata.srcjar" % srcjar_name
+    metadata_dir = "%s_metadata" % srcjar_name
 
-  unzipped_srcjar(
-    name = metadata_dir,
-    srcjar = metadata_file,
-    extension = ".json",
-    **kwargs
-  )
+    unzipped_srcjar(
+      name = metadata_dir,
+      srcjar = metadata_file,
+      extension = ".json",
+      **kwargs
+    )


### PR DESCRIPTION
Don't attempt to unzip the metadata srcjar if metadata generation was disabled as the archive will be empty and produce an error.