### PR TITLE
gapic: include import hint in all examples

### DIFF
--- a/internal/gengapic/example.go
+++ b/internal/gengapic/example.go
@@ -79,23 +79,17 @@ func (g *generator) exampleMethod(pkgName, servName string, m *descriptor.Method
 	g.imports[inSpec] = true
 
 	p("func Example%sClient_%s() {", servName, m.GetName())
+	p("// import %s \"%s\"", inSpec.Name, inSpec.Path)
 
 	pf, err := g.pagingField(m)
 	if err != nil {
 		return err
 	}
 
-	if *m.OutputType != emptyType {
-		p("// import %s \"%s\"", inSpec.Name, inSpec.Path)
-		if pf == nil {
-			p("")
-		}
-	}
-
 	if pf != nil {
 		p("// import \"google.golang.org/api/iterator\"")
-		p("")
 	}
+	p("")
 
 	g.exampleInitClient(pkgName, servName)
 

--- a/internal/gengapic/testdata/empty_example.want
+++ b/internal/gengapic/testdata/empty_example.want
@@ -11,6 +11,8 @@ func ExampleNewClient() {
 }
 
 func ExampleClient_GetEmptyThing() {
+	// import mypackagepb "mypackage"
+
 	ctx := context.Background()
 	c, err := Foo.NewClient(ctx)
 	if err != nil {
@@ -351,6 +353,8 @@ func ExampleClient_GetOperation() {
 }
 
 func ExampleClient_DeleteOperation() {
+	// import longrunningpb "google.golang.org/genproto/googleapis/longrunning"
+
 	ctx := context.Background()
 	c, err := Foo.NewClient(ctx)
 	if err != nil {
@@ -368,6 +372,8 @@ func ExampleClient_DeleteOperation() {
 }
 
 func ExampleClient_CancelOperation() {
+	// import longrunningpb "google.golang.org/genproto/googleapis/longrunning"
+
 	ctx := context.Background()
 	c, err := Foo.NewClient(ctx)
 	if err != nil {

--- a/internal/gengapic/testdata/foo_example.want
+++ b/internal/gengapic/testdata/foo_example.want
@@ -11,6 +11,8 @@ func ExampleNewFooClient() {
 }
 
 func ExampleFooClient_GetEmptyThing() {
+	// import mypackagepb "mypackage"
+
 	ctx := context.Background()
 	c, err := Bar.NewFooClient(ctx)
 	if err != nil {
@@ -351,6 +353,8 @@ func ExampleFooClient_GetOperation() {
 }
 
 func ExampleFooClient_DeleteOperation() {
+	// import longrunningpb "google.golang.org/genproto/googleapis/longrunning"
+
 	ctx := context.Background()
 	c, err := Bar.NewFooClient(ctx)
 	if err != nil {
@@ -368,6 +372,8 @@ func ExampleFooClient_DeleteOperation() {
 }
 
 func ExampleFooClient_CancelOperation() {
+	// import longrunningpb "google.golang.org/genproto/googleapis/longrunning"
+
 	ctx := context.Background()
 	c, err := Bar.NewFooClient(ctx)
 	if err != nil {


### PR DESCRIPTION
IDK why the original implementation of example import hints only generated the hint for methods with non-Empty response types...but that doesn't seem right because a Delete still has to provide a request message, which always comes from go-genproto. Fixing that oddity and some weird conditional organization.