### PR TITLE
gapic: exclude GET from custom op wrapping

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -474,12 +474,16 @@ func (g *generator) returnType(m *descriptor.MethodDescriptorProto) (string, err
 	if err != nil {
 		return "", err
 	}
+	info, err := getHTTPInfo(m)
+	if err != nil {
+		return "", err
+	}
 
 	// Regular return type.
 	retTyp := fmt.Sprintf("*%s.%s", outSpec.Name, outType.GetName())
 
-	// Returning a custom operation, use the wrapper type.
-	if g.opts.diregapic && g.aux.customOp != nil && m.GetOutputType() == g.customOpProtoName() {
+	// Returning a custom operation, not a GET (which would be a polling RPC), use the wrapper type.
+	if g.opts.diregapic && g.aux.customOp != nil && m.GetOutputType() == g.customOpProtoName() && info.verb != "get" {
 		// This will only be *Operation to start.
 		retTyp = fmt.Sprintf("*%s", g.aux.customOp.message.GetName())
 	}

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -941,10 +941,31 @@ func TestReturnType(t *testing.T) {
 	}
 	com := &descriptor.MethodDescriptorProto{
 		OutputType: proto.String(".google.cloud.foo.v1.Operation"),
+		Options:    &descriptor.MethodOptions{},
 	}
+	proto.SetExtension(com.GetOptions(), annotations.E_Http, &annotations.HttpRule{
+		Pattern: &annotations.HttpRule_Post{
+			Post: "/v1/operations",
+		},
+	})
 	reg := &descriptor.MethodDescriptorProto{
 		OutputType: proto.String(".google.cloud.foo.v1.Foo"),
+		Options:    &descriptor.MethodOptions{},
 	}
+	proto.SetExtension(reg.GetOptions(), annotations.E_Http, &annotations.HttpRule{
+		Pattern: &annotations.HttpRule_Post{
+			Post: "/v1/operations",
+		},
+	})
+	get := &descriptor.MethodDescriptorProto{
+		OutputType: proto.String(".google.cloud.foo.v1.Operation"),
+		Options:    &descriptor.MethodOptions{},
+	}
+	proto.SetExtension(get.GetOptions(), annotations.E_Http, &annotations.HttpRule{
+		Pattern: &annotations.HttpRule_Get{
+			Get: "/v1/operations",
+		},
+	})
 	f := &descriptor.FileDescriptorProto{
 		Package: proto.String("google.cloud.foo.v1"),
 		Options: &descriptor.FileOptions{
@@ -985,6 +1006,11 @@ func TestReturnType(t *testing.T) {
 			name:   "regular_unary",
 			method: reg,
 			want:   "*foopb.Foo",
+		},
+		{
+			name:   "get_custom_op",
+			method: get,
+			want:   "*foopb.Operation",
 		},
 	} {
 		got, err := g.returnType(tst.method)

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -551,6 +551,7 @@ func (g *generator) pagingRESTCall(servName string, m *descriptor.MethodDescript
 	verb := strings.ToUpper(info.verb)
 
 	max := "math.MaxInt32"
+	g.imports[pbinfo.ImportSpec{Path: "math"}] = true
 	psTyp := pbinfo.GoTypeForPrim[pageSize.GetType()]
 	ps := fmt.Sprintf("%s(pageSize)", psTyp)
 	if isOptional(inType, pageSize.GetName()) {
@@ -773,7 +774,7 @@ func (g *generator) unaryRESTCall(servName string, m *descriptor.MethodDescripto
 	if err != nil {
 		return err
 	}
-	isCustomOp := g.aux.customOp != nil && m.GetOutputType() == g.customOpProtoName()
+	isCustomOp := g.aux.customOp != nil && m.GetOutputType() == g.customOpProtoName() && info.verb != "get"
 
 	// Ignore error because the only possible error would be from looking up
 	// the ImportSpec for the OutputType, which has already happened above.

--- a/internal/gengapic/genrest_test.go
+++ b/internal/gengapic/genrest_test.go
@@ -421,7 +421,11 @@ func TestGenRestMethod(t *testing.T) {
 	opfqn := fmt.Sprintf(".%s.Operation", pkg)
 
 	opRPCOpt := &descriptor.MethodOptions{}
-	setHTTPOption(opRPCOpt, "/v1/foo")
+	proto.SetExtension(opRPCOpt, annotations.E_Http, &annotations.HttpRule{
+		Pattern: &annotations.HttpRule_Post{
+			Post: "/v1/foo",
+		},
+	})
 
 	opRPC := &descriptor.MethodDescriptorProto{
 		Name:       proto.String("CustomOp"),

--- a/internal/gengapic/testdata/rest_CustomOp.want
+++ b/internal/gengapic/testdata/rest_CustomOp.want
@@ -3,7 +3,7 @@ func (c *fooRESTClient) CustomOp(ctx context.Context, req *foopb.Foo, opts ...ga
 	baseUrl.Path += fmt.Sprintf("/v1/foo")
 
 
-	httpReq, err := http.NewRequest("GET", baseUrl.String(), nil)
+	httpReq, err := http.NewRequest("POST", baseUrl.String(), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This excludes `GET` requests from custom operation wrapping in DIREGAPIC mode because those are always polling methods that should return the raw type. 

This will be a breaking change in the compute client for those few `GET` `Operation` methods, switching _back_ to the raw `computepb.Operation` as the return type.

It also includes a missing Go dep to generated regapic pagination.