### PR TITLE
Only add "Required. " to a CLI description when it isn't already there.

### DIFF
--- a/internal/gencli/gencli.go
+++ b/internal/gencli/gencli.go
@@ -360,7 +360,7 @@ func (g *gcli) buildOneOfFlag(cmd *Command, msg *desc.MessageDescriptor, field *
 
 	cmd.HasEnums = cmd.HasEnums || flag.IsEnum()
 
-	if flag.Required {
+	if flag.Required && !strings.HasPrefix(flag.Usage, "Required. ") {
 		flag.Usage = "Required. " + flag.Usage
 	}
 
@@ -483,7 +483,7 @@ func (g *gcli) buildFieldFlags(cmd *Command, msg *desc.MessageDescriptor, parent
 
 		// evaluate field behavior
 		outputOnly, flag.Required = g.getFieldBehavior(field)
-		if flag.Required {
+		if flag.Required && !strings.HasPrefix(flag.Usage, "Required. ") {
 			flag.Usage = "Required. " + flag.Usage
 		}
 


### PR DESCRIPTION
This adds a check that prevents duplicate instances of "Required. " at the start of a flag description that occurs when the proto comment on the corresponding field begins with "Required. ". That was producing declarations like the following:
```
       ListApiSpecsCmd.Flags().StringVar(&ListApiSpecsInput.Parent, "parent", "", "Required. Required. The parent, wh
ich owns this collection...")
```
This problem appeared when our project started using protos generated by "API publish" rules, which automatically add "Required. " to proto comments ([example](https://github.com/apigee/registry/blob/0fe288e0462faecf645f300d0402734506c5e2e7/google/cloud/apigeeregistry/v1/registry_service.proto#L346)).