### PR TITLE
fix(bazel): Remove monolith Bazel rule deps [go]

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -15,7 +15,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     "@bazel_gazelle//:deps.bzl",
-
     gazelle_go_repository = "go_repository",
 )
 
@@ -363,6 +362,13 @@ def com_googleapis_gapic_generator_go_repositories():
         importpath = "golang.org/x/xerrors",
         sum = "h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=",
         version = "v0.0.0-20200804184101-5ec99f83aff1",
+    )
+    _rules_gapic_version = "0.5.4"
+    _maybe(
+        http_archive,
+        name = "rules_gapic",
+        strip_prefix = "rules_gapic-%s" % _rules_gapic_version,
+        urls = ["https://github.com/googleapis/rules_gapic/archive/v%s.tar.gz" % _rules_gapic_version],
     )
 
 def _maybe(repo_rule, name, strip_repo_prefix = "", **kwargs):

--- a/rules_go_gapic/go_gapic.bzl
+++ b/rules_go_gapic/go_gapic.bzl
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_custom_library", "unzipped_srcjar")
 load("@io_bazel_rules_go//go:def.bzl", "go_context", "go_library")
+load("@rules_gapic//:gapic.bzl", "proto_custom_library", "unzipped_srcjar")
 
 def _go_gapic_postprocessed_srcjar_impl(ctx):
     go_ctx = go_context(ctx)

--- a/rules_go_gapic/go_gapic_pkg.bzl
+++ b/rules_go_gapic/go_gapic_pkg.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go//go:def.bzl", "GoLibrary", "GoSource")
-load("@com_google_api_codegen//rules_gapic:gapic_pkg.bzl", "construct_package_dir_paths")
+load("@rules_gapic//:gapic_pkg.bzl", "construct_package_dir_paths")
 
 def _go_gapic_src_pkg_impl(ctx):
     srcjars = []


### PR DESCRIPTION
This is needed for the preliminary removal of the monolith rules from googleapis' `switched_rules_by_language`.