### PR TITLE
gapic: parse markdown in pkg doc string

### DIFF
--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -41,7 +41,9 @@ func (g *generator) genDocFile(year int, scopes []string) {
 	}
 
 	if g.serviceConfig != nil && g.serviceConfig.GetDocumentation() != nil {
-		wrapped := wrapString(g.serviceConfig.GetDocumentation().GetSummary(), 75)
+		summary := g.serviceConfig.GetDocumentation().GetSummary()
+		summary = mdPlain(summary)
+		wrapped := wrapString(summary, 75)
 
 		if len(wrapped) > 0 && g.apiName != "" {
 			p("//")

--- a/internal/gengapic/doc_file_test.go
+++ b/internal/gengapic/doc_file_test.go
@@ -27,7 +27,7 @@ func TestDocFile(t *testing.T) {
 	g.apiName = "Awesome Foo API"
 	g.serviceConfig = &serviceconfig.Service{
 		Documentation: &serviceconfig.Documentation{
-			Summary: "The Awesome Foo API is really really awesome. It enables the use of Foo with Buz and Baz to acclerate bar.",
+			Summary: "The Awesome Foo API is really really awesome. It enables the use of [Foo](https://api.foo.com) with [Buz](https://api.buz.com) and [Baz](https://api.baz.com) to acclerate `bar`.",
 		},
 	}
 	g.opts = &options{pkgPath: "path/to/awesome", pkgName: "awesome"}

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -18,7 +18,8 @@
 // Awesome Foo API.
 //
 // The Awesome Foo API is really really awesome. It enables the use of Foo
-// with Buz and Baz to acclerate bar.
+// (at https://api.foo.com) with Buz (at https://api.buz.com) and Baz (at
+// https://api.baz.com) to acclerate bar.
 //
 // Use of Context
 //

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -18,7 +18,8 @@
 // Awesome Foo API.
 //
 // The Awesome Foo API is really really awesome. It enables the use of Foo
-// with Buz and Baz to acclerate bar.
+// (at https://api.foo.com) with Buz (at https://api.buz.com) and Baz (at
+// https://api.baz.com) to acclerate bar.
 //
 //   NOTE: This package is in alpha. It is not stable, and is likely to change.
 //

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -18,7 +18,8 @@
 // Awesome Foo API.
 //
 // The Awesome Foo API is really really awesome. It enables the use of Foo
-// with Buz and Baz to acclerate bar.
+// (at https://api.foo.com) with Buz (at https://api.buz.com) and Baz (at
+// https://api.baz.com) to acclerate bar.
 //
 //   NOTE: This package is in beta. It is not stable, and may be subject to changes.
 //


### PR DESCRIPTION
Some APIs include markdown in their API Service config documentation summary section - the field that is used as the Go package documentation. It should be parsed for markdown just like the proto RPC comments.

Fixes #562 