### PR TITLE
gapic: add docs on NewClient about closing the client

### DIFF
--- a/internal/gengapic/gengrpc.go
+++ b/internal/gengapic/gengrpc.go
@@ -318,7 +318,7 @@ func (g *generator) grpcClientUtilities(serv *descriptor.ServiceDescriptorProto,
 
 	// Factory function
 	p("// New%sClient creates a new %s client based on gRPC.", servName, clientName)
-	p("// The returned client must be closed when it is done being used to free the underlying connections that have been made.")
+	p("// The returned client must be Closed when it is done being used to clean up its underlying connections.")
 	p("//")
 	g.comment(g.comments[serv])
 	p("func New%[1]sClient(ctx context.Context, opts ...option.ClientOption) (*%[1]sClient, error) {", servName)

--- a/internal/gengapic/gengrpc.go
+++ b/internal/gengapic/gengrpc.go
@@ -318,6 +318,7 @@ func (g *generator) grpcClientUtilities(serv *descriptor.ServiceDescriptorProto,
 
 	// Factory function
 	p("// New%sClient creates a new %s client based on gRPC.", servName, clientName)
+	p("// The returned client must be closed when it is done being used to free the underlying connections that have been made.")
 	p("//")
 	g.comment(g.comments[serv])
 	p("func New%[1]sClient(ctx context.Context, opts ...option.ClientOption) (*%[1]sClient, error) {", servName)

--- a/internal/gengapic/testdata/deprecated_client_init.want
+++ b/internal/gengapic/testdata/deprecated_client_init.want
@@ -69,6 +69,7 @@ type gRPCClient struct {
 }
 
 // NewClient creates a new foo client based on gRPC.
+// The returned client must be Closed when it is done being used to clean up its underlying connections.
 //
 // Foo service does stuff.
 //

--- a/internal/gengapic/testdata/empty_client_init.want
+++ b/internal/gengapic/testdata/empty_client_init.want
@@ -38,6 +38,7 @@ type gRPCClient struct {
 }
 
 // NewClient creates a new foo client based on gRPC.
+// The returned client must be closed when it is done being used to free the underlying connections that have been made.
 //
 // Foo service does stuff.
 func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error) {

--- a/internal/gengapic/testdata/empty_client_init.want
+++ b/internal/gengapic/testdata/empty_client_init.want
@@ -38,7 +38,7 @@ type gRPCClient struct {
 }
 
 // NewClient creates a new foo client based on gRPC.
-// The returned client must be closed when it is done being used to free the underlying connections that have been made.
+// The returned client must be Closed when it is done being used to clean up its underlying connections.
 //
 // Foo service does stuff.
 func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error) {

--- a/internal/gengapic/testdata/foo_client_init.want
+++ b/internal/gengapic/testdata/foo_client_init.want
@@ -47,7 +47,7 @@ type fooGRPCClient struct {
 }
 
 // NewFooClient creates a new foo client based on gRPC.
-// The returned client must be closed when it is done being used to free the underlying connections that have been made.
+// The returned client must be Closed when it is done being used to clean up its underlying connections.
 //
 // Foo service does stuff.
 func NewFooClient(ctx context.Context, opts ...option.ClientOption) (*FooClient, error) {

--- a/internal/gengapic/testdata/foo_client_init.want
+++ b/internal/gengapic/testdata/foo_client_init.want
@@ -47,6 +47,7 @@ type fooGRPCClient struct {
 }
 
 // NewFooClient creates a new foo client based on gRPC.
+// The returned client must be closed when it is done being used to free the underlying connections that have been made.
 //
 // Foo service does stuff.
 func NewFooClient(ctx context.Context, opts ...option.ClientOption) (*FooClient, error) {

--- a/internal/gengapic/testdata/lro_client_init.want
+++ b/internal/gengapic/testdata/lro_client_init.want
@@ -58,6 +58,7 @@ type fooGRPCClient struct {
 }
 
 // NewFooClient creates a new foo client based on gRPC.
+// The returned client must be closed when it is done being used to free the underlying connections that have been made.
 //
 // Foo service does stuff.
 func NewFooClient(ctx context.Context, opts ...option.ClientOption) (*FooClient, error) {

--- a/internal/gengapic/testdata/lro_client_init.want
+++ b/internal/gengapic/testdata/lro_client_init.want
@@ -58,7 +58,7 @@ type fooGRPCClient struct {
 }
 
 // NewFooClient creates a new foo client based on gRPC.
-// The returned client must be closed when it is done being used to free the underlying connections that have been made.
+// The returned client must be Closed when it is done being used to clean up its underlying connections.
 //
 // Foo service does stuff.
 func NewFooClient(ctx context.Context, opts ...option.ClientOption) (*FooClient, error) {


### PR DESCRIPTION
One issue we have seen pop up multiple times is around users of our
libraries not closing their clients after they are done being used.
This can lead to memory leaks as the underlying HTTP connections
are never closed. Adding some docs on the function that returns the
Client seems like a good first step to take.