### PR TITLE
gcli: fix a crash in generated CLIs.

### DIFF
--- a/internal/gencli/cmd_file.go
+++ b/internal/gencli/cmd_file.go
@@ -190,6 +190,9 @@ var {{$methodCmdVar}} = &cobra.Command{
 		}
 		{{ end }}
 		{{ if .IsMap }}
+		if len({{ .VarName }}) > 0 {
+			{{ .SliceAccessor }} = make(map[string]string)
+		}
 		for _, item := range {{ .VarName }} {
 			split := strings.Split(item, "=")
 			if len(split) < 2 {


### PR DESCRIPTION
When a message contains a `map<string,string>` field, the generated CLI allows map values to be set by accepting multiple options of the form:

```--parent.mapname "key=value"```

However, when these options are provided, the CLI crashes because the generated CLI attempts to store them in a map that hasn't been created yet. The map insertions crash because the map field is nil.

This commit adds code that creates maps if one or more of the options illustrated above is provided. With these maps, the associated API calls are made successfully.