### PR TITLE
chore: ignore vs code workspace files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ Session.vim
 
 # Bazel directories
 bazel-*
+
+# VS Code workspace
+*.code-workspace

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ golden:
 	go test github.com/googleapis/gapic-generator-go/internal/gengapic -update_golden
 
 test:
-	go test ./...
+	go test -mod=mod ./...
 	go install ./cmd/protoc-gen-go_gapic
 	cd showcase; ./showcase.bash; cd ..
 	./test.sh

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -60,5 +60,5 @@ cleanup() {
 }
 trap cleanup EXIT
 
-go test -count=1 ./...
+go test -mod=mod -count=1 ./...
 exit_code=$?


### PR DESCRIPTION
Ignore VS Code Workspace files and also add `-mod=mod` to some test targets that failed due to some on-the-fly go.mod/go.sum changes.