### PR TITLE
gapic: fix link in ctx docs

### DIFF
--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -71,7 +71,7 @@ func (g *generator) genDocFile(year int, scopes []string) {
 	p("// To close the open connection, use the Close() method.")
 	p("//")
 	p("// For information about setting deadlines, reusing contexts, and more")
-	p("// please visit pkg.go.dev/cloud.google.com/go.")
+	p("// please visit https://pkg.go.dev/cloud.google.com/go.")
 	p("package %s // import %q", g.opts.pkgName, g.opts.pkgPath)
 	p("")
 

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -29,7 +29,7 @@
 // To close the open connection, use the Close() method.
 //
 // For information about setting deadlines, reusing contexts, and more
-// please visit pkg.go.dev/cloud.google.com/go.
+// please visit https://pkg.go.dev/cloud.google.com/go.
 package awesome // import "path/to/awesome"
 
 import (

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -31,7 +31,7 @@
 // To close the open connection, use the Close() method.
 //
 // For information about setting deadlines, reusing contexts, and more
-// please visit pkg.go.dev/cloud.google.com/go.
+// please visit https://pkg.go.dev/cloud.google.com/go.
 package awesome // import "path/to/awesome"
 
 import (

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -31,7 +31,7 @@
 // To close the open connection, use the Close() method.
 //
 // For information about setting deadlines, reusing contexts, and more
-// please visit pkg.go.dev/cloud.google.com/go.
+// please visit https://pkg.go.dev/cloud.google.com/go.
 package awesome // import "path/to/awesome"
 
 import (


### PR DESCRIPTION
The godoc link was fixed in #412 but it was still missing `https://` which means godoc doesn't render it as a hyperlink.

Fixes #563 