### PR TITLE
chore: fix config to ignore product labels

### DIFF
--- a/.github/auto-label.yaml
+++ b/.github/auto-label.yaml
@@ -1,0 +1,2 @@
+---
+product: false

--- a/.github/label-sync.yaml
+++ b/.github/label-sync.yaml
@@ -1,3 +1,2 @@
 ---
 ignored: true
-

--- a/.github/label-sync.yaml
+++ b/.github/label-sync.yaml
@@ -1,0 +1,3 @@
+---
+ignored: true
+

--- a/.github/product-label.yaml
+++ b/.github/product-label.yaml
@@ -1,2 +1,0 @@
----
-product: false


### PR DESCRIPTION
I don't think the `product-label.yaml` file does anything.