### PR TITLE
gapic: fix enum header conversion

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -258,7 +258,7 @@ func (g *generator) insertMetadata(m *descriptor.MethodDescriptorProto) error {
 				// is named with the enum name and the _name suffix. If it is a
 				// nested enum, the name is prefixed with the parent message name.
 				// For example, Severity_name or Error_Severity_name.
-				accessor = fmt.Sprintf("%s.%s_name[%s]", imp.Name, n, accessor)
+				accessor = fmt.Sprintf("%s.%s_name[int32(%s)]", imp.Name, n, accessor)
 			}
 
 			// URL encode key & values separately per aip.dev/4222.

--- a/internal/gengapic/testdata/method_GetEmptyThing.want
+++ b/internal/gengapic/testdata/method_GetEmptyThing.want
@@ -4,7 +4,7 @@ func (c *fooGRPCClient) GetEmptyThing(ctx context.Context, req *mypackagepb.Inpu
 		defer cancel()
 		ctx = cctx
 	}
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[req.GetTopLevelEnum()], "nested_enum", mypackagepb.InputType_NestedEnum_name[req.GetNestedEnum()]))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[int32(req.GetTopLevelEnum())], "nested_enum", mypackagepb.InputType_NestedEnum_name[int32(req.GetNestedEnum())]))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append((*c.CallOptions).GetEmptyThing[0:len((*c.CallOptions).GetEmptyThing):len((*c.CallOptions).GetEmptyThing)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -1,5 +1,5 @@
 func (c *fooGRPCClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[req.GetTopLevelEnum()], "nested_enum", mypackagepb.InputType_NestedEnum_name[req.GetNestedEnum()]))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[int32(req.GetTopLevelEnum())], "nested_enum", mypackagepb.InputType_NestedEnum_name[int32(req.GetNestedEnum())]))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append((*c.CallOptions).GetManyThings[0:len((*c.CallOptions).GetManyThings):len((*c.CallOptions).GetManyThings)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetManyThingsOptional.want
+++ b/internal/gengapic/testdata/method_GetManyThingsOptional.want
@@ -1,5 +1,5 @@
 func (c *fooGRPCClient) GetManyThingsOptional(ctx context.Context, req *mypackagepb.PageInputTypeOptional, opts ...gax.CallOption) *StringIterator {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[req.GetTopLevelEnum()], "nested_enum", mypackagepb.InputType_NestedEnum_name[req.GetNestedEnum()]))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[int32(req.GetTopLevelEnum())], "nested_enum", mypackagepb.InputType_NestedEnum_name[int32(req.GetNestedEnum())]))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append((*c.CallOptions).GetManyThingsOptional[0:len((*c.CallOptions).GetManyThingsOptional):len((*c.CallOptions).GetManyThingsOptional)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetOneThing.want
+++ b/internal/gengapic/testdata/method_GetOneThing.want
@@ -4,7 +4,7 @@ func (c *fooGRPCClient) GetOneThing(ctx context.Context, req *mypackagepb.InputT
 		defer cancel()
 		ctx = cctx
 	}
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[req.GetTopLevelEnum()], "nested_enum", mypackagepb.InputType_NestedEnum_name[req.GetNestedEnum()]))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[int32(req.GetTopLevelEnum())], "nested_enum", mypackagepb.InputType_NestedEnum_name[int32(req.GetNestedEnum())]))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append((*c.CallOptions).GetOneThing[0:len((*c.CallOptions).GetOneThing):len((*c.CallOptions).GetOneThing)], opts...)
 	var resp *mypackagepb.OutputType

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,5 +1,5 @@
 func (c *fooGRPCClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb.Foo_ServerThingsClient, error) {
-	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[req.GetTopLevelEnum()], "nested_enum", mypackagepb.InputType_NestedEnum_name[req.GetNestedEnum()]))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[int32(req.GetTopLevelEnum())], "nested_enum", mypackagepb.InputType_NestedEnum_name[int32(req.GetNestedEnum())]))
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	var resp mypackagepb.Foo_ServerThingsClient
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -38,7 +38,7 @@ protoc \
 	--go_gapic_opt 'grpc-service-config=showcase_grpc_service_config.json' \
 	--go_gapic_opt 'api-service-config=showcase_v1beta1.yaml' \
 	--descriptor_set_in=<(curl -sSL https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_SEMVER/gapic-showcase-$SHOWCASE_SEMVER.desc) \
-	google/showcase/v1beta1/echo.proto google/showcase/v1beta1/identity.proto google/showcase/v1beta1/sequence.proto
+	google/showcase/v1beta1/echo.proto google/showcase/v1beta1/identity.proto google/showcase/v1beta1/sequence.proto google/showcase/v1beta1/compliance.proto
 
 hostos=$(go env GOHOSTOS)
 hostarch=$(go env GOHOSTARCH)


### PR DESCRIPTION
Go protobuf code for enums makes them typed `int32` so in order to access the string representation of the enum, which is mapped with `int32` to `string`, we need to convert the enum value to an `int32` in the map key. 

This wasn't caught before, because the showcase proto with an enum http param wasn't being generated in the integration tests. It is added here.