### PR TITLE
feat: Integration test:  Showcase compliance suite

### DIFF
--- a/showcase/README.md
+++ b/showcase/README.md
@@ -47,8 +47,8 @@ test function: `defer check(t)`.
 ### Updating the Showcase version
 
 To update the version of Showcase referenced for artifact retrieval, change the
-`VERSION` variable in `showcase.bash`. It is also good practice to update the
-`go.mod` to this version.
+`SHOWCASE_SEMVER` variable in `showcase.bash`, and the `showcaseSemver` in
+`main_test.go`. It is also good practice to update the `go.mod` to this version.
 
 ### Cleaning up after the tests
 

--- a/showcase/README.md
+++ b/showcase/README.md
@@ -8,8 +8,8 @@ gapic-generator-go, as well as the script used to setup and execute them.
 The tests can be run out-of-the-box in the normal `go test` fashion, so long as
 there is a `gapic-showcase` server already running locally. This does not test
 the Showcase client generated with the locally installed generator - it would
-use the released version of the GAPIC. Running `make test` will execute the
-tests against the locally installed generator.
+use the released version of the GAPIC. Running `make test` (from the repository
+root) will execute the tests against the locally installed generator.
 
 To test the local generator, use the `showcase.bash` script. It does the
 following:
@@ -19,9 +19,9 @@ These are the compiled proto descriptor set, the retry configuration, and a
 pre-compiled server binary.
 
 1. Using protoc and the retrieved artifacts as input, the Go protobuf/gRPC
-bindings, and the Go GAPIC are generated, the latter with the
-**locally installed** gapic-generator-go. Make sure to `make install` so that
-any new changes are utilized during generation.
+bindings, and the Go GAPIC are generated, the latter with the **locally
+installed** gapic-generator-go. Make sure to `make install` (from the repository
+root) so that any new changes are utilized during generation.
 
 1. The submodule's `go.mod` is temporarily edited to replace the remote
 dependency on `github.com/googleapis/gapic-showcase` with the locally generated

--- a/showcase/compliance_test.go
+++ b/showcase/compliance_test.go
@@ -1,0 +1,123 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package showcase
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+
+	showcase "github.com/googleapis/gapic-showcase/client"
+	genprotopb "github.com/googleapis/gapic-showcase/server/genproto"
+	gax "github.com/googleapis/gax-go/v2"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+var complianceClient *showcase.ComplianceClient
+
+// TestComplianceSuite ensures the REST test suite that we require GAPIC generators to pass works
+// correctly. GAPIC generators should generate GAPICs for the Showcase API and issue the unary calls
+// defined in the test suite using the GAPIC surface. The generators' test should follow the
+// high-level logic below, as described in the comments.
+func TestComplianceSuite(t *testing.T) {
+	defer check(t) // ???
+	type method func(ctx context.Context, req *genprotopb.RepeatRequest, opts ...gax.CallOption) (*genprotopb.RepeatResponse, error)
+
+	// Set handlers for each test case. When GAPIC generator tests do this, they should have
+	// each of their handlers invoking the correct GAPIC library method for the Showcase API.
+	restRPCs := map[string]method{
+		"Compliance.RepeatDataBody":                 complianceClient.RepeatDataBody,
+		"Compliance.RepeatDataBodyInfo":             complianceClient.RepeatDataBodyInfo,
+		"Compliance.RepeatDataQuery":                complianceClient.RepeatDataQuery,
+		"Compliance.RepeatDataSimplePath":           complianceClient.RepeatDataSimplePath,
+		"Compliance.RepeatDataPathResource":         complianceClient.RepeatDataPathResource,
+		"Compliance.RepeatDataPathTrailingResource": complianceClient.RepeatDataPathTrailingResource,
+	}
+
+	_ = restRPCs
+	/*
+		        see if suite file exists in pwd; if not, copy it  from
+		         `go env GOMODCACHE`/github.com/googleapis/gapic-showcase@v0.15.0/schema/google/showcase/v1beta1/compliance_suite.json
+		(or .../server/services/compliance_suite.json since that symlink does not seem to exist
+		)
+		       then open the file
+	*/
+
+	suite, err := getComplianceSuite()
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	_ = suite
+	//	t.Errorf("*** path is: %s", reflect.TypeOf(showcase.ComplianceClient{}).PkgPath())
+
+	// exec, _ := os.Executable()
+	// t.Errorf("*** executable is at: %s", exec)
+
+}
+
+func getComplianceSuite() (*genprotopb.ComplianceSuite, error) {
+	filePath, err := getComplianceSuiteFile()
+	if err != nil {
+		return nil, err
+	}
+
+	complianceSuiteJSON, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("could not open suite file %q", filePath)
+	}
+
+	suite := &genprotopb.ComplianceSuite{}
+	if err := protojson.Unmarshal(complianceSuiteJSON, suite); err != nil {
+		return nil, fmt.Errorf("error unmarshalling from json %s:\n   file: %s\n   input was: %s", err, filePath, complianceSuiteJSON)
+	}
+	return suite, nil
+}
+
+// getComplianceSuiteFile returns the path to the compliance_suite.json file at the current
+// directory, if a file with that name is found there, or in the Showcase module's path
+// optherwise. If such a filename cannot be found in either place, this returns an error.
+func getComplianceSuiteFile() (string, error) {
+	const fileName = "compliance_suite.json"
+	pathInShowcase := path.Join("github.com", "googleapis", "gapic-showcase@v"+showcaseSemver, "server", "services", fileName)
+
+	// Return the file in the current directory, if it exists there.
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("could not determine current directory: %s", err)
+	}
+	filePath := path.Join(currentDir, fileName)
+	if _, err := os.Stat(filePath); err == nil {
+		return filePath, nil
+	}
+
+	// Return the file in the installed module.
+	goCmd := exec.Command("go", "env", "GOMODCACHE")
+	output, err := goCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("could not determine GOMODCACHE: %s", err)
+	}
+
+	filePath = path.Join(strings.TrimSpace(string(output)), pathInShowcase)
+	if _, err := os.Stat(filePath); err != nil {
+		return "", fmt.Errorf("could not determine location of %q; output: %s", fileName, err)
+	}
+
+	return filePath, nil
+}

--- a/showcase/compliance_test.go
+++ b/showcase/compliance_test.go
@@ -34,16 +34,13 @@ import (
 
 var complianceClient *showcase.ComplianceClient
 
-// TestComplianceSuite ensures the REST test suite that we require GAPIC generators to pass works
-// correctly. GAPIC generators should generate GAPICs for the Showcase API and issue the unary calls
-// defined in the test suite using the GAPIC surface. The generators' test should follow the
-// high-level logic below, as described in the comments.
+// TestComplianceSuite is used to ensure the REST transport for the GAPIC client emitted by this
+// generator for the Showcase API works correctly. It depends on complianceClient having been
+// already initialized to be REST client.
 func TestComplianceSuite(t *testing.T) {
-	defer check(t) // ???
+	defer check(t)
 	type method func(ctx context.Context, req *genprotopb.RepeatRequest, opts ...gax.CallOption) (*genprotopb.RepeatResponse, error)
 
-	// Set handlers for each test case. When GAPIC generator tests do this, they should have
-	// each of their handlers invoking the correct GAPIC library method for the Showcase API.
 	restRPCs := map[string]method{
 		"Compliance.RepeatDataBody":                 complianceClient.RepeatDataBody,
 		"Compliance.RepeatDataBodyInfo":             complianceClient.RepeatDataBodyInfo,
@@ -86,6 +83,8 @@ func TestComplianceSuite(t *testing.T) {
 	}
 }
 
+// getComplianceSuite returns the ComplianceSuite read and parsed from the appropriate location
+// (current directory if available, otherwise the module path).
 func getComplianceSuite() (*genprotopb.ComplianceSuite, error) {
 	filePath, err := getComplianceSuiteFile()
 	if err != nil {

--- a/showcase/go.mod
+++ b/showcase/go.mod
@@ -10,5 +10,5 @@ require (
 	google.golang.org/api v0.46.0
 	google.golang.org/genproto v0.0.0-20210506142907-4a47615972c2
 	google.golang.org/grpc v1.37.0
-	google.golang.org/protobuf v1.26.0 // indirect
+	google.golang.org/protobuf v1.26.0
 )

--- a/showcase/go.mod
+++ b/showcase/go.mod
@@ -10,4 +10,5 @@ require (
 	google.golang.org/api v0.46.0
 	google.golang.org/genproto v0.0.0-20210506142907-4a47615972c2
 	google.golang.org/grpc v1.37.0
+	google.golang.org/protobuf v1.26.0 // indirect
 )

--- a/showcase/main_test.go
+++ b/showcase/main_test.go
@@ -68,6 +68,7 @@ func TestMain(m *testing.M) {
 	}
 	defer sequenceClient.Close()
 
+	// TODO: Change to use REST client: complianceClient, err = showcase.NewComplianceRESTClient(ctx, opt)
 	complianceClient, err = showcase.NewComplianceClient(ctx, opt)
 	if err != nil {
 		log.Fatal(err)

--- a/showcase/main_test.go
+++ b/showcase/main_test.go
@@ -68,7 +68,8 @@ func TestMain(m *testing.M) {
 	}
 	defer sequenceClient.Close()
 
-	// TODO: Change to use REST client: complianceClient, err = showcase.NewComplianceRESTClient(ctx, opt)
+	// TODO: Change to use REST client once the constructor is in place:
+	//  complianceClient, err = showcase.NewComplianceRESTClient(ctx, opt)
 	complianceClient, err = showcase.NewComplianceClient(ctx, opt)
 	if err != nil {
 		log.Fatal(err)

--- a/showcase/main_test.go
+++ b/showcase/main_test.go
@@ -37,6 +37,8 @@ func init() {
 	registerIgnoreGoroutine("google.golang.org/grpc.(*addrConn).connect")
 }
 
+const showcaseSemver = "0.15.0"
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 
@@ -65,6 +67,12 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 	defer sequenceClient.Close()
+
+	complianceClient, err = showcase.NewComplianceClient(ctx, opt)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer complianceClient.Close()
 
 	os.Exit(m.Run())
 }

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -39,7 +39,8 @@ protoc \
 	--go_gapic_opt 'grpc-service-config=showcase_grpc_service_config.json' \
 	--go_gapic_opt 'api-service-config=showcase_v1beta1.yaml' \
 	--descriptor_set_in=<(curl -sSL https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/gapic-showcase-$SHOWCASE_SEMVER.desc) \
-	google/showcase/v1beta1/echo.proto google/showcase/v1beta1/identity.proto google/showcase/v1beta1/sequence.proto
+	google/showcase/v1beta1/echo.proto google/showcase/v1beta1/identity.proto google/showcase/v1beta1/sequence.proto \
+        google/showcase/v1beta1/compliance.proto
 
 hostos=$(go env GOHOSTOS)
 hostarch=$(go env GOHOSTARCH)
@@ -59,6 +60,7 @@ popd
 go mod edit -replace=github.com/googleapis/gapic-showcase=./gen/github.com/googleapis/gapic-showcase
 
 curl -sSL https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/gapic-showcase-$SHOWCASE_SEMVER-$hostos-$hostarch.tar.gz | tar xz
+curl -sSL https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/compliance_suite.json
 ./gapic-showcase run &
 showcase_pid=$!
 

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -60,7 +60,8 @@ popd
 go mod edit -replace=github.com/googleapis/gapic-showcase=./gen/github.com/googleapis/gapic-showcase
 
 curl -sSL https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/gapic-showcase-$SHOWCASE_SEMVER-$hostos-$hostarch.tar.gz | tar xz
-curl -sSL https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/compliance_suite.json
+curl -sSL -O https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/compliance_suite.json
+ls -la 
 ./gapic-showcase run &
 showcase_pid=$!
 

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -61,7 +61,7 @@ go mod edit -replace=github.com/googleapis/gapic-showcase=./gen/github.com/googl
 
 curl -sSL https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/gapic-showcase-$SHOWCASE_SEMVER-$hostos-$hostarch.tar.gz | tar xz
 curl -sSL -O https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/compliance_suite.json
-ls -la 
+
 ./gapic-showcase run &
 showcase_pid=$!
 


### PR DESCRIPTION
This tests the Showcase compliance suite against a running Showcase server. The client-side checks are merely that the returned data equals the sent data. However, when the requests are made over REST, the Showcase server will check various aspects of the REST transcoding, including optional field presence, headers, etc., and informatively fail the call if any of the checks fail.

**NOTE**: At the moment gapic-generator-go does not yet expose a factory function for REST clients. Using that when available remains a TODO. For the time being, we're using a gRPC client, which will trivially pass the test.