### PR TITLE
chore: clean up linter warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,11 +20,13 @@ jobs:
       run: go get -u golang.org/x/lint/golint
       if: ${{ always() }}
     - name: Lint
+      # Exclude all gensample code and the grpc_service_config package (it is generated).
       run: golint -set_exit_status $(go list ./... | grep -v 'sample\|grpc_service_config') > golint.txt
       if: ${{ always() }}
     - name: Vet
       # The mod download is there to prevent go vet from logging mod downloads
       # which would mess up the empty vetting results check.
+      # Exclude all gensample code and the grpc_service_config package (it is generated).
       run: go mod download && go vet $(go list ./... | grep -v 'sample\|grpc_service_config') > govet.txt && ! [ -s govet.txt ]
       if: ${{ always() }}
     - name: Check license

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,14 +14,30 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '^1.13.1'
-
-    # TODO(noahdietz): fix all lint errors then enable this.
-    # - name: Install golangci-lint
-    #   run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin latest
-    # - name: Run golangci-lint
-    #   run: golangci-lint run ./...
+    - name: Check formatting
+      run: gofmt -l ./ > gofmt.txt && ! [ -s gofmt.txt ]
+    - name: Install golint
+      run: go get -u golang.org/x/lint/golint
+      if: ${{ always() }}
+    - name: Lint
+      run: golint -set_exit_status $(go list ./... | grep -v 'sample\|grpc_service_config') > golint.txt
+      if: ${{ always() }}
+    - name: Vet
+      # The mod download is there to prevent go vet from logging mod downloads
+      # which would mess up the empty vetting results check.
+      run: go mod download && go vet $(go list ./... | grep -v 'sample\|grpc_service_config') > govet.txt && ! [ -s govet.txt ]
+      if: ${{ always() }}
     - name: Check license
       run: go run ./util/cmd/license
+      if: ${{ always() }}
+    - uses: actions/upload-artifact@v2
+      if: ${{ always() }}
+      with:
+        name: linting-results
+        path: |
+          gofmt.txt
+          golint.txt
+          govet.txt
   unit-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ perf.data*
 showcase/gen
 showcase/gapic-showcase
 showcase/showcase_grpc_service_config.json
+gofmt.txt
+golint.txt
+govet.txt
 
 # Jetbrains
 .idea/

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -32,6 +32,7 @@ func (e myErr) Error() string {
 	return s
 }
 
+// E creates a new error with the given cause and message.
 func E(cause error, s string, a ...interface{}) error {
 	return myErr{
 		str: fmt.Sprintf(s, a...),

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -46,7 +46,7 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 		p("}")
 		p("")
 
-		g.imports[pbinfo.ImportSpec{"gax", "github.com/googleapis/gax-go/v2"}] = true
+		g.imports[pbinfo.ImportSpec{Name: "gax", Path: "github.com/googleapis/gax-go/v2"}] = true
 	}
 
 	// defaultClientOptions

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -115,7 +115,7 @@ func TestClientOpt(t *testing.T) {
 
 	g.descInfo = pbinfo.Info{
 		ParentFile: map[proto.Message]*descriptor.FileDescriptorProto{
-			serv: &descriptor.FileDescriptorProto{
+			serv: {
 				Package: proto.String("bar"),
 			},
 		},
@@ -193,7 +193,7 @@ func TestClientInit(t *testing.T) {
 		{tstName: "lro_client_init", servName: "Foo", serv: servLRO},
 	} {
 		g.descInfo.ParentFile = map[proto.Message]*descriptor.FileDescriptorProto{
-			tst.serv: &descriptor.FileDescriptorProto{
+			tst.serv: {
 				Options: &descriptor.FileOptions{
 					GoPackage: proto.String("mypackage"),
 				},

--- a/internal/gengapic/example_test.go
+++ b/internal/gengapic/example_test.go
@@ -169,12 +169,12 @@ func commonTypes(g *generator) {
 		lroType:   lro,
 	}
 	g.descInfo.ParentFile = map[proto.Message]*descriptor.FileDescriptorProto{
-		empty: &descriptor.FileDescriptorProto{
+		empty: {
 			Options: &descriptor.FileOptions{
 				GoPackage: proto.String("github.com/golang/protobuf/ptypes/empty"),
 			},
 		},
-		lro: &descriptor.FileDescriptorProto{
+		lro: {
 			Options: &descriptor.FileOptions{
 				GoPackage: proto.String("google.golang.org/genproto/googleapis/longrunning;longrunning"),
 			},

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -47,6 +47,7 @@ const (
 
 var headerParamRegexp = regexp.MustCompile(`{([_.a-z0-9]+)`)
 
+// Gen is the entry point for GAPIC generation via the protoc plugin.
 func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, error) {
 	var g generator
 	g.init(genReq.ProtoFile)
@@ -461,7 +462,7 @@ func (g *generator) comment(s string) {
 		return
 	}
 
-	s = MDPlain(s)
+	s = mdPlain(s)
 
 	lines := strings.Split(s, "\n")
 	for _, l := range lines {

--- a/internal/gengapic/markdown.go
+++ b/internal/gengapic/markdown.go
@@ -29,7 +29,7 @@ import (
 var linkParser = regexp.MustCompile(`<a href=["'](.+)["']`)
 var referenceParser = regexp.MustCompile(`\[([a-zA-Z1-9._]+)\]\[[a-zA-Z1-9._]*\]`)
 
-func MDPlain(s string) string {
+func mdPlain(s string) string {
 	var mdr mdRenderer
 	for _, tok := range markdown.New(markdown.HTML(true)).Parse([]byte(s)) {
 		mdr.plain(tok)

--- a/internal/gengapic/markdown_test.go
+++ b/internal/gengapic/markdown_test.go
@@ -78,7 +78,7 @@ func TestMDPlain(t *testing.T) {
 			want: "link to a search engine (at https://www.google.com) with request type Search, bizbuz.",
 		},
 	} {
-		got := MDPlain(tst.in)
+		got := mdPlain(tst.in)
 		if got != tst.want {
 			t.Errorf("MDPlain(%q)=%q, want %q", tst.in, got, tst.want)
 		}

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -167,7 +167,7 @@ func TestIterTypeOf(t *testing.T) {
 			},
 			ParentElement: map[pbinfo.ProtoType]pbinfo.ProtoType{},
 			ParentFile: map[proto.Message]*descriptor.FileDescriptorProto{
-				msgType: &descriptor.FileDescriptorProto{
+				msgType: {
 					Options: &descriptor.FileOptions{
 						GoPackage: proto.String("path/to/foo;foo"),
 					},

--- a/internal/pbinfo/pbinfo.go
+++ b/internal/pbinfo/pbinfo.go
@@ -121,6 +121,7 @@ func addMessage(typMap map[string]ProtoType, parentMap map[ProtoType]ProtoType, 
 	}
 }
 
+// ImportSpec represents a Go module import path and an optional alias.
 type ImportSpec struct {
 	Name, Path string
 }

--- a/internal/pbinfo/prim2go.go
+++ b/internal/pbinfo/prim2go.go
@@ -16,6 +16,7 @@ package pbinfo
 
 import "github.com/golang/protobuf/protoc-gen-go/descriptor"
 
+// GoTypeForPrim maps protobuf primitive types to Go primitive types.
 var GoTypeForPrim = map[descriptor.FieldDescriptorProto_Type]string{
 	descriptor.FieldDescriptorProto_TYPE_DOUBLE:   "float64",
 	descriptor.FieldDescriptorProto_TYPE_FLOAT:    "float32",

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 )
 
+// P represents a buffer for print code that tracks indentation.
 type P struct {
 	buf    bytes.Buffer
 	indent int
@@ -80,6 +81,7 @@ func (p *P) String() string {
 	return p.buf.String()
 }
 
+// Len returns the length of the printer buffer.
 func (p *P) Len() int {
 	return p.buf.Len()
 }


### PR DESCRIPTION
* clean up linter warnings in codebase
* add `go fmt` `golint` and `go vet` steps to the `lint` job
* upload linter reports in CI
* gitignore linter reports