### PR TITLE
chore: mv integration test protos to tmp

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,11 +69,11 @@ jobs:
         go install github.com/golang/protobuf/protoc-gen-go
         curl -sSL https://github.com/googleapis/googleapis/archive/master.zip > googleapis.zip
         unzip googleapis.zip -x "googleapis-master/google/ads/*"
-        mv googleapis-master googleapis
+        mv googleapis-master /tmp/googleapis
     - name: Run integration tests
       run: |
         export PATH=$PATH:protobuf/bin
-        export GOOGLEAPIS=googleapis
+        export GOOGLEAPIS=/tmp/googleapis
         make test
   bazel-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Apparently there is bugged code in an example application in googleapis: https://github.com/googleapis/gapic-generator-go/pull/703/checks?check_run_id=3049979631.

This moves the local download of googleapis to a separate directory so as to avoid being compiled via `go test ./...`