### PR TITLE
chore: ignore product labels

### DIFF
--- a/.github/product-label.yaml
+++ b/.github/product-label.yaml
@@ -1,0 +1,2 @@
+---
+product: false


### PR DESCRIPTION
We don't need API product labels in this repo because this is not a client repo.