### PR TITLE
gapic: fix missing LRO type wrapper

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -261,6 +261,10 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
 		p("}")
 		p("")
+		p("func (c *%s) %s(name string) *%[2]s {", clientTypeName, lroType)
+		p("  return c.internalClient.%s(name)", lroType)
+		p("}")
+		p("")
 		return nil
 	}
 

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -261,6 +261,8 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
 		p("}")
 		p("")
+		p("// %s returns a new %[1]s from a given name.", lroType)
+		p("// The name must be that of a previously created %s, possibly from a different process.", lroType)
 		p("func (c *%s) %s(name string) *%[2]s {", clientTypeName, lroType)
 		p("  return c.internalClient.%s(name)", lroType)
 		p("}")

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -332,103 +332,25 @@ func TestClientInit(t *testing.T) {
 			parameter: proto.String("go-gapic-package=path;mypackage,transport=grpc+rest"),
 		},
 	} {
+		fds := append(mixinDescriptors(), &descriptor.FileDescriptorProto{
+			Package: proto.String("mypackage"),
+			Options: &descriptor.FileOptions{
+				GoPackage: proto.String("mypackage"),
+			},
+			Service: []*descriptor.ServiceDescriptorProto{tst.serv},
+			MessageType: []*descriptor.DescriptorProto{
+				{
+					Name: proto.String("Bar"),
+				},
+				{
+					Name: proto.String("Foo"),
+				},
+			},
+		})
 		request := plugin.CodeGeneratorRequest{
 			Parameter: tst.parameter,
-			ProtoFile: []*descriptor.FileDescriptorProto{
-				{
-					Package: proto.String("mypackage"),
-					Options: &descriptor.FileOptions{
-						GoPackage: proto.String("mypackage"),
-					},
-					Service: []*descriptor.ServiceDescriptorProto{tst.serv},
-					MessageType: []*descriptor.DescriptorProto{
-						{
-							Name: proto.String("Bar"),
-						},
-						{
-							Name: proto.String("Foo"),
-						},
-					},
-				},
-				{
-					Package: proto.String("google.longrunning"),
-					Options: &descriptor.FileOptions{
-						GoPackage: proto.String("google.golang.org/genproto/googleapis/longrunning;longrunning"),
-					},
-					MessageType: []*descriptor.DescriptorProto{
-						{
-							Name: proto.String("Operation"),
-						},
-						{
-							Name: proto.String("GetOperationRequest"),
-						},
-						{
-							Name: proto.String("DeleteOperationRequest"),
-						},
-						{
-							Name: proto.String("WaitOperationRequest"),
-						},
-						{
-							Name: proto.String("ListOperationsRequest"),
-						},
-						{
-							Name: proto.String("ListOperationsResponse"),
-						},
-						{
-							Name: proto.String("CancelOperationRequest"),
-						},
-					},
-				},
-				{
-					Package: proto.String("google.cloud.location"),
-					Options: &descriptor.FileOptions{
-						GoPackage: proto.String("google.golang.org/genproto/googleapis/cloud/location;location"),
-					},
-					MessageType: []*descriptor.DescriptorProto{
-						{
-							Name: proto.String("ListLocationsRequest"),
-						},
-						{
-							Name: proto.String("ListLocationsResponse"),
-						},
-						{
-							Name: proto.String("Location"),
-						},
-						{
-							Name: proto.String("GetLocationRequest"),
-						},
-						{
-							Name: proto.String("GetLocationResponse"),
-						},
-					},
-				},
-				{
-					Package: proto.String("google.iam.v1"),
-					Options: &descriptor.FileOptions{
-						GoPackage: proto.String("google.golang.org/genproto/googleapis/iam/v1;iam"),
-					},
-					MessageType: []*descriptor.DescriptorProto{
-						{
-							Name: proto.String("Policy"),
-						},
-						{
-							Name: proto.String("TestIamPermissionsRequest"),
-						},
-						{
-							Name: proto.String("TestIamPermissionsResponse"),
-						},
-						{
-							Name: proto.String("SetIamPolicyRequest"),
-						},
-						{
-							Name: proto.String("SetIamPolicyResponse"),
-						},
-						{
-							Name: proto.String("GetIamPolicyRequest"),
-						},
-					},
-				},
-			}}
+			ProtoFile: fds,
+		}
 		g.init(&request)
 		g.comments = map[proto.Message]string{
 			tst.serv: "Foo service does stuff.",
@@ -472,4 +394,13 @@ func TestGenerateDefaultAudience(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mixinDescriptors is used for testing purposes only.
+func mixinDescriptors() []*descriptor.FileDescriptorProto {
+	files := []*descriptor.FileDescriptorProto{}
+	for _, fds := range mixinFiles {
+		files = append(files, fds...)
+	}
+	return files
 }

--- a/internal/gengapic/testdata/foo_client_init.want
+++ b/internal/gengapic/testdata/foo_client_init.want
@@ -4,7 +4,7 @@ type internalFooClient interface {
 	setGoogleClientInfo(...string)
 	Connection() *grpc.ClientConn
 	Zip(context.Context, *mypackagepb.Bar, ...gax.CallOption) (*mypackagepb.Foo, error)
-	ListLocations(context.Context, *locationpb.ListLocationsRequest, ...gax.CallOption) (*locationpb.ListLocationsResponse, error)
+	ListLocations(context.Context, *locationpb.ListLocationsRequest, ...gax.CallOption) *LocationIterator
 	GetLocation(context.Context, *locationpb.GetLocationRequest, ...gax.CallOption) (*locationpb.Location, error)
 	SetIamPolicy(context.Context, *iampb.SetIamPolicyRequest, ...gax.CallOption) (*iampb.Policy, error)
 	GetIamPolicy(context.Context, *iampb.GetIamPolicyRequest, ...gax.CallOption) (*iampb.Policy, error)
@@ -50,7 +50,7 @@ func (c *FooClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.C
 	return c.internalClient.Zip(ctx, req, opts...)
 }
 
-func (c *FooClient) ListLocations(ctx context.Context, req *locationpb.ListLocationsRequest, opts ...gax.CallOption) (*locationpb.ListLocationsResponse, error) {
+func (c *FooClient) ListLocations(ctx context.Context, req *locationpb.ListLocationsRequest, opts ...gax.CallOption) *LocationIterator {
 	return c.internalClient.ListLocations(ctx, req, opts...)
 }
 

--- a/internal/gengapic/testdata/foo_rest_client_init.want
+++ b/internal/gengapic/testdata/foo_rest_client_init.want
@@ -4,7 +4,7 @@ type internalFooClient interface {
 	setGoogleClientInfo(...string)
 	Connection() *grpc.ClientConn
 	Zip(context.Context, *mypackagepb.Bar, ...gax.CallOption) (*mypackagepb.Foo, error)
-	ListLocations(context.Context, *locationpb.ListLocationsRequest, ...gax.CallOption) (*locationpb.ListLocationsResponse, error)
+	ListLocations(context.Context, *locationpb.ListLocationsRequest, ...gax.CallOption) *LocationIterator
 	GetLocation(context.Context, *locationpb.GetLocationRequest, ...gax.CallOption) (*locationpb.Location, error)
 	SetIamPolicy(context.Context, *iampb.SetIamPolicyRequest, ...gax.CallOption) (*iampb.Policy, error)
 	GetIamPolicy(context.Context, *iampb.GetIamPolicyRequest, ...gax.CallOption) (*iampb.Policy, error)
@@ -50,7 +50,7 @@ func (c *FooClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.C
 	return c.internalClient.Zip(ctx, req, opts...)
 }
 
-func (c *FooClient) ListLocations(ctx context.Context, req *locationpb.ListLocationsRequest, opts ...gax.CallOption) (*locationpb.ListLocationsResponse, error) {
+func (c *FooClient) ListLocations(ctx context.Context, req *locationpb.ListLocationsRequest, opts ...gax.CallOption) *LocationIterator {
 	return c.internalClient.ListLocations(ctx, req, opts...)
 }
 
@@ -76,15 +76,6 @@ type fooRESTClient struct {
 }
 
 func (c *fooRESTClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
-	m := jsonpb.Marshaler{}
-	if jsonReq, err := m.MarshalToString(req); err != nil {
-		return nil, err
-
-	}
-	return nil, nil
-
-}
-func (c *fooRESTClient) ListLocations(ctx context.Context, req *locationpb.ListLocationsRequest, opts ...gax.CallOption) (*locationpb.ListLocationsResponse, error) {
 	m := jsonpb.Marshaler{}
 	if jsonReq, err := m.MarshalToString(req); err != nil {
 		return nil, err

--- a/internal/gengapic/testdata/lro_client_init.want
+++ b/internal/gengapic/testdata/lro_client_init.want
@@ -5,13 +5,11 @@ type internalFooClient interface {
 	Connection() *grpc.ClientConn
 	Zip(context.Context, *mypackagepb.Bar, ...gax.CallOption) (*ZipOperation, error)
 	ZipOperation(name string) *ZipOperation
-	ListOperations(context.Context, *longrunningpb.ListOperationsRequest, ...gax.CallOption) (*longrunningpb.ListOperationsResponse, error)
-	GetOperation(context.Context, *longrunningpb.GetOperationRequest, ...gax.CallOption) (*GetOperationOperation, error)
-	GetOperationOperation(name string) *GetOperationOperation
+	ListOperations(context.Context, *longrunningpb.ListOperationsRequest, ...gax.CallOption) *OperationIterator
+	GetOperation(context.Context, *longrunningpb.GetOperationRequest, ...gax.CallOption) (*longrunningpb.Operation, error)
 	DeleteOperation(context.Context, *longrunningpb.DeleteOperationRequest, ...gax.CallOption) error
 	CancelOperation(context.Context, *longrunningpb.CancelOperationRequest, ...gax.CallOption) error
-	WaitOperation(context.Context, *longrunningpb.WaitOperationRequest, ...gax.CallOption) (*WaitOperationOperation, error)
-	WaitOperationOperation(name string) *WaitOperationOperation
+	WaitOperation(context.Context, *longrunningpb.WaitOperationRequest, ...gax.CallOption) (*longrunningpb.Operation, error)
 }
 
 // FooClient is a client for interacting with Awesome Foo API.
@@ -58,11 +56,15 @@ func (c *FooClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.C
 	return c.internalClient.Zip(ctx, req, opts...)
 }
 
-func (c *FooClient) ListOperations(ctx context.Context, req *longrunningpb.ListOperationsRequest, opts ...gax.CallOption) (*longrunningpb.ListOperationsResponse, error) {
+func (c *FooClient) ZipOperation(name string) *ZipOperation {
+	return c.internalClient.ZipOperation(name)
+}
+
+func (c *FooClient) ListOperations(ctx context.Context, req *longrunningpb.ListOperationsRequest, opts ...gax.CallOption) *OperationIterator {
 	return c.internalClient.ListOperations(ctx, req, opts...)
 }
 
-func (c *FooClient) GetOperation(ctx context.Context, req *longrunningpb.GetOperationRequest, opts ...gax.CallOption) (*GetOperationOperation, error) {
+func (c *FooClient) GetOperation(ctx context.Context, req *longrunningpb.GetOperationRequest, opts ...gax.CallOption) (*longrunningpb.Operation, error) {
 	return c.internalClient.GetOperation(ctx, req, opts...)
 }
 
@@ -74,7 +76,7 @@ func (c *FooClient) CancelOperation(ctx context.Context, req *longrunningpb.Canc
 	return c.internalClient.CancelOperation(ctx, req, opts...)
 }
 
-func (c *FooClient) WaitOperation(ctx context.Context, req *longrunningpb.WaitOperationRequest, opts ...gax.CallOption) (*WaitOperationOperation, error) {
+func (c *FooClient) WaitOperation(ctx context.Context, req *longrunningpb.WaitOperationRequest, opts ...gax.CallOption) (*longrunningpb.Operation, error) {
 	return c.internalClient.WaitOperation(ctx, req, opts...)
 }
 

--- a/internal/gengapic/testdata/lro_client_init.want
+++ b/internal/gengapic/testdata/lro_client_init.want
@@ -56,6 +56,8 @@ func (c *FooClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.C
 	return c.internalClient.Zip(ctx, req, opts...)
 }
 
+// ZipOperation returns a new ZipOperation from a given name.
+// The name must be that of a previously created ZipOperation, possibly from a different process.
 func (c *FooClient) ZipOperation(name string) *ZipOperation {
 	return c.internalClient.ZipOperation(name)
 }


### PR DESCRIPTION
This adds the missing LRO type wrappers and it also fixes the the client_init tests to produce accurate generated code (e.g. `ListLocations` should return  a `LocationIterator` nor a `ListLocationsResponse`. 