### PR TITLE
gapic: ignore empty plugin flags

### DIFF
--- a/internal/gengapic/options.go
+++ b/internal/gengapic/options.go
@@ -71,6 +71,10 @@ func parseOptions(parameter *string) (*options, error) {
 
 	// parse plugin params, ignoring unknown values
 	for _, s := range strings.Split(*parameter, ",") {
+		// skip empty --go_gapic_opt flags
+		if s == "" {
+			continue
+		}
 		// check for the boolean flag, sample-only, that disables client generation
 		if s == "sample-only" {
 			return &options{sampleOnly: true}, nil

--- a/internal/gengapic/options_test.go
+++ b/internal/gengapic/options_test.go
@@ -95,6 +95,18 @@ func TestParseOptions(t *testing.T) {
 			param:     "module=different_path,go-gapic-package=path;pkg",
 			expectErr: true,
 		},
+		{
+			// Test empty parameter in the CSV.
+			param: "go-gapic-package=path/to/imp;pkg,,module=path",
+			expectedOpts: &options{
+				transports:   []transport{grpc},
+				pkgPath:      "path/to/imp",
+				pkgName:      "pkg",
+				outDir:       "to/imp",
+				modulePrefix: "path",
+			},
+			expectErr: false,
+		},
 	} {
 		opts, err := parseOptions(&tst.param)
 		if tst.expectErr && err == nil {


### PR DESCRIPTION
Sometimes, a caller of the plugin will provide an empty plugin option flag `--go_gapic_opt=` which ends up in the comma-separated value `parameter` like `foo=foo,,bar=bar` and the option parser would report an invalid flag. They should just be ignored instead, which makes it easier on wrapper scripts, etc.

Fixes #558 

cc: @mscno 