### PR TITLE
gapic: gen mixins based on http rules

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -282,28 +282,7 @@ func (g *generator) grpcClientInit(serv *descriptor.ServiceDescriptorProto, serv
 		g.imports[pbinfo.ImportSpec{Name: "lroauto", Path: "cloud.google.com/go/longrunning/autogen"}] = true
 	}
 
-	if g.hasLROMixin() {
-		p("operationsClient longrunningpb.OperationsClient")
-		p("")
-
-		g.imports[pbinfo.ImportSpec{Name: "longrunningpb", Path: "google.golang.org/genproto/googleapis/longrunning"}] = true
-	}
-
-	if g.hasIAMPolicyMixin() {
-
-		p("iamPolicyClient iampb.IAMPolicyClient")
-		p("")
-
-		g.imports[pbinfo.ImportSpec{Name: "iampb", Path: "google.golang.org/genproto/googleapis/iam/v1"}] = true
-	}
-
-	if g.hasLocationMixin() {
-
-		p("locationsClient locationpb.LocationsClient")
-		p("")
-
-		g.imports[pbinfo.ImportSpec{Name: "locationpb", Path: "google.golang.org/genproto/googleapis/cloud/location"}] = true
-	}
+	g.mixinStubs()
 
 	p("// The x-goog-* metadata to be sent with each request.")
 	p("xGoogMetadata metadata.MD")
@@ -355,15 +334,7 @@ func (g *generator) grpcClientUtilities(serv *descriptor.ServiceDescriptorProto,
 	p("    disableDeadlines: disableDeadlines,")
 	p("    %s: %s.New%sClient(connPool),", grpcClientField(servName), imp.Name, serv.GetName())
 	p("    CallOptions: &client.CallOptions,")
-	if g.hasLROMixin() {
-		p("    operationsClient: longrunningpb.NewOperationsClient(connPool),")
-	}
-	if g.hasIAMPolicyMixin() {
-		p("    iamPolicyClient: iampb.NewIAMPolicyClient(connPool),")
-	}
-	if g.hasLocationMixin() {
-		p("    locationsClient: locationpb.NewLocationsClient(connPool),")
-	}
+	g.mixinStubsInit()
 	p("")
 	p("  }")
 	p("  c.setGoogleClientInfo()")

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -50,10 +50,10 @@ func TestClientHook(t *testing.T) {
 func TestClientOpt(t *testing.T) {
 	var g generator
 	g.imports = map[pbinfo.ImportSpec]bool{}
-	g.mixins = map[string]bool{
-		"google.longrunning.Operations":   true,
-		"google.cloud.location.Locations": true,
-		"google.iam.v1.IAMPolicy":         true,
+	g.mixins = mixins{
+		"google.longrunning.Operations":   operationsMethods(),
+		"google.cloud.location.Locations": locationMethods(),
+		"google.iam.v1.IAMPolicy":         iamPolicyMethods(),
 	}
 	g.serviceConfig = &serviceconfig.Service{
 		Apis: []*apipb.Api{
@@ -220,18 +220,17 @@ func TestClientInit(t *testing.T) {
 			{Name: proto.String("Zip"), InputType: proto.String(".mypackage.Bar"), OutputType: proto.String(".google.longrunning.Operation")},
 		},
 	}
-
 	for _, tst := range []struct {
 		tstName  string
 		servName string
-		mixins   map[string]bool
+		mixins   mixins
 		serv     *descriptor.ServiceDescriptorProto
 	}{
 		{
 			tstName: "foo_client_init",
-			mixins: map[string]bool{
-				"google.cloud.location.Locations": true,
-				"google.iam.v1.IAMPolicy":         true,
+			mixins: mixins{
+				"google.cloud.location.Locations": locationMethods(),
+				"google.iam.v1.IAMPolicy":         iamPolicyMethods(),
 			},
 			servName: "Foo",
 			serv:     servPlain,
@@ -243,8 +242,8 @@ func TestClientInit(t *testing.T) {
 		},
 		{
 			tstName: "lro_client_init",
-			mixins: map[string]bool{
-				"google.longrunning.Operations": true,
+			mixins: mixins{
+				"google.longrunning.Operations": operationsMethods(),
 			},
 			servName: "Foo",
 			serv:     servLRO,

--- a/internal/gengapic/example_test.go
+++ b/internal/gengapic/example_test.go
@@ -30,10 +30,10 @@ import (
 func TestExample(t *testing.T) {
 	var g generator
 	g.imports = map[pbinfo.ImportSpec]bool{}
-	g.mixins = map[string]bool{
-		"google.longrunning.Operations":   true,
-		"google.cloud.location.Locations": true,
-		"google.iam.v1.IAMPolicy":         true,
+	g.mixins = mixins{
+		"google.longrunning.Operations":   operationsMethods(),
+		"google.cloud.location.Locations": locationMethods(),
+		"google.iam.v1.IAMPolicy":         iamPolicyMethods(),
 	}
 	g.serviceConfig = &serviceconfig.Service{
 		Apis: []*apipb.Api{

--- a/internal/gengapic/generator.go
+++ b/internal/gengapic/generator.go
@@ -71,7 +71,7 @@ type generator struct {
 	// gapic_metadata.json file.
 	metadata *metadatapb.GapicMetadata
 
-	mixins map[string]bool
+	mixins mixins
 
 	hasIAMPolicyOverrides bool
 }
@@ -84,7 +84,7 @@ func (g *generator) init(req *plugin.CodeGeneratorRequest) error {
 		Services: make(map[string]*metadatapb.GapicMetadata_ServiceForTransport),
 	}
 
-	g.mixins = map[string]bool{}
+	g.mixins = make(mixins)
 	g.comments = map[proto.Message]string{}
 	g.imports = map[pbinfo.ImportSpec]bool{}
 	g.aux = &auxTypes{

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -58,9 +58,7 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 		genServs = append(genServs, f.GetService()...)
 	}
 
-	if g.hasIAMPolicyMixin() {
-		g.hasIAMPolicyOverrides = hasIAMPolicyOverrides(genServs)
-	}
+	g.checkIAMPolicyOverrides(genServs)
 
 	if g.serviceConfig != nil {
 		g.apiName = g.serviceConfig.GetTitle()

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -253,10 +253,10 @@ func TestGenMethod(t *testing.T) {
 	g.opts = &options{
 		pkgName: "pkg",
 	}
-	g.mixins = map[string]bool{
-		"google.longrunning.Operations":   true,
-		"google.cloud.location.Locations": true,
-		"google.iam.v1.IAMPolicy":         true,
+	g.mixins = mixins{
+		"google.longrunning.Operations":   operationsMethods(),
+		"google.cloud.location.Locations": locationMethods(),
+		"google.iam.v1.IAMPolicy":         iamPolicyMethods(),
 	}
 	g.imports = map[pbinfo.ImportSpec]bool{}
 	cpb := &conf.ServiceConfig{
@@ -390,10 +390,10 @@ func TestGenLRO(t *testing.T) {
 
 	var g generator
 	g.imports = map[pbinfo.ImportSpec]bool{}
-	g.mixins = map[string]bool{
-		"google.longrunning.Operations":   true,
-		"google.cloud.location.Locations": true,
-		"google.iam.v1.IAMPolicy":         true,
+	g.mixins = mixins{
+		"google.longrunning.Operations":   operationsMethods(),
+		"google.cloud.location.Locations": locationMethods(),
+		"google.iam.v1.IAMPolicy":         iamPolicyMethods(),
 	}
 	g.opts = &options{
 		pkgName: "pkg",

--- a/internal/gengapic/mixins.go
+++ b/internal/gengapic/mixins.go
@@ -214,6 +214,7 @@ func (g *generator) checkIAMPolicyOverrides(servs []*descriptor.ServiceDescripto
 		for _, iamMethod := range iam {
 			if hasMethod(s, iamMethod.GetName()) {
 				g.hasIAMPolicyOverrides = true
+				return
 			}
 		}
 	}

--- a/internal/gengapic/mixins.go
+++ b/internal/gengapic/mixins.go
@@ -15,7 +15,13 @@
 package gengapic
 
 import (
+	"fmt"
+	"log"
+
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
+	"google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/genproto/googleapis/cloud/location"
 	iam "google.golang.org/genproto/googleapis/iam/v1"
 	"google.golang.org/genproto/googleapis/longrunning"
@@ -40,14 +46,71 @@ func init() {
 
 var mixinFiles map[string][]*descriptor.FileDescriptorProto
 
+type mixins map[string][]*descriptor.MethodDescriptorProto
+
+// collectMixins collects the configured mixin APIs from the Service config and
+// gathers the appropriately configured mixin methods to generate for each.
 func (g *generator) collectMixins() {
 	for _, api := range g.serviceConfig.GetApis() {
 		if _, ok := mixinFiles[api.GetName()]; ok {
-			g.mixins[api.GetName()] = true
+			g.mixins[api.GetName()] = g.collectMixinMethods(api.GetName())
 		}
 	}
 }
 
+// collectMixinMethods collects the method descriptors for the given mixin API
+// that should be generated for a client. In order for a method to be included
+// for generation, it must have a google.api.http defined in the Service config
+// http.rules section. The MethodDescriptorProto.options are overwritten with
+// that same google.api.http binding. Furthermore, a basic leading comment is
+// defined for the method to be generated.
+func (g *generator) collectMixinMethods(api string) []*descriptor.MethodDescriptorProto {
+	methods := map[string]*descriptor.MethodDescriptorProto{}
+	methodsToGenerate := []*descriptor.MethodDescriptorProto{}
+
+	// Note: Triple nested loops are nasty, but this is tightly bound and really
+	// the only way to traverse proto descriptors that are backed by slices.
+	for _, file := range mixinFiles[api] {
+		for _, service := range file.GetService() {
+			for _, method := range service.GetMethod() {
+				fqn := fmt.Sprintf("%s.%s.%s", file.GetPackage(), service.GetName(), method.GetName())
+				methods[fqn] = method
+
+				// Set a default comment in case the Service does not have a DocumentationRule for it.
+				// Exclude the leading method name because methodDoc adds automatically.
+				g.comments[method] = fmt.Sprintf("is a utility method from %s.%s.", file.GetPackage(), service.GetName())
+			}
+		}
+	}
+
+	// Overwrite the google.api.http annotations with bindings from the Service config.
+	for _, rule := range g.serviceConfig.GetHttp().GetRules() {
+		m, match := methods[rule.GetSelector()]
+		if !match {
+			continue
+		}
+
+		if err := proto.SetExtension(m.Options, annotations.E_Http, rule); err != nil {
+			log.Println("Encountered error setting HTTP annotations:", err)
+		}
+		methodsToGenerate = append(methodsToGenerate, m)
+	}
+
+	// Include any documentation from the Service config.
+	for _, rule := range g.serviceConfig.GetDocumentation().GetRules() {
+		m, match := methods[rule.GetSelector()]
+		if !match {
+			continue
+		}
+
+		g.comments[m] = rule.GetDescription()
+	}
+
+	return methodsToGenerate
+}
+
+// getMixinFiles returns a set of file descriptors for the APIs configured to be
+// mixed in.
 func (g *generator) getMixinFiles() []*descriptor.FileDescriptorProto {
 	files := []*descriptor.FileDescriptorProto{}
 	for key := range g.mixins {
@@ -56,65 +119,102 @@ func (g *generator) getMixinFiles() []*descriptor.FileDescriptorProto {
 	return files
 }
 
+// getMixinMethods is a convenience method to collect the method descriptors of
+// those methods to be generated based on if they should be included or not.
 func (g *generator) getMixinMethods() []*descriptor.MethodDescriptorProto {
 	methods := []*descriptor.MethodDescriptorProto{}
 	if g.hasLocationMixin() {
-		methods = append(methods, getLocationsMethods()...)
+		methods = append(methods, g.mixins["google.cloud.location.Locations"]...)
 	}
 	if g.hasIAMPolicyMixin() {
-		methods = append(methods, getIAMPolicyMethods()...)
+		methods = append(methods, g.mixins["google.iam.v1.IAMPolicy"]...)
 	}
 	if g.hasLROMixin() {
-		methods = append(methods, getOperationsMethods()...)
+		methods = append(methods, g.mixins["google.longrunning.Operations"]...)
 	}
 
 	return methods
 }
 
+// mixinStubs prints the field definition for the mixin gRPC stubs that are
+// configured to be generated. This is used in the definition of the generated
+// client type(s).
+func (g *generator) mixinStubs() {
+	p := g.printf
+
+	if g.hasLROMixin() {
+		p("operationsClient longrunningpb.OperationsClient")
+		p("")
+
+		g.imports[pbinfo.ImportSpec{Name: "longrunningpb", Path: "google.golang.org/genproto/googleapis/longrunning"}] = true
+	}
+
+	if g.hasIAMPolicyMixin() {
+
+		p("iamPolicyClient iampb.IAMPolicyClient")
+		p("")
+
+		g.imports[pbinfo.ImportSpec{Name: "iampb", Path: "google.golang.org/genproto/googleapis/iam/v1"}] = true
+	}
+
+	if g.hasLocationMixin() {
+
+		p("locationsClient locationpb.LocationsClient")
+		p("")
+
+		g.imports[pbinfo.ImportSpec{Name: "locationpb", Path: "google.golang.org/genproto/googleapis/cloud/location"}] = true
+	}
+}
+
+// mixinStubsInit prints the stub intialization for the mixin gRPC stubs that are
+// configured to be generated. This is used in the factory method of a generated client.
+func (g *generator) mixinStubsInit() {
+	p := g.printf
+
+	if g.hasLROMixin() {
+		p("    operationsClient: longrunningpb.NewOperationsClient(connPool),")
+	}
+	if g.hasIAMPolicyMixin() {
+		p("    iamPolicyClient: iampb.NewIAMPolicyClient(connPool),")
+	}
+	if g.hasLocationMixin() {
+		p("    locationsClient: locationpb.NewLocationsClient(connPool),")
+	}
+}
+
+// hasLROMixin is a convenience method for determining if the Operations mixin
+// should be generated.
 func (g *generator) hasLROMixin() bool {
-	return g.mixins["google.longrunning.Operations"] && len(g.serviceConfig.GetApis()) > 1
+	return len(g.mixins["google.longrunning.Operations"]) > 0 && len(g.serviceConfig.GetApis()) > 1
 }
 
+// hasIAMPolicyMixin is a convenience method for determining if the IAMPolicy
+// mixin should be generated.
 func (g *generator) hasIAMPolicyMixin() bool {
-	return g.mixins["google.iam.v1.IAMPolicy"] && !g.hasIAMPolicyOverrides
+	return len(g.mixins["google.iam.v1.IAMPolicy"]) > 0 && !g.hasIAMPolicyOverrides
 }
 
+// hasLocationixin is a convenience method for determining if the Locations
+// mixin should be generated.
 func (g *generator) hasLocationMixin() bool {
-	return g.mixins["google.cloud.location.Locations"]
+	return len(g.mixins["google.cloud.location.Locations"]) > 0
 }
 
-func hasIAMPolicyOverrides(servs []*descriptor.ServiceDescriptorProto) bool {
+// checkIAMPolicyOverrides determines if any of the given services define an
+// IAMPolicy RPC and sets the hasIAMpolicyOverrides generator flag if so. If set
+// to true, the IAMPolicy mixin will not be generated on any service client. This
+// is for backwards compatibility with existing IAMPolicy redefinitions.
+func (g *generator) checkIAMPolicyOverrides(servs []*descriptor.ServiceDescriptorProto) {
+	iam, hasMixin := g.mixins["google.iam.v1.IAMPolicy"]
+	if !hasMixin {
+		return
+	}
+
 	for _, s := range servs {
-		for _, iamMethod := range getIAMPolicyMethods() {
+		for _, iamMethod := range iam {
 			if hasMethod(s, iamMethod.GetName()) {
-				return true
+				g.hasIAMPolicyOverrides = true
 			}
 		}
 	}
-
-	return false
-}
-
-func getLocationsDescriptor() *descriptor.FileDescriptorProto {
-	return mixinFiles["google.cloud.location.Locations"][0]
-}
-
-func getLocationsMethods() []*descriptor.MethodDescriptorProto {
-	return getLocationsDescriptor().GetService()[0].GetMethod()
-}
-
-func getIAMPolicyDescriptor() *descriptor.FileDescriptorProto {
-	return mixinFiles["google.iam.v1.IAMPolicy"][0]
-}
-
-func getIAMPolicyMethods() []*descriptor.MethodDescriptorProto {
-	return getIAMPolicyDescriptor().GetService()[0].GetMethod()
-}
-
-func getOperationsDescriptor() *descriptor.FileDescriptorProto {
-	return mixinFiles["google.longrunning.Operations"][0]
-}
-
-func getOperationsMethods() []*descriptor.MethodDescriptorProto {
-	return getOperationsDescriptor().GetService()[0].GetMethod()
 }


### PR DESCRIPTION
The main change in this PR is the use of the `http.rules` section to determine which mixin RPCs should be generated. Only those with such a binding will be generated. This is primarily because not every service implements all of the RPCs for a given mixin. The `http.rules` are the best indicator of this. Furthermore, those methods to generate will be overwritten with the `google.api.http` binding defined in the corresponding `http.rules` item. This way, the hosting service's http bindings are used for REGAPIC and header injection. 

This change also references the Service config's `documentation.rules` for method-level docs for the mixins. Absent those, a generic comment is added. 

Some refactoring of the mixin code is also done, in order to keep mixin logic inside of `mixins.go` and simplify call-sites elsewhere in the generator.

Fixes #598