### PR TITLE
feat: generate rest client method implementation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - diregapic-dev-branch
   pull_request:
 
 jobs:

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -265,24 +265,47 @@ func TestClientInit(t *testing.T) {
 	servPlain := &descriptor.ServiceDescriptorProto{
 		Name: proto.String("Foo"),
 		Method: []*descriptor.MethodDescriptorProto{
-			{Name: proto.String("Zip"), InputType: proto.String(".mypackage.Bar"), OutputType: proto.String(".mypackage.Foo")},
+			{
+				Name:       proto.String("Zip"),
+				InputType:  proto.String(".mypackage.Bar"),
+				OutputType: proto.String(".mypackage.Foo"),
+				Options:    &descriptor.MethodOptions{},
+			},
 		},
 	}
 	servLRO := &descriptor.ServiceDescriptorProto{
 		Name: proto.String("Foo"),
 		Method: []*descriptor.MethodDescriptorProto{
-			{Name: proto.String("Zip"), InputType: proto.String(".mypackage.Bar"), OutputType: proto.String(".google.longrunning.Operation")},
+			{
+				Name:       proto.String("Zip"),
+				InputType:  proto.String(".mypackage.Bar"),
+				OutputType: proto.String(".google.longrunning.Operation"),
+				Options:    &descriptor.MethodOptions{},
+			},
 		},
 	}
 	servDeprecated := &descriptor.ServiceDescriptorProto{
 		Name: proto.String("Foo"),
 		Method: []*descriptor.MethodDescriptorProto{
-			{Name: proto.String("Zip"), InputType: proto.String(".mypackage.Bar"), OutputType: proto.String(".mypackage.Foo")},
+			{
+				Name:       proto.String("Zip"),
+				InputType:  proto.String(".mypackage.Bar"),
+				OutputType: proto.String(".mypackage.Foo"),
+				Options:    &descriptor.MethodOptions{},
+			},
 		},
 		Options: &descriptor.ServiceOptions{
 			Deprecated: proto.Bool(true),
 		},
 	}
+	for _, s := range []*descriptor.ServiceDescriptorProto{servPlain, servDeprecated, servLRO} {
+		proto.SetExtension(s.Method[0].Options, annotations.E_Http, &annotations.HttpRule{
+			Pattern: &annotations.HttpRule_Get{
+				Get: "/zip",
+			},
+		})
+	}
+
 	for _, tst := range []struct {
 		tstName   string
 		servName  string

--- a/internal/gengapic/options.go
+++ b/internal/gengapic/options.go
@@ -17,6 +17,7 @@ package gengapic
 import (
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/googleapis/gapic-generator-go/internal/errors"
@@ -119,16 +120,24 @@ func parseOptions(parameter *string) (*options, error) {
 		case "release-level":
 			opts.relLvl = strings.ToLower(val)
 		case "transport":
+			// Prevent duplicates
+			transports := map[transport]bool{}
 			for _, t := range strings.Split(val, "+") {
 				switch t {
 				case "grpc":
-					opts.transports = append(opts.transports, grpc)
+					transports[grpc] = true
 				case "rest":
-					opts.transports = append(opts.transports, rest)
+					transports[rest] = true
 				default:
 					return nil, errors.E(nil, "invalid transport option: %s", t)
 				}
 			}
+			for t := range transports {
+				opts.transports = append(opts.transports, t)
+			}
+			sort.Slice(opts.transports, func(i, j int) bool {
+				return opts.transports[i] < opts.transports[j]
+			})
 		}
 	}
 

--- a/internal/gengapic/options_test.go
+++ b/internal/gengapic/options_test.go
@@ -38,7 +38,7 @@ func TestParseOptions(t *testing.T) {
 		{
 			param: "transport=rest+grpc,go-gapic-package=path;pkg",
 			expectedOpts: &options{
-				transports: []transport{rest, grpc},
+				transports: []transport{grpc, rest},
 				pkgPath:    "path",
 				pkgName:    "pkg",
 				outDir:     "path",

--- a/internal/gengapic/testdata/deprecated_client_init.want
+++ b/internal/gengapic/testdata/deprecated_client_init.want
@@ -131,15 +131,7 @@ func (c *gRPCClient) Close() error {
 
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.
 type restClient struct {
-	host string
+	endpoint string
+	httpClient http.Client
 }
 
-func (c *restClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
-	m := jsonpb.Marshaler{}
-	if jsonReq, err := m.MarshalToString(req); err != nil {
-		return nil, err
-
-	}
-	return nil, nil
-
-}

--- a/internal/gengapic/testdata/empty_client_init.want
+++ b/internal/gengapic/testdata/empty_client_init.want
@@ -127,15 +127,7 @@ func (c *gRPCClient) Close() error {
 
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.
 type restClient struct {
-	host string
+	endpoint string
+	httpClient http.Client
 }
 
-func (c *restClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
-	m := jsonpb.Marshaler{}
-	if jsonReq, err := m.MarshalToString(req); err != nil {
-		return nil, err
-
-	}
-	return nil, nil
-
-}

--- a/internal/gengapic/testdata/foo_rest_client_init.want
+++ b/internal/gengapic/testdata/foo_rest_client_init.want
@@ -72,51 +72,7 @@ func (c *FooClient) TestIamPermissions(ctx context.Context, req *iampb.TestIamPe
 
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.
 type fooRESTClient struct {
-	host string
+	endpoint string
+	httpClient http.Client
 }
 
-func (c *fooRESTClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
-	m := jsonpb.Marshaler{}
-	if jsonReq, err := m.MarshalToString(req); err != nil {
-		return nil, err
-
-	}
-	return nil, nil
-
-}
-func (c *fooRESTClient) GetLocation(ctx context.Context, req *locationpb.GetLocationRequest, opts ...gax.CallOption) (*locationpb.Location, error) {
-	m := jsonpb.Marshaler{}
-	if jsonReq, err := m.MarshalToString(req); err != nil {
-		return nil, err
-
-	}
-	return nil, nil
-
-}
-func (c *fooRESTClient) SetIamPolicy(ctx context.Context, req *iampb.SetIamPolicyRequest, opts ...gax.CallOption) (*iampb.Policy, error) {
-	m := jsonpb.Marshaler{}
-	if jsonReq, err := m.MarshalToString(req); err != nil {
-		return nil, err
-
-	}
-	return nil, nil
-
-}
-func (c *fooRESTClient) GetIamPolicy(ctx context.Context, req *iampb.GetIamPolicyRequest, opts ...gax.CallOption) (*iampb.Policy, error) {
-	m := jsonpb.Marshaler{}
-	if jsonReq, err := m.MarshalToString(req); err != nil {
-		return nil, err
-
-	}
-	return nil, nil
-
-}
-func (c *fooRESTClient) TestIamPermissions(ctx context.Context, req *iampb.TestIamPermissionsRequest, opts ...gax.CallOption) (*iampb.TestIamPermissionsResponse, error) {
-	m := jsonpb.Marshaler{}
-	if jsonReq, err := m.MarshalToString(req); err != nil {
-		return nil, err
-
-	}
-	return nil, nil
-
-}

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -34,6 +34,7 @@ protoc \
 	--experimental_allow_proto3_optional \
 	--go_out=plugins=grpc:./gen \
 	--go_gapic_out ./gen \
+    --go_gapic_opt 'transport=rest+grpc' \
 	--go_gapic_opt 'go-gapic-package=github.com/googleapis/gapic-showcase/client;client' \
 	--go_gapic_opt 'grpc-service-config=showcase_grpc_service_config.json' \
 	--go_gapic_opt 'api-service-config=showcase_v1beta1.yaml' \

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -34,7 +34,7 @@ protoc \
 	--experimental_allow_proto3_optional \
 	--go_out=plugins=grpc:./gen \
 	--go_gapic_out ./gen \
-    --go_gapic_opt 'transport=rest+grpc' \
+	--go_gapic_opt 'transport=rest+grpc' \
 	--go_gapic_opt 'go-gapic-package=github.com/googleapis/gapic-showcase/client;client' \
 	--go_gapic_opt 'grpc-service-config=showcase_grpc_service_config.json' \
 	--go_gapic_opt 'api-service-config=showcase_v1beta1.yaml' \

--- a/test.sh
+++ b/test.sh
@@ -37,13 +37,13 @@ generate() {
 }
 
 echo "Generating Cloud KMS v1"
-generate --go_gapic_opt 'go-gapic-package=cloud.google.com/go/kms/apiv1;kms' $GOOGLEAPIS/google/cloud/kms/v1/*.proto
+generate --go_gapic_opt 'go-gapic-package=cloud.google.com/go/kms/apiv1;kms,transport=grpc+rest' $GOOGLEAPIS/google/cloud/kms/v1/*.proto
 
 echo "Generating Cloud Data Catalog v1beta1"
-generate --go_gapic_opt 'go-gapic-package=cloud.google.com/go/datacatalog/apiv1beta1;datacatalog' $GOOGLEAPIS/google/cloud/datacatalog/v1beta1/*.proto
+generate --go_gapic_opt 'go-gapic-package=cloud.google.com/go/datacatalog/apiv1beta1;datacatalog,transport=grpc+rest' $GOOGLEAPIS/google/cloud/datacatalog/v1beta1/*.proto
 
 echo "Generating Cloud Text-to-Speech v1 w/gRPC ServiceConfig"
-generate --go_gapic_opt 'go-gapic-package=cloud.google.com/go/texttospeech/apiv1;texttospeech' --go_gapic_opt "grpc-service-config=$GOOGLEAPIS/google/cloud/texttospeech/v1/texttospeech_grpc_service_config.json" $GOOGLEAPIS/google/cloud/texttospeech/v1/*.proto
+generate --go_gapic_opt 'go-gapic-package=cloud.google.com/go/texttospeech/apiv1;texttospeech,transport=grpc+rest' --go_gapic_opt "grpc-service-config=$GOOGLEAPIS/google/cloud/texttospeech/v1/texttospeech_grpc_service_config.json" $GOOGLEAPIS/google/cloud/texttospeech/v1/*.proto
 
 echo "Generation complete"
 


### PR DESCRIPTION
This change generates code for unary and empty unary methods for REST
based clients.

TODO:
* Set http headers
* Handle query parameters
* Expose REST client factory function
* Add nil returning stubs for unsupported methods