### PR TITLE
fix(gengapic): standardize output of metadata files

### DIFF
--- a/internal/gengapic/metadata.go
+++ b/internal/gengapic/metadata.go
@@ -15,16 +15,22 @@
 package gengapic
 
 import (
+	"regexp"
+
 	"google.golang.org/genproto/googleapis/gapic/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 )
+
+var spaceSanitizerRegex = regexp.MustCompile(`:\s*`)
 
 func (g *generator) genGapicMetadataFile() error {
 	data, err := protojson.MarshalOptions{Multiline: true}.Marshal(g.metadata)
 	if err != nil {
 		return err
 	}
-
+	// Hack to standardize output from protojson which is currently non-deterministic
+	// with spacing after json keys.
+	spaceSanitizerRegex.ReplaceAll(data, []byte(": "))
 	g.pt.Printf("%s", data)
 	return nil
 }

--- a/internal/gengapic/testdata/metadata.want
+++ b/internal/gengapic/testdata/metadata.want
@@ -1,0 +1,23 @@
+{
+  "schema": "schema",
+  "comment": "comment",
+  "language": "language",
+  "protoPackage": "packagename",
+  "libraryPackage": "lib",
+  "services": {
+    "FooService": {
+      "clients": {
+        "grpc": {
+          "libraryClient": "libClient",
+          "rpcs": {
+            "GetBook": {
+              "methods": [
+                "GetBook"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
protojson produces non-deterministic output in the form of adding
random amounts of space after keys. This causes unneeded diffs in
google-cloud-go. This is a hack to make the output deterministic.

More context: https://go-review.googlesource.com/c/protobuf/+/151340
Fixes: #691