### PR TITLE
feat: stub out currently unsupported method types for REST clients

### DIFF
--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -162,10 +162,9 @@ func (g *generator) genRESTMethod(servName string, serv *descriptor.ServiceDescr
 }
 
 func (g *generator) serverStreamRESTCall(servName string, s *descriptor.ServiceDescriptorProto, m *descriptor.MethodDescriptorProto) error {
-	// Streaming calls will most likely NEVER be supported for REST clients,
+	// Streaming calls are not currently supported for REST clients,
 	// but the interface signature must be preserved.
-	// Making sure not to call streaming methods on a REST client, or checking for
-	// errors in a situation with mixed gRPC and REST clients, is left to user code.
+	// Unimplemented REST methods will always error.
 
 	inType := g.descInfo.Type[m.GetInputType()]
 
@@ -193,10 +192,9 @@ func (g *generator) serverStreamRESTCall(servName string, s *descriptor.ServiceD
 }
 
 func (g *generator) noRequestStreamRESTCall(servName string, s *descriptor.ServiceDescriptorProto, m *descriptor.MethodDescriptorProto) error {
-	// Streaming calls will most likely NEVER be supported for REST clients,
+	// Streaming calls are not currently supported for REST clients,
 	// but the interface signature must be preserved.
-	// Making sure not to call streaming methods on a REST client, or checking for
-	// errors in a situation with mixed gRPC and REST clients, is left to user code.
+	// Unimplemented REST methods will always error.
 
 	p := g.printf
 

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -167,7 +167,7 @@ func (g *generator) serverStreamRESTCall(servName string, s *descriptor.ServiceD
 	// Making sure not to call streaming methods on a REST client, or checking for
 	// errors in a situation with mixed gRPC and REST clients, is left to user code.
 
-	inType := g.descInfo.Type[*m.InputType]
+	inType := g.descInfo.Type[m.GetInputType()]
 
 	inSpec, err := g.descInfo.ImportSpec(inType)
 	if err != nil {
@@ -185,8 +185,7 @@ func (g *generator) serverStreamRESTCall(servName string, s *descriptor.ServiceD
 	lowcaseServName := lowcaseRestClientName(servName)
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), servSpec.Name, s.GetName(), m.GetName())
-	p("  var resp %s.%s_%sClient", servSpec.Name, s.GetName(), m.GetName())
-	p("  return resp, fmt.Errorf(\"%s not yet supported for REST clients\")", m.GetName())
+	p(`  return nil, fmt.Errorf("%s not yet supported for REST clients")`, m.GetName())
 	p("}")
 	p("")
 
@@ -211,8 +210,7 @@ func (g *generator) noRequestStreamRESTCall(servName string, s *descriptor.Servi
 
 	p("func (c *%s) %s(ctx context.Context, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 		lowcaseServName, m.GetName(), servSpec.Name, s.GetName(), m.GetName())
-	p("  var resp %s.%s_%sClient", servSpec.Name, s.GetName(), m.GetName())
-	p("  return resp, fmt.Errorf(\"%s not yet supported for REST clients\")", m.GetName())
+	p(`  return nil, fmt.Errorf("%s not yet supported for REST clients")`, m.GetName())
 	p("}")
 	p("")
 
@@ -241,13 +239,13 @@ func (g *generator) pagingRESTCall(servName string, m *descriptor.MethodDescript
 	p("it := &%s{}", pt.iterTypeName)
 	p("req = proto.Clone(req).(*%s.%s)", inSpec.Name, inType.GetName())
 	p("it.InternalFetch = func(pageSize int, pageToken string) ([]%s, string, error) {", pt.elemTypeName)
-	p("return nil, \"\", fmt.Errorf(\"%s not yet supported for REST clients\")", m.GetName())
+	p(`return nil, "", fmt.Errorf("%s not yet supported for REST clients")`, m.GetName())
 	p("}")
 	p("")
 	p("fetch := func(pageSize int, pageToken string) (string, error) {")
 	p("  items, nextPageToken, err := it.InternalFetch(pageSize, pageToken)")
 	p("  if err != nil {")
-	p("    return \"\", err")
+	p(`    return "", err`)
 	p("  }")
 	p("  it.items = append(it.items, items...)")
 	p("  return nextPageToken, nil")
@@ -282,7 +280,7 @@ func (g *generator) lroRESTCall(servName string, m *descriptor.MethodDescriptorP
 	lroType := lroTypeName(m.GetName())
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s, error) {",
 		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), lroType)
-	p("    return nil, fmt.Errorf(\"%s not yet supported for REST clients\")", m.GetName())
+	p(`    return nil, fmt.Errorf("%s not yet supported for REST clients")`, m.GetName())
 	p("}")
 	p("")
 


### PR DESCRIPTION
The initial scope for DIREGAPIC is unary method calls, but clients
must still expose _all_ API methods in order to fit the internal interface.
Just return helfpul errors for now.