### PR TITLE
gapic: fix wrappers, add missing wrappers, fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,12 +55,17 @@ jobs:
     - uses: actions/setup-go@v2
       with:
         go-version: '1.15.8'
+    - name: Install protoc
+      run: |
+        sudo mkdir -p /usr/src/protoc/
+        sudo chown -R ${USER} /usr/src/
+        curl --location https://github.com/google/protobuf/releases/download/v3.12.1/protoc-3.12.1-linux-x86_64.zip --output /usr/src/protoc/protoc-3.12.1.zip
+        cd /usr/src/protoc/
+        unzip protoc-3.12.1.zip
+        sudo ln -s /usr/src/protoc/bin/protoc /usr/local/bin/protoc
     - name: Install tools and dependencies
       run: |
         go install github.com/golang/protobuf/protoc-gen-go
-        mkdir protobuf
-        curl -sSL https://github.com/protocolbuffers/protobuf/releases/download/v3.12.0/protoc-3.12.0-linux-x86_64.zip > protobuf/protoc.zip
-        unzip -d protobuf protobuf/protoc.zip
         curl -sSL https://github.com/googleapis/googleapis/archive/master.zip > googleapis.zip
         unzip googleapis.zip -x "googleapis-master/google/ads/*"
         mv googleapis-master googleapis

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,7 @@ golden:
 test:
 	go test -mod=mod ./...
 	go install ./cmd/protoc-gen-go_gapic
-	cd showcase; ./showcase.bash; cd ..
-	./test.sh
+	cd showcase && ./showcase.bash && cd .. && ./test.sh
 
 install:
 	go install ./cmd/protoc-gen-go_gapic

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -203,7 +203,27 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 	p("")
 
 	methods := append(serv.GetMethod(), g.getMixinMethods()...)
-	p("// Wrapper methods routed to the internal client")
+	p("// Wrapper methods routed to the internal client.")
+	p("")
+	p("// Close closes the connection to the API service. The user should invoke this when")
+	p("// the client is no longer required.")
+	p("func (c *%sClient) Close() error {", servName)
+	p("  return c.internalClient.Close()")
+	p("}")
+	p("")
+	p("// setGoogleClientInfo sets the name and version of the application in")
+	p("// the `x-goog-api-client` header passed on each request. Intended for")
+	p("// use by Google-written clients.")
+	p("func (c *%sClient) setGoogleClientInfo(...string) {", servName)
+	p("  c.internalClient.setGoogleClientInfo()")
+	p("}")
+	p("")
+	p("// Connection returns a connection to the API service.")
+	p("//")
+	p("// Deprecated.")
+	p("func (c *%sClient) Connection() *grpc.ClientConn {", servName)
+	p("  return c.internalClient.Connection()")
+	p("}")
 	p("")
 	for _, m := range methods {
 		g.genClientWrapperMethod(m, serv, servName)
@@ -223,7 +243,7 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 	if m.GetOutputType() == emptyType {
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) error {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName())
-		p("    return c.internalClient.%s(ctx, req, opts)", m.GetName())
+		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
 		p("}")
 		p("")
 		return nil
@@ -239,7 +259,7 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		lroType := lroTypeName(m.GetName())
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s, error) {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), lroType)
-		p("    return c.internalClient.%s(ctx, req, opts)", m.GetName())
+		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
 		p("}")
 		p("")
 		return nil
@@ -254,7 +274,7 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		}
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) *%s {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), iter.iterTypeName)
-		p("    return c.internalClient.%s(ctx, req, opts)", m.GetName())
+		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
 		p("}")
 		p("")
 		return nil
@@ -269,7 +289,7 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 
 		p("func (c *%s) %s(ctx context.Context, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 			clientTypeName, m.GetName(), servSpec.Name, serv.GetName(), m.GetName())
-		p("    return c.internalClient.%s(ctx, req, opts)", m.GetName())
+		p("    return c.internalClient.%s(ctx, opts...)", m.GetName())
 		p("}")
 		p("")
 		return nil
@@ -280,14 +300,14 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		}
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), servSpec.Name, serv.GetName(), m.GetName())
-		p("    return c.internalClient.%s(ctx, req, opts)", m.GetName())
+		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
 		p("}")
 		p("")
 		return nil
 	default:
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s.%s, error) {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), outSpec.Name, outType.GetName())
-		p("    return c.internalClient.%s(ctx, req, opts)", m.GetName())
+		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
 		p("}")
 		p("")
 		return nil

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -201,8 +201,6 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 
 	p("}")
 	p("")
-
-	methods := append(serv.GetMethod(), g.getMixinMethods()...)
 	p("// Wrapper methods routed to the internal client.")
 	p("")
 	p("// Close closes the connection to the API service. The user should invoke this when")
@@ -225,6 +223,7 @@ func (g *generator) clientInit(serv *descriptor.ServiceDescriptorProto, servName
 	p("  return c.internalClient.Connection()")
 	p("}")
 	p("")
+	methods := append(serv.GetMethod(), g.getMixinMethods()...)
 	for _, m := range methods {
 		g.genClientWrapperMethod(m, serv, servName)
 	}

--- a/internal/gengapic/testdata/deprecated_client_init.want
+++ b/internal/gengapic/testdata/deprecated_client_init.want
@@ -21,10 +21,30 @@ type Client struct {
 
 }
 
-// Wrapper methods routed to the internal client
+// Wrapper methods routed to the internal client.
+
+// Close closes the connection to the API service. The user should invoke this when
+// the client is no longer required.
+func (c *Client) Close() error {
+	return c.internalClient.Close()
+}
+
+// setGoogleClientInfo sets the name and version of the application in
+// the `x-goog-api-client` header passed on each request. Intended for
+// use by Google-written clients.
+func (c *Client) setGoogleClientInfo(...string) {
+	c.internalClient.setGoogleClientInfo()
+}
+
+// Connection returns a connection to the API service.
+//
+// Deprecated.
+func (c *Client) Connection() *grpc.ClientConn {
+	return c.internalClient.Connection()
+}
 
 func (c *Client) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
-	return c.internalClient.Zip(ctx, req, opts)
+	return c.internalClient.Zip(ctx, req, opts...)
 }
 
 // gRPCClient is a client for interacting with Awesome Foo API over gRPC transport.

--- a/internal/gengapic/testdata/empty_client_init.want
+++ b/internal/gengapic/testdata/empty_client_init.want
@@ -19,10 +19,30 @@ type Client struct {
 
 }
 
-// Wrapper methods routed to the internal client
+// Wrapper methods routed to the internal client.
+
+// Close closes the connection to the API service. The user should invoke this when
+// the client is no longer required.
+func (c *Client) Close() error {
+	return c.internalClient.Close()
+}
+
+// setGoogleClientInfo sets the name and version of the application in
+// the `x-goog-api-client` header passed on each request. Intended for
+// use by Google-written clients.
+func (c *Client) setGoogleClientInfo(...string) {
+	c.internalClient.setGoogleClientInfo()
+}
+
+// Connection returns a connection to the API service.
+//
+// Deprecated.
+func (c *Client) Connection() *grpc.ClientConn {
+	return c.internalClient.Connection()
+}
 
 func (c *Client) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
-	return c.internalClient.Zip(ctx, req, opts)
+	return c.internalClient.Zip(ctx, req, opts...)
 }
 
 // gRPCClient is a client for interacting with Awesome Foo API over gRPC transport.

--- a/internal/gengapic/testdata/foo_client_init.want
+++ b/internal/gengapic/testdata/foo_client_init.want
@@ -24,30 +24,50 @@ type FooClient struct {
 
 }
 
-// Wrapper methods routed to the internal client
+// Wrapper methods routed to the internal client.
+
+// Close closes the connection to the API service. The user should invoke this when
+// the client is no longer required.
+func (c *FooClient) Close() error {
+	return c.internalClient.Close()
+}
+
+// setGoogleClientInfo sets the name and version of the application in
+// the `x-goog-api-client` header passed on each request. Intended for
+// use by Google-written clients.
+func (c *FooClient) setGoogleClientInfo(...string) {
+	c.internalClient.setGoogleClientInfo()
+}
+
+// Connection returns a connection to the API service.
+//
+// Deprecated.
+func (c *FooClient) Connection() *grpc.ClientConn {
+	return c.internalClient.Connection()
+}
 
 func (c *FooClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
-	return c.internalClient.Zip(ctx, req, opts)
+	return c.internalClient.Zip(ctx, req, opts...)
 }
 
 func (c *FooClient) ListLocations(ctx context.Context, req *locationpb.ListLocationsRequest, opts ...gax.CallOption) (*locationpb.ListLocationsResponse, error) {
-	return c.internalClient.ListLocations(ctx, req, opts)
+	return c.internalClient.ListLocations(ctx, req, opts...)
 }
 
 func (c *FooClient) GetLocation(ctx context.Context, req *locationpb.GetLocationRequest, opts ...gax.CallOption) (*locationpb.Location, error) {
-	return c.internalClient.GetLocation(ctx, req, opts)
+	return c.internalClient.GetLocation(ctx, req, opts...)
 }
 
 func (c *FooClient) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest, opts ...gax.CallOption) (*iampb.Policy, error) {
-	return c.internalClient.SetIamPolicy(ctx, req, opts)
+	return c.internalClient.SetIamPolicy(ctx, req, opts...)
 }
 
 func (c *FooClient) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest, opts ...gax.CallOption) (*iampb.Policy, error) {
-	return c.internalClient.GetIamPolicy(ctx, req, opts)
+	return c.internalClient.GetIamPolicy(ctx, req, opts...)
 }
 
 func (c *FooClient) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest, opts ...gax.CallOption) (*iampb.TestIamPermissionsResponse, error) {
-	return c.internalClient.TestIamPermissions(ctx, req, opts)
+	return c.internalClient.TestIamPermissions(ctx, req, opts...)
 }
 
 // fooGRPCClient is a client for interacting with Awesome Foo API over gRPC transport.

--- a/internal/gengapic/testdata/foo_rest_client_init.want
+++ b/internal/gengapic/testdata/foo_rest_client_init.want
@@ -24,30 +24,50 @@ type FooClient struct {
 
 }
 
-// Wrapper methods routed to the internal client
+// Wrapper methods routed to the internal client.
+
+// Close closes the connection to the API service. The user should invoke this when
+// the client is no longer required.
+func (c *FooClient) Close() error {
+	return c.internalClient.Close()
+}
+
+// setGoogleClientInfo sets the name and version of the application in
+// the `x-goog-api-client` header passed on each request. Intended for
+// use by Google-written clients.
+func (c *FooClient) setGoogleClientInfo(...string) {
+	c.internalClient.setGoogleClientInfo()
+}
+
+// Connection returns a connection to the API service.
+//
+// Deprecated.
+func (c *FooClient) Connection() *grpc.ClientConn {
+	return c.internalClient.Connection()
+}
 
 func (c *FooClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
-	return c.internalClient.Zip(ctx, req, opts)
+	return c.internalClient.Zip(ctx, req, opts...)
 }
 
 func (c *FooClient) ListLocations(ctx context.Context, req *locationpb.ListLocationsRequest, opts ...gax.CallOption) (*locationpb.ListLocationsResponse, error) {
-	return c.internalClient.ListLocations(ctx, req, opts)
+	return c.internalClient.ListLocations(ctx, req, opts...)
 }
 
 func (c *FooClient) GetLocation(ctx context.Context, req *locationpb.GetLocationRequest, opts ...gax.CallOption) (*locationpb.Location, error) {
-	return c.internalClient.GetLocation(ctx, req, opts)
+	return c.internalClient.GetLocation(ctx, req, opts...)
 }
 
 func (c *FooClient) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest, opts ...gax.CallOption) (*iampb.Policy, error) {
-	return c.internalClient.SetIamPolicy(ctx, req, opts)
+	return c.internalClient.SetIamPolicy(ctx, req, opts...)
 }
 
 func (c *FooClient) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest, opts ...gax.CallOption) (*iampb.Policy, error) {
-	return c.internalClient.GetIamPolicy(ctx, req, opts)
+	return c.internalClient.GetIamPolicy(ctx, req, opts...)
 }
 
 func (c *FooClient) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest, opts ...gax.CallOption) (*iampb.TestIamPermissionsResponse, error) {
-	return c.internalClient.TestIamPermissions(ctx, req, opts)
+	return c.internalClient.TestIamPermissions(ctx, req, opts...)
 }
 
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.

--- a/internal/gengapic/testdata/lro_client_init.want
+++ b/internal/gengapic/testdata/lro_client_init.want
@@ -32,30 +32,50 @@ type FooClient struct {
 
 }
 
-// Wrapper methods routed to the internal client
+// Wrapper methods routed to the internal client.
+
+// Close closes the connection to the API service. The user should invoke this when
+// the client is no longer required.
+func (c *FooClient) Close() error {
+	return c.internalClient.Close()
+}
+
+// setGoogleClientInfo sets the name and version of the application in
+// the `x-goog-api-client` header passed on each request. Intended for
+// use by Google-written clients.
+func (c *FooClient) setGoogleClientInfo(...string) {
+	c.internalClient.setGoogleClientInfo()
+}
+
+// Connection returns a connection to the API service.
+//
+// Deprecated.
+func (c *FooClient) Connection() *grpc.ClientConn {
+	return c.internalClient.Connection()
+}
 
 func (c *FooClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*ZipOperation, error) {
-	return c.internalClient.Zip(ctx, req, opts)
+	return c.internalClient.Zip(ctx, req, opts...)
 }
 
 func (c *FooClient) ListOperations(ctx context.Context, req *longrunningpb.ListOperationsRequest, opts ...gax.CallOption) (*longrunningpb.ListOperationsResponse, error) {
-	return c.internalClient.ListOperations(ctx, req, opts)
+	return c.internalClient.ListOperations(ctx, req, opts...)
 }
 
 func (c *FooClient) GetOperation(ctx context.Context, req *longrunningpb.GetOperationRequest, opts ...gax.CallOption) (*GetOperationOperation, error) {
-	return c.internalClient.GetOperation(ctx, req, opts)
+	return c.internalClient.GetOperation(ctx, req, opts...)
 }
 
 func (c *FooClient) DeleteOperation(ctx context.Context, req *longrunningpb.DeleteOperationRequest, opts ...gax.CallOption) error {
-	return c.internalClient.DeleteOperation(ctx, req, opts)
+	return c.internalClient.DeleteOperation(ctx, req, opts...)
 }
 
 func (c *FooClient) CancelOperation(ctx context.Context, req *longrunningpb.CancelOperationRequest, opts ...gax.CallOption) error {
-	return c.internalClient.CancelOperation(ctx, req, opts)
+	return c.internalClient.CancelOperation(ctx, req, opts...)
 }
 
 func (c *FooClient) WaitOperation(ctx context.Context, req *longrunningpb.WaitOperationRequest, opts ...gax.CallOption) (*WaitOperationOperation, error) {
-	return c.internalClient.WaitOperation(ctx, req, opts)
+	return c.internalClient.WaitOperation(ctx, req, opts...)
 }
 
 // fooGRPCClient is a client for interacting with Awesome Foo API over gRPC transport.

--- a/showcase/go.mod
+++ b/showcase/go.mod
@@ -11,3 +11,5 @@ require (
 	google.golang.org/genproto v0.0.0-20210506142907-4a47615972c2
 	google.golang.org/grpc v1.37.0
 )
+
+replace github.com/googleapis/gapic-showcase => ./gen/github.com/googleapis/gapic-showcase

--- a/showcase/go.mod
+++ b/showcase/go.mod
@@ -11,5 +11,3 @@ require (
 	google.golang.org/genproto v0.0.0-20210506142907-4a47615972c2
 	google.golang.org/grpc v1.37.0
 )
-
-replace github.com/googleapis/gapic-showcase => ./gen/github.com/googleapis/gapic-showcase

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -40,16 +40,20 @@ protoc \
 	--descriptor_set_in=<(curl -sSL https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/gapic-showcase-$SHOWCASE_SEMVER.desc) \
 	google/showcase/v1beta1/echo.proto google/showcase/v1beta1/identity.proto google/showcase/v1beta1/sequence.proto
 
+hostos=$(go env GOHOSTOS)
+hostarch=$(go env GOHOSTARCH)
+
 pushd gen/github.com/googleapis/gapic-showcase
 go mod init github.com/googleapis/gapic-showcase
 # Fixes a name collision with the operation helper WaitOperation by renaming the mixin method.
-sed  -i '' '1,/WaitOperation(ctx/{s/WaitOperation(ctx/WaitOperationMixin(ctx/;}' client/echo_client*
+if [[ "$hostos" == "darwin" ]]; then
+	sed  -i '' '1,/WaitOperation(ctx/{s/WaitOperation(ctx/WaitOperationMixin(ctx/;}' client/echo_client*
+else
+	sed '1,/WaitOperation(ctx/{s/WaitOperation(ctx/WaitOperationMixin(ctx/;}' client/echo_client*
+fi
 popd
 
 go mod edit -replace=github.com/googleapis/gapic-showcase=./gen/github.com/googleapis/gapic-showcase
-
-hostos=$(go env GOHOSTOS)
-hostarch=$(go env GOHOSTARCH)
 
 curl -sSL https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/gapic-showcase-$SHOWCASE_SEMVER-$hostos-$hostarch.tar.gz | tar xz
 ./gapic-showcase run &

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -47,10 +47,12 @@ pushd gen/github.com/googleapis/gapic-showcase
 go mod init github.com/googleapis/gapic-showcase
 # Fixes a name collision with the operation helper WaitOperation by renaming the mixin method.
 if [[ "$hostos" == "darwin" ]]; then
-	sed  -i '' '1,/WaitOperation(ctx/{s/WaitOperation(ctx/WaitOperationMixin(ctx/;}' client/echo_client*
+    SEDARGS="-i ''"
 else
-	sed '1,/WaitOperation(ctx/{s/WaitOperation(ctx/WaitOperationMixin(ctx/;}' client/echo_client*
+    SEDARGS="-i"
 fi
+sed $SEDARGS '1,/WaitOperation(ctx/{s/WaitOperation(ctx/WaitOperationMixin(ctx/;}' client/echo_client*
+
 popd
 
 go mod edit -replace=github.com/googleapis/gapic-showcase=./gen/github.com/googleapis/gapic-showcase


### PR DESCRIPTION
The integration test script/job were silently failing. Once these were fixed, changes were needed to fix the new wrapper methods and get the tests to pass, including:

- expanding the `[]gax.CallOption` slice from `opts ...gax.CallOption` via `opts...`
- fix use of missing var in client-streaming RPC wrapper
- implement wrappers for `Close`, `setGoogleClientInfo` and `Connection`