### PR TITLE
gapic: REST - remove EmitUnpopulated encoding option

### DIFF
--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -638,7 +638,7 @@ func (g *generator) emptyUnaryRESTCall(servName string, m *descriptor.MethodDesc
 		if verb == http.MethodGet || verb == http.MethodDelete {
 			return fmt.Errorf("invalid use of body parameter for a get/delete method %q", m.GetName())
 		}
-		p("m := protojson.MarshalOptions{AllowPartial: true, EmitUnpopulated: true, UseProtoNames: false}")
+		p("m := protojson.MarshalOptions{AllowPartial: true, UseProtoNames: false}")
 		requestObject := "req"
 		if info.body != "*" {
 			requestObject = "body"
@@ -735,7 +735,7 @@ func (g *generator) unaryRESTCall(servName string, m *descriptor.MethodDescripto
 		if verb == http.MethodGet || verb == http.MethodDelete {
 			return fmt.Errorf("invalid use of body parameter for a get/delete method %q", m.GetName())
 		}
-		p("m := protojson.MarshalOptions{AllowPartial: true, EmitUnpopulated: true}")
+		p("m := protojson.MarshalOptions{AllowPartial: true}")
 		requestObject := "req"
 		if info.body != "*" {
 			requestObject = "body"


### PR DESCRIPTION
Including `EmitUnpopulated` in the proto-to-json encoding results in unset fields being set with empty values, defeating the purpose of using `proto3` `optional` for field presence. A backend may interpret this as an error and return a `BadRequest` response.