### PR TITLE
gapic: rest GAPIC wrap unknown enum error

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,7 @@ jobs:
           -gocloud-dir=$CLOUD_GO \
           -googleapis-dir=$GOOGLEAPIS \
           -googleapis-disco-dir=$GOOGLEAPIS_DISCO
+        go get ./compute/apiv1
     - name: Compare regenerated code to baseline
       if: "!contains(github.event.pull_request.labels.*.name, 'breaking change allowed')"
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,7 +139,7 @@ jobs:
           -gocloud-dir=$CLOUD_GO \
           -googleapis-dir=$GOOGLEAPIS \
           -googleapis-disco-dir=$GOOGLEAPIS_DISCO
-        go get ./compute/apiv1
+        cd $CLOUD_GO && go get ./compute/apiv1
     - name: Compare regenerated code to baseline
       if: "!contains(github.event.pull_request.labels.*.name, 'breaking change allowed')"
       run: |

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -33,6 +33,7 @@ import (
 // it does not use g.commit().
 func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.ServiceDescriptorProto) {
 	p := g.printf
+	hasREST := containsTransport(g.opts.transports, rest)
 
 	p(license.Apache, year)
 	p("")
@@ -116,6 +117,9 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("%s%q", "\t", "strings")
 	p("%s%q", "\t", "unicode")
 	p("")
+	if hasREST {
+		p("%s%q", "\t", "golang.org/x/xerrors")
+	}
 	p("%s%q", "\t", "google.golang.org/api/option")
 	p("%s%q", "\t", "google.golang.org/grpc/metadata")
 	p(")")
@@ -202,6 +206,17 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 		p("  return %q", "UNKNOWN")
 		p("}")
 		p("")
+	}
+
+	if hasREST {
+		p("// maybeUnknownEnum wraps the given proto-JSON parsing error if it is the result")
+		p("// of receiving an unknown enum value.")
+		p("func maybeUnknownEnum(err error) error {")
+		p(`  if strings.Contains(err.Error(), "invalid value for enum type") {`)
+		p(`    err = xerrors.Errorf("received an unknown enum value, a later version of the library may support it: %%w", err)`)
+		p("  }")
+		p("  return err")
+		p("}")
 	}
 }
 

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -213,7 +213,7 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 		p("// of receiving an unknown enum value.")
 		p("func maybeUnknownEnum(err error) error {")
 		p(`  if strings.Contains(err.Error(), "invalid value for enum type") {`)
-		p(`    err = xerrors.Errorf("received an unknown enum value, a later version of the library may support it: %%w", err)`)
+		p(`    err = xerrors.Errorf("received an unknown enum value; a later version of the library may support it: %%w", err)`)
 		p("  }")
 		p("  return err")
 		p("}")

--- a/internal/gengapic/doc_file_test.go
+++ b/internal/gengapic/doc_file_test.go
@@ -33,7 +33,7 @@ func TestDocFile(t *testing.T) {
 			Summary: "The Awesome Foo API is really really awesome. It enables the use of [Foo](https://api.foo.com) with [Buz](https://api.buz.com) and [Baz](https://api.baz.com) to acclerate `bar`.",
 		},
 	}
-	g.opts = &options{pkgPath: "path/to/awesome", pkgName: "awesome", transports: []transport{grpc}}
+	g.opts = &options{pkgPath: "path/to/awesome", pkgName: "awesome", transports: []transport{grpc, rest}}
 	g.imports = map[pbinfo.ImportSpec]bool{}
 
 	inputType := &descriptor.DescriptorProto{

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -856,11 +856,11 @@ func (g *generator) unaryRESTCall(servName string, m *descriptor.MethodDescripto
 	p("unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}")
 	p("rsp := &%s.%s{}", outSpec.Name, outType.GetName())
 	p("")
-	ret := "return rsp, unm.Unmarshal(buf, rsp)"
+	p("if err := unm.Unmarshal(buf, rsp); err != nil {")
+	p("  return nil, maybeUnknownEnum(err)")
+	p("}")
+	ret := "return rsp, nil"
 	if g.isCustomOp(m, info) {
-		p("if err := unm.Unmarshal(buf, rsp); err != nil {")
-		p("  return nil, err")
-		p("}")
 		p("op := %s", g.customOpInit("rsp"))
 		ret = "return op, err"
 	}

--- a/internal/gengapic/helpers.go
+++ b/internal/gengapic/helpers.go
@@ -118,3 +118,15 @@ func hasMethod(service *descriptor.ServiceDescriptorProto, method string) bool {
 
 	return false
 }
+
+// containsTransport determines if a set of transports contains a specific
+// transport.
+func containsTransport(t []transport, tr transport) bool {
+	for _, x := range t {
+		if x == tr {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -77,6 +77,7 @@ import (
 	"strings"
 	"unicode"
 
+	"golang.org/x/xerrors"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
 )
@@ -154,3 +155,11 @@ func versionGo() string {
 	return "UNKNOWN"
 }
 
+// maybeUnknownEnum wraps the given proto-JSON parsing error if it is the result
+// of receiving an unknown enum value.
+func maybeUnknownEnum(err error) error {
+	if strings.Contains(err.Error(), "invalid value for enum type") {
+		err = xerrors.Errorf("received an unknown enum value, a later version of the library may support it: %w", err)
+	}
+	return err
+}

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -159,7 +159,7 @@ func versionGo() string {
 // of receiving an unknown enum value.
 func maybeUnknownEnum(err error) error {
 	if strings.Contains(err.Error(), "invalid value for enum type") {
-		err = xerrors.Errorf("received an unknown enum value, a later version of the library may support it: %w", err)
+		err = xerrors.Errorf("received an unknown enum value; a later version of the library may support it: %w", err)
 	}
 	return err
 }

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -79,6 +79,7 @@ import (
 	"strings"
 	"unicode"
 
+	"golang.org/x/xerrors"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
 )
@@ -156,3 +157,11 @@ func versionGo() string {
 	return "UNKNOWN"
 }
 
+// maybeUnknownEnum wraps the given proto-JSON parsing error if it is the result
+// of receiving an unknown enum value.
+func maybeUnknownEnum(err error) error {
+	if strings.Contains(err.Error(), "invalid value for enum type") {
+		err = xerrors.Errorf("received an unknown enum value, a later version of the library may support it: %w", err)
+	}
+	return err
+}

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -161,7 +161,7 @@ func versionGo() string {
 // of receiving an unknown enum value.
 func maybeUnknownEnum(err error) error {
 	if strings.Contains(err.Error(), "invalid value for enum type") {
-		err = xerrors.Errorf("received an unknown enum value, a later version of the library may support it: %w", err)
+		err = xerrors.Errorf("received an unknown enum value; a later version of the library may support it: %w", err)
 	}
 	return err
 }

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -79,6 +79,7 @@ import (
 	"strings"
 	"unicode"
 
+	"golang.org/x/xerrors"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
 )
@@ -156,3 +157,11 @@ func versionGo() string {
 	return "UNKNOWN"
 }
 
+// maybeUnknownEnum wraps the given proto-JSON parsing error if it is the result
+// of receiving an unknown enum value.
+func maybeUnknownEnum(err error) error {
+	if strings.Contains(err.Error(), "invalid value for enum type") {
+		err = xerrors.Errorf("received an unknown enum value, a later version of the library may support it: %w", err)
+	}
+	return err
+}

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -161,7 +161,7 @@ func versionGo() string {
 // of receiving an unknown enum value.
 func maybeUnknownEnum(err error) error {
 	if strings.Contains(err.Error(), "invalid value for enum type") {
-		err = xerrors.Errorf("received an unknown enum value, a later version of the library may support it: %w", err)
+		err = xerrors.Errorf("received an unknown enum value; a later version of the library may support it: %w", err)
 	}
 	return err
 }

--- a/internal/gengapic/testdata/rest_CustomOp.want
+++ b/internal/gengapic/testdata/rest_CustomOp.want
@@ -33,7 +33,7 @@ func (c *fooRESTClient) CustomOp(ctx context.Context, req *foopb.Foo, opts ...ga
 	rsp := &foopb.Operation{}
 
 	if err := unm.Unmarshal(buf, rsp); err != nil {
-		return nil, err
+		return nil, maybeUnknownEnum(err)
 	}
 	op := &Operation{proto: rsp}
 	return op, err


### PR DESCRIPTION
This adds generation and use of a `maybeUnknownEnum` helper to REST clients. This helper will `Wrap` proto-JSON parsing errors caused by the server replying with an unknown enum value. The goal is to produce a more friendly/actionable error message. See http://go/actools-regapic-unknown-enum for more details. The wrapped error produces an error message like the following:

    received an unknown enum value; a later version of the library may support it: proto: (line 1:17): invalid value for enum type: "NOT_VALID_ENUM"

This is (hopefully) a temporary solution, with the long-term solution being a fix to the proto-JSON parsers. 

A companion PR for `compute` is at https://github.com/googleapis/google-cloud-go/pull/4710.

Note: This change introduces the `golang.org/x/xerrors` module as a dependency.
