### PR TITLE
gapic: fix compute wait wrapping logic

### DIFF
--- a/internal/gengapic/custom_operation.go
+++ b/internal/gengapic/custom_operation.go
@@ -26,6 +26,15 @@ type customOp struct {
 	generated bool
 }
 
+// isCustomOp determines if the given method should return a custom operation wrapper.
+func (g *generator) isCustomOp(m *descriptor.MethodDescriptorProto, info *httpInfo) bool {
+	return g.opts.diregapic && // Generator in DIREGAPIC mode.
+		g.aux.customOp != nil && // API Defines a custom operation.
+		m.GetOutputType() == g.customOpProtoName() && // Method returns the custom operation.
+		info.verb != "get" && // Method is not a GET (polling methods).
+		m.GetName() != "Wait" // Method is not a Wait (uses POST).
+}
+
 // customOpProtoName builds the fully-qualified proto name for the custom
 // operation message type.
 func (g *generator) customOpProtoName() string {

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -481,14 +481,9 @@ func (g *generator) returnType(m *descriptor.MethodDescriptorProto) (string, err
 
 	// Regular return type.
 	retTyp := fmt.Sprintf("*%s.%s", outSpec.Name, outType.GetName())
-	wrap := g.opts.diregapic && // Generator in DIREGAPIC mode.
-		g.aux.customOp != nil && // API Defines a custom operation.
-		m.GetOutputType() == g.customOpProtoName() && // Method returns the custom operation.
-		info.verb != "get" && // Method is not a GET (polling methods).
-		m.GetName() != "Wait" // Method is not a Wait (uses POST).
 
 	// Wrap the raw operation with a custom operation type.
-	if wrap {
+	if g.isCustomOp(m, info) {
 		// This will only be *Operation to start.
 		retTyp = fmt.Sprintf("*%s", g.aux.customOp.message.GetName())
 	}

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -774,7 +774,6 @@ func (g *generator) unaryRESTCall(servName string, m *descriptor.MethodDescripto
 	if err != nil {
 		return err
 	}
-	isCustomOp := g.aux.customOp != nil && m.GetOutputType() == g.customOpProtoName() && info.verb != "get"
 
 	// Ignore error because the only possible error would be from looking up
 	// the ImportSpec for the OutputType, which has already happened above.
@@ -858,7 +857,7 @@ func (g *generator) unaryRESTCall(servName string, m *descriptor.MethodDescripto
 	p("rsp := &%s.%s{}", outSpec.Name, outType.GetName())
 	p("")
 	ret := "return rsp, unm.Unmarshal(buf, rsp)"
-	if isCustomOp {
+	if g.isCustomOp(m, info) {
 		p("if err := unm.Unmarshal(buf, rsp); err != nil {")
 		p("  return nil, err")
 		p("}")


### PR DESCRIPTION
I missed updating another spot where the custom operation decision logic was used, so I moved it into a function and used it in both spots.