### PR TITLE
gapic: ignore mixin proto files in input when generating mixins

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -55,6 +55,9 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 		if !strContains(genReq.GetFileToGenerate(), f.GetName()) {
 			continue
 		}
+		if f.GetName() == "google/cloud/location/locations.proto" && g.hasLROMixin() {
+			continue
+		}
 		genServs = append(genServs, f.GetService()...)
 	}
 

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -17,6 +17,7 @@ package gengapic
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -55,7 +56,7 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 		if !strContains(genReq.GetFileToGenerate(), f.GetName()) {
 			continue
 		}
-		fmt.Printf("Input file: %s\n", f.GetName())
+		fmt.Fprintf(os.Stderr, "Input file: %s\n", f.GetName())
 		if f.GetName() == "google/cloud/location/locations.proto" && g.hasLROMixin() {
 			continue
 		}

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -55,6 +55,7 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 		if !strContains(genReq.GetFileToGenerate(), f.GetName()) {
 			continue
 		}
+		fmt.Printf("Input file: %s\n", f.GetName())
 		if f.GetName() == "google/cloud/location/locations.proto" && g.hasLROMixin() {
 			continue
 		}

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -17,7 +17,6 @@ package gengapic
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -56,7 +55,6 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 		if !strContains(genReq.GetFileToGenerate(), f.GetName()) {
 			continue
 		}
-		fmt.Fprintf(os.Stderr, "Input file: %s\n", f.GetName())
 		if !g.includeMixinInputFile(f.GetName()) {
 			continue
 		}

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -57,7 +57,7 @@ func Gen(genReq *plugin.CodeGeneratorRequest) (*plugin.CodeGeneratorResponse, er
 			continue
 		}
 		fmt.Fprintf(os.Stderr, "Input file: %s\n", f.GetName())
-		if f.GetName() == "google/cloud/location/locations.proto" && g.hasLROMixin() {
+		if !g.includeMixinInputFile(f.GetName()) {
 			continue
 		}
 		genServs = append(genServs, f.GetService()...)

--- a/internal/gengapic/mixins.go
+++ b/internal/gengapic/mixins.go
@@ -194,10 +194,10 @@ func (g *generator) hasIAMPolicyMixin() bool {
 	return len(g.mixins["google.iam.v1.IAMPolicy"]) > 0 && !g.hasIAMPolicyOverrides
 }
 
-// hasLocationixin is a convenience method for determining if the Locations
+// hasLocationMixin is a convenience method for determining if the Locations
 // mixin should be generated.
 func (g *generator) hasLocationMixin() bool {
-	return len(g.mixins["google.cloud.location.Locations"]) > 0
+	return len(g.mixins["google.cloud.location.Locations"]) > 0 && len(g.serviceConfig.GetApis()) > 1
 }
 
 // checkIAMPolicyOverrides determines if any of the given services define an

--- a/internal/gengapic/mixins.go
+++ b/internal/gengapic/mixins.go
@@ -191,7 +191,7 @@ func (g *generator) hasLROMixin() bool {
 // hasIAMPolicyMixin is a convenience method for determining if the IAMPolicy
 // mixin should be generated.
 func (g *generator) hasIAMPolicyMixin() bool {
-	return len(g.mixins["google.iam.v1.IAMPolicy"]) > 0 && !g.hasIAMPolicyOverrides
+	return len(g.mixins["google.iam.v1.IAMPolicy"]) > 0 && !g.hasIAMPolicyOverrides && len(g.serviceConfig.GetApis()) > 1
 }
 
 // hasLocationMixin is a convenience method for determining if the Locations
@@ -218,4 +218,17 @@ func (g *generator) checkIAMPolicyOverrides(servs []*descriptor.ServiceDescripto
 			}
 		}
 	}
+}
+
+func (g *generator) includeMixinInputFile(file string) bool {
+	if file == "google/cloud/location/locations.proto" && g.hasLocationMixin() {
+		return false
+	}
+	if file == "google/iam/v1/iam_policy.proto" && g.hasIAMPolicyMixin() {
+		return false
+	}
+	if file == "google/longrunning/operations.proto" && g.hasLROMixin() {
+		return false
+	}
+	return true
 }

--- a/internal/gengapic/mixins.go
+++ b/internal/gengapic/mixins.go
@@ -220,6 +220,10 @@ func (g *generator) checkIAMPolicyOverrides(servs []*descriptor.ServiceDescripto
 	}
 }
 
+// includeMixinInputFile determines if the given proto file name matches
+// a known mixin file and indicates if it should be included in the
+// protos-to-be-generated file set based on if the package is using it for
+// mixins or not.
 func (g *generator) includeMixinInputFile(file string) bool {
 	if file == "google/cloud/location/locations.proto" && g.hasLocationMixin() {
 		return false

--- a/internal/gengapic/mixins_test.go
+++ b/internal/gengapic/mixins_test.go
@@ -190,6 +190,12 @@ func TestHasLocationMixin(t *testing.T) {
 			"google.longrunning.Operations": operationsMethods(),
 			"google.iam.v1.IAMPolicy":       iamPolicyMethods(),
 		},
+		serviceConfig: &serviceconfig.Service{
+			Apis: []*apipb.Api{
+				{Name: "foo.bar.Baz"},
+				{Name: "google.cloud.location.Locations"},
+			},
+		},
 	}
 
 	var want bool
@@ -199,6 +205,12 @@ func TestHasLocationMixin(t *testing.T) {
 
 	want = true
 	g.mixins["google.cloud.location.Locations"] = locationMethods()
+	if got := g.hasLocationMixin(); !cmp.Equal(got, want) {
+		t.Errorf("TestHasLocationMixin wanted %v but got %v", want, got)
+	}
+
+	want = false
+	g.serviceConfig.Apis = []*apipb.Api{{Name: "google.cloud.location.Locations"}}
 	if got := g.hasLocationMixin(); !cmp.Equal(got, want) {
 		t.Errorf("TestHasLocationMixin wanted %v but got %v", want, got)
 	}

--- a/internal/gengapic/mixins_test.go
+++ b/internal/gengapic/mixins_test.go
@@ -132,6 +132,12 @@ func TestHasIAMPolicyMixin(t *testing.T) {
 			"google.longrunning.Operations":   operationsMethods(),
 			"google.cloud.location.Locations": locationMethods(),
 		},
+		serviceConfig: &serviceconfig.Service{
+			Apis: []*apipb.Api{
+				{Name: "foo.bar.Baz"},
+				{Name: "google.iam.v1.IAMPolicy"},
+			},
+		},
 	}
 
 	var want bool
@@ -146,7 +152,13 @@ func TestHasIAMPolicyMixin(t *testing.T) {
 	}
 
 	want = false
+	g.serviceConfig.Apis = []*apipb.Api{{Name: "google.iam.v1.IAMPolicy"}}
+	if got := g.hasIAMPolicyMixin(); !cmp.Equal(got, want) {
+		t.Errorf("TestHasIAMPolicyMixin wanted %v but got %v", want, got)
+	}
+
 	g.hasIAMPolicyOverrides = true
+	g.serviceConfig.Apis = append(g.serviceConfig.Apis, &apipb.Api{Name: "foo.bar.Baz"})
 	if got := g.hasIAMPolicyMixin(); !cmp.Equal(got, want) {
 		t.Errorf("TestHasIAMPolicyMixin wanted %v but got %v", want, got)
 	}


### PR DESCRIPTION
We need to exclude the mixin proto files when they are present in the input from client generation, so that we do not generate extra clients.