### PR TITLE
gapic: fix example use of factory methods for REST transport

### DIFF
--- a/internal/gengapic/example.go
+++ b/internal/gengapic/example.go
@@ -98,7 +98,7 @@ func (g *generator) exampleMethod(pkgName, servName string, m *descriptor.Method
 		return err
 	}
 
-	// Pick the first transport for simplicity sake. We don't need examples
+	// Pick the first transport for simplicity. We don't need examples
 	// of each method for both transports when they have the same surface.
 	t := g.opts.transports[0]
 	s := servName

--- a/internal/gengapic/example_test.go
+++ b/internal/gengapic/example_test.go
@@ -29,6 +29,7 @@ import (
 
 func TestExample(t *testing.T) {
 	var g generator
+	g.opts = &options{}
 	g.imports = map[pbinfo.ImportSpec]bool{}
 	g.mixins = mixins{
 		"google.longrunning.Operations":   operationsMethods(),
@@ -158,12 +159,17 @@ func TestExample(t *testing.T) {
 	}
 	for _, tst := range []struct {
 		tstName, pkgName string
+		transports       []transport
 	}{
-		{tstName: "empty_example", pkgName: "Foo"},
-		{tstName: "foo_example", pkgName: "Bar"},
+		{tstName: "empty_example", pkgName: "Foo", transports: []transport{grpc, rest}},
+		{tstName: "empty_example_grpc", pkgName: "Foo", transports: []transport{grpc}},
+		{tstName: "foo_example", pkgName: "Bar", transports: []transport{grpc, rest}},
+		{tstName: "foo_example_rest", pkgName: "Bar", transports: []transport{rest}},
 	} {
 		g.reset()
-		g.genExampleFile(serv, tst.pkgName)
+		g.opts.pkgName = tst.pkgName
+		g.opts.transports = tst.transports
+		g.genExampleFile(serv)
 		txtdiff.Diff(t, tst.tstName, g.pt.String(), filepath.Join("testdata", tst.tstName+".want"))
 	}
 }

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -86,7 +86,7 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 		g.commit(outFile+"_client.go", g.opts.pkgName)
 
 		g.reset()
-		if err := g.genExampleFile(s, g.opts.pkgName); err != nil {
+		if err := g.genExampleFile(s); err != nil {
 			return &g.resp, errors.E(err, "example: %s", s.GetName())
 		}
 		g.imports[pbinfo.ImportSpec{Name: g.opts.pkgName, Path: g.opts.pkgPath}] = true

--- a/internal/gengapic/testdata/empty_example.want
+++ b/internal/gengapic/testdata/empty_example.want
@@ -10,6 +10,18 @@ func ExampleNewClient() {
 	_ = c
 }
 
+func ExampleNewRESTClient() {
+	ctx := context.Background()
+	c, err := Foo.NewRESTClient(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	defer c.Close()
+
+	// TODO: Use client.
+	_ = c
+}
+
 func ExampleClient_GetEmptyThing() {
 	ctx := context.Background()
 	c, err := Foo.NewClient(ctx)

--- a/internal/gengapic/testdata/empty_example_grpc.want
+++ b/internal/gengapic/testdata/empty_example_grpc.want
@@ -1,6 +1,6 @@
-func ExampleNewFooClient() {
+func ExampleNewClient() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -10,21 +10,9 @@ func ExampleNewFooClient() {
 	_ = c
 }
 
-func ExampleNewFooRESTClient() {
+func ExampleClient_GetEmptyThing() {
 	ctx := context.Background()
-	c, err := Bar.NewFooRESTClient(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	defer c.Close()
-
-	// TODO: Use client.
-	_ = c
-}
-
-func ExampleFooClient_GetEmptyThing() {
-	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -39,9 +27,9 @@ func ExampleFooClient_GetEmptyThing() {
 	}
 }
 
-func ExampleFooClient_GetOneThing() {
+func ExampleClient_GetOneThing() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -58,9 +46,9 @@ func ExampleFooClient_GetOneThing() {
 	_ = resp
 }
 
-func ExampleFooClient_GetBigThing() {
+func ExampleClient_GetBigThing() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -82,9 +70,9 @@ func ExampleFooClient_GetBigThing() {
 	_ = resp
 }
 
-func ExampleFooClient_GetManyThings() {
+func ExampleClient_GetManyThings() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -107,9 +95,9 @@ func ExampleFooClient_GetManyThings() {
 	}
 }
 
-func ExampleFooClient_BidiThings() {
+func ExampleClient_BidiThings() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -142,9 +130,9 @@ func ExampleFooClient_BidiThings() {
 	}
 }
 
-func ExampleFooClient_EmptyLRO() {
+func ExampleClient_EmptyLRO() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -164,9 +152,9 @@ func ExampleFooClient_EmptyLRO() {
 	}
 }
 
-func ExampleFooClient_RespLRO() {
+func ExampleClient_RespLRO() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -188,9 +176,9 @@ func ExampleFooClient_RespLRO() {
 	_ = resp
 }
 
-func ExampleFooClient_ListLocations() {
+func ExampleClient_ListLocations() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -213,9 +201,9 @@ func ExampleFooClient_ListLocations() {
 	}
 }
 
-func ExampleFooClient_GetLocation() {
+func ExampleClient_GetLocation() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -232,9 +220,9 @@ func ExampleFooClient_GetLocation() {
 	_ = resp
 }
 
-func ExampleFooClient_SetIamPolicy() {
+func ExampleClient_SetIamPolicy() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -251,9 +239,9 @@ func ExampleFooClient_SetIamPolicy() {
 	_ = resp
 }
 
-func ExampleFooClient_GetIamPolicy() {
+func ExampleClient_GetIamPolicy() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -270,9 +258,9 @@ func ExampleFooClient_GetIamPolicy() {
 	_ = resp
 }
 
-func ExampleFooClient_TestIamPermissions() {
+func ExampleClient_TestIamPermissions() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -289,9 +277,9 @@ func ExampleFooClient_TestIamPermissions() {
 	_ = resp
 }
 
-func ExampleFooClient_ListOperations() {
+func ExampleClient_ListOperations() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -314,9 +302,9 @@ func ExampleFooClient_ListOperations() {
 	}
 }
 
-func ExampleFooClient_GetOperation() {
+func ExampleClient_GetOperation() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -333,9 +321,9 @@ func ExampleFooClient_GetOperation() {
 	_ = resp
 }
 
-func ExampleFooClient_DeleteOperation() {
+func ExampleClient_DeleteOperation() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -350,9 +338,9 @@ func ExampleFooClient_DeleteOperation() {
 	}
 }
 
-func ExampleFooClient_CancelOperation() {
+func ExampleClient_CancelOperation() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -367,9 +355,9 @@ func ExampleFooClient_CancelOperation() {
 	}
 }
 
-func ExampleFooClient_WaitOperation() {
+func ExampleClient_WaitOperation() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Foo.NewClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}

--- a/internal/gengapic/testdata/foo_example_rest.want
+++ b/internal/gengapic/testdata/foo_example_rest.want
@@ -1,15 +1,3 @@
-func ExampleNewFooClient() {
-	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	defer c.Close()
-
-	// TODO: Use client.
-	_ = c
-}
-
 func ExampleNewFooRESTClient() {
 	ctx := context.Background()
 	c, err := Bar.NewFooRESTClient(ctx)
@@ -24,7 +12,7 @@ func ExampleNewFooRESTClient() {
 
 func ExampleFooClient_GetEmptyThing() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -41,7 +29,7 @@ func ExampleFooClient_GetEmptyThing() {
 
 func ExampleFooClient_GetOneThing() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -60,7 +48,7 @@ func ExampleFooClient_GetOneThing() {
 
 func ExampleFooClient_GetBigThing() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -84,7 +72,7 @@ func ExampleFooClient_GetBigThing() {
 
 func ExampleFooClient_GetManyThings() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -109,7 +97,7 @@ func ExampleFooClient_GetManyThings() {
 
 func ExampleFooClient_BidiThings() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -144,7 +132,7 @@ func ExampleFooClient_BidiThings() {
 
 func ExampleFooClient_EmptyLRO() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -166,7 +154,7 @@ func ExampleFooClient_EmptyLRO() {
 
 func ExampleFooClient_RespLRO() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -190,7 +178,7 @@ func ExampleFooClient_RespLRO() {
 
 func ExampleFooClient_ListLocations() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -215,7 +203,7 @@ func ExampleFooClient_ListLocations() {
 
 func ExampleFooClient_GetLocation() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -234,7 +222,7 @@ func ExampleFooClient_GetLocation() {
 
 func ExampleFooClient_SetIamPolicy() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -253,7 +241,7 @@ func ExampleFooClient_SetIamPolicy() {
 
 func ExampleFooClient_GetIamPolicy() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -272,7 +260,7 @@ func ExampleFooClient_GetIamPolicy() {
 
 func ExampleFooClient_TestIamPermissions() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -291,7 +279,7 @@ func ExampleFooClient_TestIamPermissions() {
 
 func ExampleFooClient_ListOperations() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -316,7 +304,7 @@ func ExampleFooClient_ListOperations() {
 
 func ExampleFooClient_GetOperation() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -335,7 +323,7 @@ func ExampleFooClient_GetOperation() {
 
 func ExampleFooClient_DeleteOperation() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -352,7 +340,7 @@ func ExampleFooClient_DeleteOperation() {
 
 func ExampleFooClient_CancelOperation() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}
@@ -369,7 +357,7 @@ func ExampleFooClient_CancelOperation() {
 
 func ExampleFooClient_WaitOperation() {
 	ctx := context.Background()
-	c, err := Bar.NewFooClient(ctx)
+	c, err := Bar.NewFooRESTClient(ctx)
 	if err != nil {
 		// TODO: Handle error.
 	}


### PR DESCRIPTION
When `rest` only transport is targeted for generation, the generated example files do not adjust to use the `rest` client factory method instead of the gRPC one resulting in a compilation error when the _examples_ are compiled.