### PR TITLE
gapic: fix empty libraryClient in metadata

### DIFF
--- a/internal/gengapic/metadata.go
+++ b/internal/gengapic/metadata.go
@@ -38,6 +38,15 @@ func (g *generator) addMetadataServiceForTransport(service, transport, lib strin
 		g.metadata.Services[service] = s
 	}
 
+	// When the Service name matches the package name, the client is named just
+	// "Client". We need to catch that.
+	//
+	// TODO(noahdietz): when REGAPIC is added we may need to special case based
+	// on transport.
+	if lib == "" {
+		lib = "Client"
+	}
+
 	s.Clients[transport] = &metadata.GapicMetadata_ServiceAsClient{
 		LibraryClient: lib,
 		Rpcs:          make(map[string]*metadata.GapicMetadata_MethodList),

--- a/internal/gengapic/metadata_test.go
+++ b/internal/gengapic/metadata_test.go
@@ -79,6 +79,38 @@ func TestAddMetadataServiceForTransport(t *testing.T) {
 				},
 			},
 		},
+		{
+			service: "LibraryService",
+			lib:     "",
+			init: &metadatapb.GapicMetadata{
+				Services: map[string]*metadatapb.GapicMetadata_ServiceForTransport{
+					"LibraryService": {
+						Clients: map[string]*metadatapb.GapicMetadata_ServiceAsClient{
+							"rest": {
+								LibraryClient: "LibraryServiceRestClient",
+								Rpcs:          make(map[string]*metadata.GapicMetadata_MethodList),
+							},
+						},
+					},
+				},
+			},
+			want: &metadatapb.GapicMetadata{
+				Services: map[string]*metadatapb.GapicMetadata_ServiceForTransport{
+					"LibraryService": {
+						Clients: map[string]*metadatapb.GapicMetadata_ServiceAsClient{
+							"grpc": {
+								LibraryClient: "Client",
+								Rpcs:          make(map[string]*metadata.GapicMetadata_MethodList),
+							},
+							"rest": {
+								LibraryClient: "LibraryServiceRestClient",
+								Rpcs:          make(map[string]*metadata.GapicMetadata_MethodList),
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		g := generator{
 			metadata: tst.init,


### PR DESCRIPTION
Sometimes, when the `package` name matches the reduced service name (the proto Service name sans `"Service"` suffix), the generated client type is named `Client` as the `servName` variable is `""`.

This accounts for that with the metadata generation.