### PR TITLE
chore: change bazel go update job filter

### DIFF
--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -2,11 +2,12 @@
 name: Generator dependency management
 on:
   push:
-    branches:
-      - master
+    paths:
+      - go.mod
+      - go.sum
 jobs:
+  if: github.ref == 'refs/heads/master'
   update-bazel-deps:
-    if: github.actor == 'renovate-bot'
     outputs:
       changed: ${{ steps.update.outputs.changed }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Changes the workflow filter to run on any change to `go.mod` or `go.sum`, but the job only runs when the workflow is referencing `master` i.e. when a dep update lands on `master`.