### PR TITLE
gapic: fix fields with nums

### DIFF
--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -670,6 +670,7 @@ func Test_buildAccessor(t *testing.T) {
 		{name: "nested", field: "foo_foo.bar_bar", want: ".GetFooFoo().GetBarBar()", variant: fieldGetter},
 		{name: "numbers", field: "foo_foo64", want: ".GetFooFoo64()", variant: fieldGetter},
 		{name: "raw_final", field: "foo.bar.baz.bif", want: ".GetFoo().GetBar().GetBaz().Bif", variant: directAccess},
+		{name: "independent_number", field: "display_video_360_advertiser_links", want: ".GetDisplayVideo_360AdvertiserLinks()", variant: fieldGetter},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -706,7 +706,7 @@ func (g *generator) emptyUnaryRESTCall(servName string, m *descriptor.MethodDesc
 		requestObject := "req"
 		if info.body != "*" {
 			requestObject = "body"
-			p("body := req.Get%s()", snakeToCamel(info.body))
+			p("body := req%s", fieldGetter(info.body))
 		}
 		p("jsonReq, err := m.Marshal(%s)", requestObject)
 		p("if err != nil {")
@@ -808,7 +808,7 @@ func (g *generator) unaryRESTCall(servName string, m *descriptor.MethodDescripto
 		requestObject := "req"
 		if info.body != "*" {
 			requestObject = "body"
-			p("body := req.Get%s()", snakeToCamel(info.body))
+			p("body := req%s", fieldGetter(info.body))
 		}
 		p("jsonReq, err := m.Marshal(%s)", requestObject)
 		p("if err != nil {")

--- a/internal/gengapic/helpers.go
+++ b/internal/gengapic/helpers.go
@@ -64,6 +64,10 @@ func snakeToCamel(s string) string {
 	for _, r := range s {
 		if r == '_' {
 			up = true
+		} else if up && unicode.IsDigit(r) {
+			sb.WriteRune('_')
+			sb.WriteRune(r)
+			up = false
 		} else if up {
 			sb.WriteRune(unicode.ToUpper(r))
 			up = false

--- a/internal/gengapic/helpers_test.go
+++ b/internal/gengapic/helpers_test.go
@@ -45,6 +45,7 @@ func TestSnakeToCamel(t *testing.T) {
 		{"iam_credentials", "IamCredentials"},
 		{"dlp", "Dlp"},
 		{"os_config", "OsConfig"},
+		{"display_video_360_advertiser_links", "DisplayVideo_360AdvertiserLinks"},
 	} {
 		got := snakeToCamel(tst.in)
 		if diff := cmp.Diff(got, tst.want); diff != "" {

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -212,7 +212,7 @@ func (g *generator) getPagingFields(m *descriptor.MethodDescriptorProto) (repeat
 func (g *generator) maybeSortMapPage(elemField *descriptor.FieldDescriptorProto, pt *iterType) string {
 	p := g.printf
 
-	repeatedField, elems := fmt.Sprintf("resp.Get%s()", snakeToCamel(elemField.GetName())), ""
+	repeatedField, elems := fmt.Sprintf("resp%s", fieldGetter(elemField.GetName())), ""
 	// Most paged methods have a normal repeated field and not a map, so use that as a default.
 	elems = repeatedField
 	if pt.mapValueTypeName != "" {


### PR DESCRIPTION
When a proto field has a number in a snake_case field name like `foo_123_bar`, protobuf-go generates the field name and resulting accessor as `Foo_123Bar` and `GetFoo_123Bar` respectively. We recently had an API add such a field, seemingly a first for us.

This change updates the `snakeToCamel` helper to account for that, and updates several places where it was being used directly to generate accessors to instead use the `fieldGetter` helper that uses `snakeToCamel` under the hood.

Fixes b/197160410.