### PR TITLE
gapic: fix metadata libraryClient naming

### DIFF
--- a/internal/gengapic/metadata.go
+++ b/internal/gengapic/metadata.go
@@ -38,14 +38,12 @@ func (g *generator) addMetadataServiceForTransport(service, transport, lib strin
 		g.metadata.Services[service] = s
 	}
 
-	// When the Service name matches the package name, the client is named just
-	// "Client". We need to catch that.
+	// The "Client" part of the generated type's name is hard coded in the
+	// generator so we need to append it to the lib name.
 	//
 	// TODO(noahdietz): when REGAPIC is added we may need to special case based
 	// on transport.
-	if lib == "" {
-		lib = "Client"
-	}
+	lib += "Client"
 
 	s.Clients[transport] = &metadata.GapicMetadata_ServiceAsClient{
 		LibraryClient: lib,

--- a/internal/gengapic/metadata_test.go
+++ b/internal/gengapic/metadata_test.go
@@ -30,7 +30,7 @@ func TestAddMetadataServiceForTransport(t *testing.T) {
 	}{
 		{
 			service: "LibraryService",
-			lib:     "LibraryServiceClient",
+			lib:     "LibraryService",
 			init: &metadatapb.GapicMetadata{
 				Services: make(map[string]*metadatapb.GapicMetadata_ServiceForTransport),
 			},
@@ -49,7 +49,7 @@ func TestAddMetadataServiceForTransport(t *testing.T) {
 		},
 		{
 			service: "LibraryService",
-			lib:     "LibraryServiceClient",
+			lib:     "LibraryService",
 			init: &metadatapb.GapicMetadata{
 				Services: map[string]*metadatapb.GapicMetadata_ServiceForTransport{
 					"LibraryService": {


### PR DESCRIPTION
The `Client` suffix of the generated client's type is hardcoded everywhere in the generator's printing logic. We need to append it any entry we are given, including `""`. 