### PR TITLE
gapic: gen RPC docs on wrapper methods

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -239,8 +239,9 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		return err
 	}
 
+	g.methodDoc(m)
+
 	if m.GetOutputType() == emptyType {
-		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) error {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName())
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
@@ -257,7 +258,6 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 
 	if g.isLRO(m) {
 		lroType := lroTypeName(m.GetName())
-		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s, error) {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), lroType)
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
@@ -279,7 +279,6 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		if err != nil {
 			return err
 		}
-		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) *%s {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), iter.iterTypeName)
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
@@ -295,7 +294,6 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 			return err
 		}
 
-		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 			clientTypeName, m.GetName(), servSpec.Name, serv.GetName(), m.GetName())
 		p("    return c.internalClient.%s(ctx, opts...)", m.GetName())
@@ -307,7 +305,6 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		if err != nil {
 			return err
 		}
-		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), servSpec.Name, serv.GetName(), m.GetName())
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
@@ -315,7 +312,6 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		p("")
 		return nil
 	default:
-		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s.%s, error) {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), outSpec.Name, outType.GetName())
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -240,6 +240,7 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 	}
 
 	if m.GetOutputType() == emptyType {
+		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) error {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName())
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
@@ -256,6 +257,7 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 
 	if g.isLRO(m) {
 		lroType := lroTypeName(m.GetName())
+		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s, error) {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), lroType)
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
@@ -277,6 +279,7 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		if err != nil {
 			return err
 		}
+		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) *%s {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), iter.iterTypeName)
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
@@ -292,6 +295,7 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 			return err
 		}
 
+		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 			clientTypeName, m.GetName(), servSpec.Name, serv.GetName(), m.GetName())
 		p("    return c.internalClient.%s(ctx, opts...)", m.GetName())
@@ -303,6 +307,7 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		if err != nil {
 			return err
 		}
+		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), servSpec.Name, serv.GetName(), m.GetName())
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
@@ -310,6 +315,7 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		p("")
 		return nil
 	default:
+		g.methodDoc(m)
 		p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s.%s, error) {",
 			clientTypeName, m.GetName(), inSpec.Name, inType.GetName(), outSpec.Name, outType.GetName())
 		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -239,6 +239,7 @@ func (g *generator) genClientWrapperMethod(m *descriptor.MethodDescriptorProto, 
 		return err
 	}
 
+	// Generate method documentation just before any method is generated.
 	g.methodDoc(m)
 
 	if m.GetOutputType() == emptyType {

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -353,7 +353,8 @@ func TestClientInit(t *testing.T) {
 		}
 		g.init(&request)
 		g.comments = map[proto.Message]string{
-			tst.serv: "Foo service does stuff.",
+			tst.serv:                "Foo service does stuff.",
+			tst.serv.GetMethod()[0]: "Does some stuff.",
 		}
 		g.mixins = tst.mixins
 		g.serviceConfig = &serviceconfig.Service{

--- a/internal/gengapic/gengrpc.go
+++ b/internal/gengapic/gengrpc.go
@@ -32,7 +32,6 @@ func (g *generator) genGRPCMethods(serv *descriptor.ServiceDescriptorProto, serv
 
 	methods := append(serv.GetMethod(), g.getMixinMethods()...)
 	for _, m := range methods {
-		g.methodDoc(m)
 		if err := g.genGRPCMethod(servName, serv, m); err != nil {
 			return errors.E(err, "method: %s", m.GetName())
 		}

--- a/internal/gengapic/testdata/deprecated_client_init.want
+++ b/internal/gengapic/testdata/deprecated_client_init.want
@@ -43,6 +43,7 @@ func (c *Client) Connection() *grpc.ClientConn {
 	return c.internalClient.Connection()
 }
 
+// Zip does some stuff.
 func (c *Client) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
 	return c.internalClient.Zip(ctx, req, opts...)
 }
@@ -134,6 +135,7 @@ type restClient struct {
 	host string
 }
 
+// Zip does some stuff.
 func (c *restClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
 	m := jsonpb.Marshaler{}
 	if jsonReq, err := m.MarshalToString(req); err != nil {

--- a/internal/gengapic/testdata/empty_client_init.want
+++ b/internal/gengapic/testdata/empty_client_init.want
@@ -41,6 +41,7 @@ func (c *Client) Connection() *grpc.ClientConn {
 	return c.internalClient.Connection()
 }
 
+// Zip does some stuff.
 func (c *Client) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
 	return c.internalClient.Zip(ctx, req, opts...)
 }
@@ -130,6 +131,7 @@ type restClient struct {
 	host string
 }
 
+// Zip does some stuff.
 func (c *restClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
 	m := jsonpb.Marshaler{}
 	if jsonReq, err := m.MarshalToString(req); err != nil {

--- a/internal/gengapic/testdata/foo_client_init.want
+++ b/internal/gengapic/testdata/foo_client_init.want
@@ -46,6 +46,7 @@ func (c *FooClient) Connection() *grpc.ClientConn {
 	return c.internalClient.Connection()
 }
 
+// Zip does some stuff.
 func (c *FooClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
 	return c.internalClient.Zip(ctx, req, opts...)
 }

--- a/internal/gengapic/testdata/foo_rest_client_init.want
+++ b/internal/gengapic/testdata/foo_rest_client_init.want
@@ -46,6 +46,7 @@ func (c *FooClient) Connection() *grpc.ClientConn {
 	return c.internalClient.Connection()
 }
 
+// Zip does some stuff.
 func (c *FooClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
 	return c.internalClient.Zip(ctx, req, opts...)
 }
@@ -75,6 +76,7 @@ type fooRESTClient struct {
 	host string
 }
 
+// Zip does some stuff.
 func (c *fooRESTClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
 	m := jsonpb.Marshaler{}
 	if jsonReq, err := m.MarshalToString(req); err != nil {

--- a/internal/gengapic/testdata/lro_client_init.want
+++ b/internal/gengapic/testdata/lro_client_init.want
@@ -52,6 +52,7 @@ func (c *FooClient) Connection() *grpc.ClientConn {
 	return c.internalClient.Connection()
 }
 
+// Zip does some stuff.
 func (c *FooClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*ZipOperation, error) {
 	return c.internalClient.Zip(ctx, req, opts...)
 }


### PR DESCRIPTION
Since the wrapper methods are the "public facing" methods of a `Client`, we should generate the RPC documentation on them instead of the internal, transport-based, interface implementation.