### PR TITLE
gapic:  include example in package doc overview

### DIFF
--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -66,7 +66,7 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	}
 
 	p("//")
-	p("// Example Usage")
+	p("// Example usage")
 	p("//")
 	p("// To get started with this package, create a client.")
 	// Code block for client creation

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-generator-go/internal/errors"
 	"github.com/googleapis/gapic-generator-go/internal/license"
+	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"github.com/googleapis/gapic-generator-go/internal/printer"
 	"google.golang.org/genproto/googleapis/api/annotations"
 )
@@ -68,35 +69,27 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("// Example Usage")
 	p("//")
 	p("// To get started with this package, create a client.")
-	p("//")
-	p("//")
 	// Code block for client creation
 	tmpClient := g.pt
 	g.pt = printer.P{}
-	g.exampleInitClient(g.opts.pkgName, serv.GetName())
+	g.exampleInitClient(g.opts.pkgName, pbinfo.ReduceServName(serv.GetName(), g.opts.pkgName))
 	snipClient := g.pt.String()
 	g.pt = tmpClient
 	g.codesnippet(snipClient)
-	p("//")
-	p("//")
 	p("// The client will use your default application credentials. Clients should be reused instead of created as needed.")
 	p("// The methods of Client are safe for concurrent use by multiple goroutines.")
 	p("// The returned client must be Closed when it is done being used.")
 	p("//")
-	p("//")
 	p("// Using the Client")
 	p("//")
 	p("// The following is an example of making an API call with the newly created client.")
-	p("//")
-	p("//")
 	// Code block for client using the first method of the service
 	tmpMethod := g.pt
 	g.pt = printer.P{}
-	g.exampleMethodBody(g.opts.pkgName, serv.GetName(), serv.GetMethod()[0])
+	g.exampleMethodBody(g.opts.pkgName, pbinfo.ReduceServName(serv.GetName(), g.opts.pkgName), serv.GetMethod()[0])
 	snipMethod := g.pt.String()
 	g.pt = tmpMethod
 	g.codesnippet(snipMethod)
-	p("//")
 	p("// Use of Context")
 	p("//")
 	p("// The ctx passed to NewClient is used for authentication requests and")

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -24,7 +24,6 @@ import (
 	"github.com/googleapis/gapic-generator-go/internal/license"
 	"github.com/googleapis/gapic-generator-go/internal/printer"
 	"google.golang.org/genproto/googleapis/api/annotations"
-
 )
 
 // genDocFile generates doc.go

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -83,6 +83,7 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("// Using the Client")
 	p("//")
 	p("// The following is an example of making an API call with the newly created client.")
+	p("//")
 	// Code block for client using the first method of the service
 	tmpMethod := g.pt
 	g.pt = printer.P{}

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -22,14 +22,16 @@ import (
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-generator-go/internal/errors"
 	"github.com/googleapis/gapic-generator-go/internal/license"
+	"github.com/googleapis/gapic-generator-go/internal/printer"
 	"google.golang.org/genproto/googleapis/api/annotations"
+
 )
 
 // genDocFile generates doc.go
 //
 // Since it's the only file that needs to write package documentation and canonical import,
 // it does not use g.commit().
-func (g *generator) genDocFile(year int, scopes []string) {
+func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.ServiceDescriptorProto) {
 	p := g.printf
 
 	p(license.Apache, year)
@@ -63,6 +65,38 @@ func (g *generator) genDocFile(year int, scopes []string) {
 		p("//   NOTE: This package is in beta. It is not stable, and may be subject to changes.")
 	}
 
+	p("//")
+	p("// Example Usage")
+	p("//")
+	p("// To get started with this package, create a client.")
+	p("//")
+	p("//")
+	// Code block for client creation
+	tmpClient := g.pt
+	g.pt = printer.P{}
+	g.exampleInitClient(g.opts.pkgName, serv.GetName())
+	snipClient := g.pt.String()
+	g.pt = tmpClient
+	g.codesnippet(snipClient)
+	p("//")
+	p("//")
+	p("// The client will use your default application credentials. Clients should be reused instead of created as needed.")
+	p("// The methods of Client are safe for concurrent use by multiple goroutines.")
+	p("// The returned client must be Closed when it is done being used.")
+	p("//")
+	p("//")
+	p("// Using the Client")
+	p("//")
+	p("// The following is an example of making an API call with the newly created client.")
+	p("//")
+	p("//")
+	// Code block for client using the first method of the service
+	tmpMethod := g.pt
+	g.pt = printer.P{}
+	g.exampleMethodBody(g.opts.pkgName, serv.GetName(), serv.GetMethod()[0])
+	snipMethod := g.pt.String()
+	g.pt = tmpMethod
+	g.codesnippet(snipMethod)
 	p("//")
 	p("// Use of Context")
 	p("//")

--- a/internal/gengapic/doc_file_test.go
+++ b/internal/gengapic/doc_file_test.go
@@ -18,11 +18,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"github.com/googleapis/gapic-generator-go/internal/txtdiff"
 	"google.golang.org/genproto/googleapis/api/serviceconfig"
-	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"google.golang.org/protobuf/proto"
-	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 )
 
 func TestDocFile(t *testing.T) {

--- a/internal/gengapic/example.go
+++ b/internal/gengapic/example.go
@@ -79,52 +79,8 @@ func (g *generator) exampleMethod(pkgName, servName string, m *descriptor.Method
 
 	p := g.printf
 
-	inType := g.descInfo.Type[m.GetInputType()]
-	if inType == nil {
-		return errors.E(nil, "cannot find type %q, malformed descriptor?", m.GetInputType())
-	}
-
-	inSpec, err := g.descInfo.ImportSpec(inType)
-	if err != nil {
-		return err
-	}
-
-	g.imports[inSpec] = true
-
 	p("func Example%sClient_%s() {", servName, m.GetName())
-
-	pf, _, err := g.getPagingFields(m)
-	if err != nil {
-		return err
-	}
-
-	// Pick the first transport for simplicity. We don't need examples
-	// of each method for both transports when they have the same surface.
-	t := g.opts.transports[0]
-	s := servName
-	if t == rest {
-		s += "REST"
-	}
-	g.exampleInitClient(pkgName, s)
-
-	if !m.GetClientStreaming() && !m.GetServerStreaming() {
-		p("")
-		p("req := &%s.%s{", inSpec.Name, inType.GetName())
-		p("  // TODO: Fill request struct fields.")
-		p("}")
-	}
-
-	if pf != nil {
-		g.examplePagingCall(m)
-	} else if g.isLRO(m) {
-		g.exampleLROCall(m)
-	} else if *m.OutputType == emptyType {
-		g.exampleEmptyCall(m)
-	} else if m.GetClientStreaming() && m.GetServerStreaming() {
-		g.exampleBidiCall(m, inType, inSpec)
-	} else {
-		g.exampleUnaryCall(m)
-	}
+	g.exampleMethodBody(pkgName, servName, m)
 
 	p("}")
 	p("")
@@ -150,12 +106,6 @@ func (g *generator) exampleMethodBody(pkgName, servName string, m *descriptor.Me
 	}
 
 	g.imports[inSpec] = true
-
-	pf, _, err := g.getPagingFields(m)
-	if err != nil {
-		return err
-	}
-
 	// Pick the first transport for simplicity. We don't need examples
 	// of each method for both transports when they have the same surface.
 	t := g.opts.transports[0]
@@ -172,6 +122,10 @@ func (g *generator) exampleMethodBody(pkgName, servName string, m *descriptor.Me
 		p("}")
 	}
 
+	pf, _, err := g.getPagingFields(m)
+	if err != nil {
+		return err
+	}
 	if pf != nil {
 		g.examplePagingCall(m)
 	} else if g.isLRO(m) {

--- a/internal/gengapic/example.go
+++ b/internal/gengapic/example.go
@@ -83,7 +83,7 @@ func (g *generator) exampleMethod(pkgName, servName string, m *descriptor.Method
 	if inType == nil {
 		return errors.E(nil, "cannot find type %q, malformed descriptor?", m.GetInputType())
 	}
-	
+
 	inSpec, err := g.descInfo.ImportSpec(inType)
 	if err != nil {
 		return err
@@ -131,7 +131,7 @@ func (g *generator) exampleMethod(pkgName, servName string, m *descriptor.Method
 	return nil
 }
 
-func (g *generator) exampleMethodBody (pkgName, servName string, m *descriptor.MethodDescriptorProto) error {
+func (g *generator) exampleMethodBody(pkgName, servName string, m *descriptor.MethodDescriptorProto) error {
 	if m.GetClientStreaming() != m.GetServerStreaming() {
 		// TODO(pongad): implement this correctly.
 		return nil
@@ -143,7 +143,7 @@ func (g *generator) exampleMethodBody (pkgName, servName string, m *descriptor.M
 	if inType == nil {
 		return errors.E(nil, "cannot find type %q, malformed descriptor?", m.GetInputType())
 	}
-	
+
 	inSpec, err := g.descInfo.ImportSpec(inType)
 	if err != nil {
 		return err

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -104,7 +104,10 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 	if err != nil {
 		return &g.resp, err
 	}
-	g.genDocFile(time.Now().Year(), scopes)
+	
+	serv := genServs[0]
+
+	g.genDocFile(time.Now().Year(), scopes, serv)
 	g.resp.File = append(g.resp.File, &plugin.CodeGeneratorResponse_File{
 		Name:    proto.String(filepath.Join(g.opts.outDir, "doc.go")),
 		Content: proto.String(g.pt.String()),
@@ -432,6 +435,22 @@ func (g *generator) comment(s string) {
 			g.printf("//")
 		} else {
 			g.printf("// %s", l)
+		}
+	}
+}
+
+// Similar functionality to 'comment', except specifically used for generating formatted code snippets. 
+func (g *generator) codesnippet(s string) {
+	if s == "" {
+		return
+	}
+
+	lines := strings.Split(s, "\n")
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			g.printf("//")
+		} else {
+			g.printf("//  %s", l)
 		}
 	}
 }

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -450,6 +450,7 @@ func (g *generator) codesnippet(s string) {
 		if strings.TrimSpace(l) == "" {
 			g.printf("//")
 		} else {
+			// At least 2 spaces after the // are necessary for GoDoc code snippet formatting.
 			g.printf("//  %s", l)
 		}
 	}

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -104,7 +104,7 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 	if err != nil {
 		return &g.resp, err
 	}
-	
+
 	serv := genServs[0]
 
 	g.genDocFile(time.Now().Year(), scopes, serv)
@@ -439,7 +439,7 @@ func (g *generator) comment(s string) {
 	}
 }
 
-// Similar functionality to 'comment', except specifically used for generating formatted code snippets. 
+// Similar functionality to 'comment', except specifically used for generating formatted code snippets.
 func (g *generator) codesnippet(s string) {
 	if s == "" {
 		return

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -58,6 +58,29 @@ func TestComment(t *testing.T) {
 	}
 }
 
+func TestCodeSnippet(t *testing.T) {
+	var g generator
+
+	for _, tst := range []struct {
+		in, want string
+	}{
+		{
+			in:   "",
+			want: "",
+		},
+		{
+			in:   "abc\ndef\n",
+			want: "//  abc\n//  def\n//\n",
+		},
+	} {
+		g.pt.Reset()
+		g.codesnippet(tst.in)
+		if got := g.pt.String(); got != tst.want {
+			t.Errorf("comment(%q) = %q, want %q", tst.in, got, tst.want)
+		}
+	}
+}
+
 func TestReduceServName(t *testing.T) {
 	for _, tst := range []struct {
 		in, pkg, want string

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -21,7 +21,7 @@
 // (at https://api.foo.com) with Buz (at https://api.buz.com) and Baz (at
 // https://api.baz.com) to acclerate bar.
 //
-// Example Usage
+// Example usage
 //
 // To get started with this package, create a client.
 //  ctx := context.Background()

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -63,7 +63,6 @@
 //  _ = resp
 //
 //
-//
 // Use of Context
 //
 // The ctx passed to NewClient is used for authentication requests and

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -38,6 +38,7 @@
 // Using the Client
 //
 // The following is an example of making an API call with the newly created client.
+//
 //  ctx := context.Background()
 //  c, err := awesome.NewFooClient(ctx)
 //  if err != nil {

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -24,8 +24,6 @@
 // Example Usage
 //
 // To get started with this package, create a client.
-//
-//
 //  ctx := context.Background()
 //  c, err := awesome.NewFooClient(ctx)
 //  if err != nil {
@@ -33,18 +31,13 @@
 //  }
 //  defer c.Close()
 //
-//
-//
 // The client will use your default application credentials. Clients should be reused instead of created as needed.
 // The methods of Client are safe for concurrent use by multiple goroutines.
 // The returned client must be Closed when it is done being used.
 //
-//
 // Using the Client
 //
 // The following is an example of making an API call with the newly created client.
-//
-//
 //  ctx := context.Background()
 //  c, err := awesome.NewFooClient(ctx)
 //  if err != nil {
@@ -61,7 +54,6 @@
 //  }
 //  // TODO: Use resp.
 //  _ = resp
-//
 //
 // Use of Context
 //

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -21,6 +21,49 @@
 // (at https://api.foo.com) with Buz (at https://api.buz.com) and Baz (at
 // https://api.baz.com) to acclerate bar.
 //
+// Example Usage
+//
+// To get started with this package, create a client.
+//
+//
+//  ctx := context.Background()
+//  c, err := awesome.NewFooClient(ctx)
+//  if err != nil {
+//  	// TODO: Handle error.
+//  }
+//  defer c.Close()
+//
+//
+//
+// The client will use your default application credentials. Clients should be reused instead of created as needed.
+// The methods of Client are safe for concurrent use by multiple goroutines.
+// The returned client must be Closed when it is done being used.
+//
+//
+// Using the Client
+//
+// The following is an example of making an API call with the newly created client.
+//
+//
+//  ctx := context.Background()
+//  c, err := awesome.NewFooClient(ctx)
+//  if err != nil {
+//  	// TODO: Handle error.
+//  }
+//  defer c.Close()
+//
+//  req := &mypackagepb.InputType{
+//  	// TODO: Fill request struct fields.
+//  }
+//  resp, err := c.GetOneThing(ctx, req)
+//  if err != nil {
+//  	// TODO: Handle error.
+//  }
+//  // TODO: Use resp.
+//  _ = resp
+//
+//
+//
 // Use of Context
 //
 // The ctx passed to NewClient is used for authentication requests and

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -26,8 +26,6 @@
 // Example Usage
 //
 // To get started with this package, create a client.
-//
-//
 //  ctx := context.Background()
 //  c, err := awesome.NewFooClient(ctx)
 //  if err != nil {
@@ -35,18 +33,13 @@
 //  }
 //  defer c.Close()
 //
-//
-//
 // The client will use your default application credentials. Clients should be reused instead of created as needed.
 // The methods of Client are safe for concurrent use by multiple goroutines.
 // The returned client must be Closed when it is done being used.
 //
-//
 // Using the Client
 //
 // The following is an example of making an API call with the newly created client.
-//
-//
 //  ctx := context.Background()
 //  c, err := awesome.NewFooClient(ctx)
 //  if err != nil {
@@ -63,7 +56,6 @@
 //  }
 //  // TODO: Use resp.
 //  _ = resp
-//
 //
 // Use of Context
 //

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -23,6 +23,49 @@
 //
 //   NOTE: This package is in alpha. It is not stable, and is likely to change.
 //
+// Example Usage
+//
+// To get started with this package, create a client.
+//
+//
+//  ctx := context.Background()
+//  c, err := awesome.NewFooClient(ctx)
+//  if err != nil {
+//  	// TODO: Handle error.
+//  }
+//  defer c.Close()
+//
+//
+//
+// The client will use your default application credentials. Clients should be reused instead of created as needed.
+// The methods of Client are safe for concurrent use by multiple goroutines.
+// The returned client must be Closed when it is done being used.
+//
+//
+// Using the Client
+//
+// The following is an example of making an API call with the newly created client.
+//
+//
+//  ctx := context.Background()
+//  c, err := awesome.NewFooClient(ctx)
+//  if err != nil {
+//  	// TODO: Handle error.
+//  }
+//  defer c.Close()
+//
+//  req := &mypackagepb.InputType{
+//  	// TODO: Fill request struct fields.
+//  }
+//  resp, err := c.GetOneThing(ctx, req)
+//  if err != nil {
+//  	// TODO: Handle error.
+//  }
+//  // TODO: Use resp.
+//  _ = resp
+//
+//
+//
 // Use of Context
 //
 // The ctx passed to NewClient is used for authentication requests and

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -40,6 +40,7 @@
 // Using the Client
 //
 // The following is an example of making an API call with the newly created client.
+//
 //  ctx := context.Background()
 //  c, err := awesome.NewFooClient(ctx)
 //  if err != nil {

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -23,7 +23,7 @@
 //
 //   NOTE: This package is in alpha. It is not stable, and is likely to change.
 //
-// Example Usage
+// Example usage
 //
 // To get started with this package, create a client.
 //  ctx := context.Background()

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -65,7 +65,6 @@
 //  _ = resp
 //
 //
-//
 // Use of Context
 //
 // The ctx passed to NewClient is used for authentication requests and

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -26,8 +26,6 @@
 // Example Usage
 //
 // To get started with this package, create a client.
-//
-//
 //  ctx := context.Background()
 //  c, err := awesome.NewFooClient(ctx)
 //  if err != nil {
@@ -35,18 +33,13 @@
 //  }
 //  defer c.Close()
 //
-//
-//
 // The client will use your default application credentials. Clients should be reused instead of created as needed.
 // The methods of Client are safe for concurrent use by multiple goroutines.
 // The returned client must be Closed when it is done being used.
 //
-//
 // Using the Client
 //
 // The following is an example of making an API call with the newly created client.
-//
-//
 //  ctx := context.Background()
 //  c, err := awesome.NewFooClient(ctx)
 //  if err != nil {
@@ -63,7 +56,6 @@
 //  }
 //  // TODO: Use resp.
 //  _ = resp
-//
 //
 // Use of Context
 //

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -40,6 +40,7 @@
 // Using the Client
 //
 // The following is an example of making an API call with the newly created client.
+//
 //  ctx := context.Background()
 //  c, err := awesome.NewFooClient(ctx)
 //  if err != nil {

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -23,6 +23,49 @@
 //
 //   NOTE: This package is in beta. It is not stable, and may be subject to changes.
 //
+// Example Usage
+//
+// To get started with this package, create a client.
+//
+//
+//  ctx := context.Background()
+//  c, err := awesome.NewFooClient(ctx)
+//  if err != nil {
+//  	// TODO: Handle error.
+//  }
+//  defer c.Close()
+//
+//
+//
+// The client will use your default application credentials. Clients should be reused instead of created as needed.
+// The methods of Client are safe for concurrent use by multiple goroutines.
+// The returned client must be Closed when it is done being used.
+//
+//
+// Using the Client
+//
+// The following is an example of making an API call with the newly created client.
+//
+//
+//  ctx := context.Background()
+//  c, err := awesome.NewFooClient(ctx)
+//  if err != nil {
+//  	// TODO: Handle error.
+//  }
+//  defer c.Close()
+//
+//  req := &mypackagepb.InputType{
+//  	// TODO: Fill request struct fields.
+//  }
+//  resp, err := c.GetOneThing(ctx, req)
+//  if err != nil {
+//  	// TODO: Handle error.
+//  }
+//  // TODO: Use resp.
+//  _ = resp
+//
+//
+//
 // Use of Context
 //
 // The ctx passed to NewClient is used for authentication requests and

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -65,7 +65,6 @@
 //  _ = resp
 //
 //
-//
 // Use of Context
 //
 // The ctx passed to NewClient is used for authentication requests and

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -23,7 +23,7 @@
 //
 //   NOTE: This package is in beta. It is not stable, and may be subject to changes.
 //
-// Example Usage
+// Example usage
 //
 // To get started with this package, create a client.
 //  ctx := context.Background()


### PR DESCRIPTION
Fixes #591 

Adding sample client and method to the top of the docfile to make the entry point for using a package more visible to end users.

Example image of sample client + method for the Language API in attached image:

![Screenshot from 2021-08-04 15-25-30](https://user-images.githubusercontent.com/65933803/128263290-c75eaaac-7f5e-43a4-bd72-028fc1f90269.png)

