### PR TITLE
chore: fix bazel deps diff check

### DIFF
--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -20,8 +20,10 @@ jobs:
       run: |
         bazel run //:gazelle -- update-repos -from_file=go.mod -prune -to_macro=repositories.bzl%com_googleapis_gapic_generator_go_repositories
         sed -i "s/    \"go_repository\",//g" repositories.bzl
+        set +e
         git diff --exit-code repositories.bzl
         echo ::set-output name=changed::$?
+        set -e
     - name: Prepare repositories.bzl payload
       if: steps.update.outputs.changed
       run: tar czf repos.tgz repositories.bzl


### PR DESCRIPTION
Using `--exit-code` creates a non-zero exit code when there is a change, which causes the step/job to fail, so we disable exit on non-zero codes, capture the exit code (`1` means there was a change), then reenable it.

Hopefully this fixes it finally.