### PR TITLE
feat: headers, utils, and REST client construction

### DIFF
--- a/internal/gengapic/testdata/deprecated_client_init.want
+++ b/internal/gengapic/testdata/deprecated_client_init.want
@@ -133,7 +133,50 @@ func (c *gRPCClient) Close() error {
 
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.
 type restClient struct {
+	// The http endpoint to connect to.
 	endpoint string
-	httpClient http.Client
+
+	// The http client.
+	httpClient *http.Client
+
+	// The x-goog-* metadata to be sent with each request.
+	xGoogMetadata metadata.MD
 }
 
+// NewRESTClient creates a new foo rest client.
+//
+// Foo service does stuff.
+//
+// Deprecated: Foo may be removed in a future version.
+func NewRESTClient(ctx context.Context, opts ...option.ClientOption) (*Client, error) {
+	clientOpts := defaultRESTClientOptions()
+	httpClient, endpoint, err := httptransport.NewClient(ctx, append(clientOpts, opts...)...)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &restClient{
+		endpoint: endpoint,
+		httpClient: httpClient,
+	}
+	c.setGoogleClientInfo()
+
+	return &Client{internalClient: c, CallOptions: defaultCallOptions()}, nil
+}
+
+// setGoogleClientInfo sets the name and version of the application in
+// the `x-goog-api-client` header passed on each request. Intended for
+// use by Google-written clients.
+func (c *restClient) setGoogleClientInfo(keyval ...string) {
+	kv := append([]string{"gl-go", versionGo()}, keyval...)
+	kv = append(kv, "gapic", versionClient, "gax", gax.Version, "rest", "UNKNOWN")
+	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
+}
+
+func (c *restClient) Close() error {
+	return nil
+}
+
+func (c *restClient) Connection() *grpc.ClientConn {
+	return nil
+}

--- a/internal/gengapic/testdata/deprecated_client_init.want
+++ b/internal/gengapic/testdata/deprecated_client_init.want
@@ -173,10 +173,16 @@ func (c *restClient) setGoogleClientInfo(keyval ...string) {
 	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 
+// Close closes the connection to the API service. The user should invoke this when
+// the client is no longer required.
 func (c *restClient) Close() error {
+	c.httpClient.CloseIdleConnections()
 	return nil
 }
 
+// Connection returns a connection to the API service.
+//
+// Deprecated.
 func (c *restClient) Connection() *grpc.ClientConn {
 	return nil
 }

--- a/internal/gengapic/testdata/empty_client_init.want
+++ b/internal/gengapic/testdata/empty_client_init.want
@@ -129,7 +129,48 @@ func (c *gRPCClient) Close() error {
 
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.
 type restClient struct {
+	// The http endpoint to connect to.
 	endpoint string
-	httpClient http.Client
+
+	// The http client.
+	httpClient *http.Client
+
+	// The x-goog-* metadata to be sent with each request.
+	xGoogMetadata metadata.MD
 }
 
+// NewRESTClient creates a new foo rest client.
+//
+// Foo service does stuff.
+func NewRESTClient(ctx context.Context, opts ...option.ClientOption) (*Client, error) {
+	clientOpts := defaultRESTClientOptions()
+	httpClient, endpoint, err := httptransport.NewClient(ctx, append(clientOpts, opts...)...)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &restClient{
+		endpoint: endpoint,
+		httpClient: httpClient,
+	}
+	c.setGoogleClientInfo()
+
+	return &Client{internalClient: c, CallOptions: defaultCallOptions()}, nil
+}
+
+// setGoogleClientInfo sets the name and version of the application in
+// the `x-goog-api-client` header passed on each request. Intended for
+// use by Google-written clients.
+func (c *restClient) setGoogleClientInfo(keyval ...string) {
+	kv := append([]string{"gl-go", versionGo()}, keyval...)
+	kv = append(kv, "gapic", versionClient, "gax", gax.Version, "rest", "UNKNOWN")
+	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
+}
+
+func (c *restClient) Close() error {
+	return nil
+}
+
+func (c *restClient) Connection() *grpc.ClientConn {
+	return nil
+}

--- a/internal/gengapic/testdata/empty_client_init.want
+++ b/internal/gengapic/testdata/empty_client_init.want
@@ -167,10 +167,16 @@ func (c *restClient) setGoogleClientInfo(keyval ...string) {
 	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 
+// Close closes the connection to the API service. The user should invoke this when
+// the client is no longer required.
 func (c *restClient) Close() error {
+	c.httpClient.CloseIdleConnections()
 	return nil
 }
 
+// Connection returns a connection to the API service.
+//
+// Deprecated.
 func (c *restClient) Connection() *grpc.ClientConn {
 	return nil
 }

--- a/internal/gengapic/testdata/foo_rest_client_init.want
+++ b/internal/gengapic/testdata/foo_rest_client_init.want
@@ -111,10 +111,16 @@ func (c *fooRESTClient) setGoogleClientInfo(keyval ...string) {
 	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 
+// Close closes the connection to the API service. The user should invoke this when
+// the client is no longer required.
 func (c *fooRESTClient) Close() error {
+	c.httpClient.CloseIdleConnections()
 	return nil
 }
 
+// Connection returns a connection to the API service.
+//
+// Deprecated.
 func (c *fooRESTClient) Connection() *grpc.ClientConn {
 	return nil
 }

--- a/internal/gengapic/testdata/foo_rest_client_init.want
+++ b/internal/gengapic/testdata/foo_rest_client_init.want
@@ -73,7 +73,48 @@ func (c *FooClient) TestIamPermissions(ctx context.Context, req *iampb.TestIamPe
 
 // Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.
 type fooRESTClient struct {
+	// The http endpoint to connect to.
 	endpoint string
-	httpClient http.Client
+
+	// The http client.
+	httpClient *http.Client
+
+	// The x-goog-* metadata to be sent with each request.
+	xGoogMetadata metadata.MD
 }
 
+// NewFooRESTClient creates a new foo rest client.
+//
+// Foo service does stuff.
+func NewFooRESTClient(ctx context.Context, opts ...option.ClientOption) (*FooClient, error) {
+	clientOpts := defaultFooRESTClientOptions()
+	httpClient, endpoint, err := httptransport.NewClient(ctx, append(clientOpts, opts...)...)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &fooRESTClient{
+		endpoint: endpoint,
+		httpClient: httpClient,
+	}
+	c.setGoogleClientInfo()
+
+	return &FooClient{internalClient: c, CallOptions: defaultFooCallOptions()}, nil
+}
+
+// setGoogleClientInfo sets the name and version of the application in
+// the `x-goog-api-client` header passed on each request. Intended for
+// use by Google-written clients.
+func (c *fooRESTClient) setGoogleClientInfo(keyval ...string) {
+	kv := append([]string{"gl-go", versionGo()}, keyval...)
+	kv = append(kv, "gapic", versionClient, "gax", gax.Version, "rest", "UNKNOWN")
+	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
+}
+
+func (c *fooRESTClient) Close() error {
+	return nil
+}
+
+func (c *fooRESTClient) Connection() *grpc.ClientConn {
+	return nil
+}


### PR DESCRIPTION
GAPICs that build REST clients now include factory functions that
create REST clients, as well as commensurate utilities.