### PR TITLE
feat(gengapic): REGAPIC headers built from metadata

### DIFF
--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -110,6 +110,9 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 
 	p("import (")
 	p("%s%q", "\t", "context")
+	if hasREST {
+		p("%s%q", "\t", "net/http")
+	}
 	p("%s%q", "\t", "os")
 	p("%s%q", "\t", "runtime")
 	p("%s%q", "\t", "strconv")
@@ -215,6 +218,16 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 		p(`    err = xerrors.Errorf("received an unknown enum value; a later version of the library may support it: %%w", err)`)
 		p("  }")
 		p("  return err")
+		p("}")
+		p("")
+		p("// buildHeaders extracts metadata from the outgoing context, joins it with any other")
+		p("// given metadata, and converts them into a http.Header. ")
+		p("func buildHeaders(ctx context.Context, mds ...metadata.MD) http.Header {")
+		p("  if cmd, ok := metadata.FromOutgoingContext(ctx); ok {")
+		p("    mds = append(mds, cmd)")
+		p("  }")
+		p("  md := metadata.Join(mds...)")
+		p("  return http.Header(md)")
 		p("}")
 	}
 }

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -71,6 +71,7 @@ package awesome // import "path/to/awesome"
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"runtime"
 	"strconv"
@@ -162,4 +163,14 @@ func maybeUnknownEnum(err error) error {
 		err = xerrors.Errorf("received an unknown enum value; a later version of the library may support it: %w", err)
 	}
 	return err
+}
+
+// buildHeaders extracts metadata from the outgoing context, joins it with any other
+// given metadata, and converts them into a http.Header.
+func buildHeaders(ctx context.Context, mds ...metadata.MD) http.Header {
+	if cmd, ok := metadata.FromOutgoingContext(ctx); ok {
+		mds = append(mds, cmd)
+	}
+	md := metadata.Join(mds...)
+	return http.Header(md)
 }

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -73,6 +73,7 @@ package awesome // import "path/to/awesome"
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"runtime"
 	"strconv"
@@ -164,4 +165,14 @@ func maybeUnknownEnum(err error) error {
 		err = xerrors.Errorf("received an unknown enum value; a later version of the library may support it: %w", err)
 	}
 	return err
+}
+
+// buildHeaders extracts metadata from the outgoing context, joins it with any other
+// given metadata, and converts them into a http.Header.
+func buildHeaders(ctx context.Context, mds ...metadata.MD) http.Header {
+	if cmd, ok := metadata.FromOutgoingContext(ctx); ok {
+		mds = append(mds, cmd)
+	}
+	md := metadata.Join(mds...)
+	return http.Header(md)
 }

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -73,6 +73,7 @@ package awesome // import "path/to/awesome"
 
 import (
 	"context"
+	"net/http"
 	"os"
 	"runtime"
 	"strconv"
@@ -164,4 +165,14 @@ func maybeUnknownEnum(err error) error {
 		err = xerrors.Errorf("received an unknown enum value; a later version of the library may support it: %w", err)
 	}
 	return err
+}
+
+// buildHeaders extracts metadata from the outgoing context, joins it with any other
+// given metadata, and converts them into a http.Header.
+func buildHeaders(ctx context.Context, mds ...metadata.MD) http.Header {
+	if cmd, ok := metadata.FromOutgoingContext(ctx); ok {
+		mds = append(mds, cmd)
+	}
+	md := metadata.Join(mds...)
+	return http.Header(md)
 }

--- a/internal/gengapic/testdata/rest_CustomOp.want
+++ b/internal/gengapic/testdata/rest_CustomOp.want
@@ -10,6 +10,8 @@ func (c *fooRESTClient) CustomOp(ctx context.Context, req *foopb.Foo, opts ...ga
 
 	baseUrl.RawQuery = params.Encode()
 
+	// Build HTTP headers from client and context metadata.
+	headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &foopb.Operation{}
 	e := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -18,11 +20,7 @@ func (c *fooRESTClient) CustomOp(ctx context.Context, req *foopb.Foo, opts ...ga
 			return err
 		}
 		httpReq = httpReq.WithContext(ctx)
-		// Set the headers
-		for k, v := range c.xGoogMetadata {
-			httpReq.Header[k] = v
-		}
-		httpReq.Header["Content-Type"] = []string{"application/json",}
+		httpReq.Header = headers
 
 		httpRsp, err := c.httpClient.Do(httpReq)
 		if err != nil{

--- a/internal/gengapic/testdata/rest_EmptyRPC.want
+++ b/internal/gengapic/testdata/rest_EmptyRPC.want
@@ -10,18 +10,15 @@ func (c *fooRESTClient) EmptyRPC(ctx context.Context, req *foopb.Foo, opts ...ga
 
 	baseUrl.RawQuery = params.Encode()
 
+	// Build HTTP headers from client and context metadata.
+	headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))
 	return gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		httpReq, err := http.NewRequest("DELETE", baseUrl.String(), nil)
 		if err != nil {
 			return err
 		}
 		httpReq = httpReq.WithContext(ctx)
-
-		// Set the headers
-		for k, v := range c.xGoogMetadata {
-			httpReq.Header[k] = v
-		}
-		httpReq.Header["Content-Type"] = []string{"application/json"}
+		httpReq.Header = headers
 
 		httpRsp, err := c.httpClient.Do(httpReq)
 		if err != nil{

--- a/internal/gengapic/testdata/rest_PagingRPC.want
+++ b/internal/gengapic/testdata/rest_PagingRPC.want
@@ -25,18 +25,15 @@ func (c *fooRESTClient) PagingRPC(ctx context.Context, req *foopb.PagedFooReques
 
 		baseUrl.RawQuery = params.Encode()
 
+		// Build HTTP headers from client and context metadata.
+		headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))
 		e := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 			httpReq, err := http.NewRequest("GET", baseUrl.String(), nil)
 			if err != nil {
 				return err
 			}
+			httpReq.Header = headers
 
-			// Set the headers
-			for k, v := range c.xGoogMetadata {
-				httpReq.Header[k] = v
-			}
-
-			httpReq.Header["Content-Type"] = []string{"application/json"}
 			httpRsp, err := c.httpClient.Do(httpReq)
 			if err != nil{
 				return err

--- a/internal/gengapic/testdata/rest_UnaryRPC.want
+++ b/internal/gengapic/testdata/rest_UnaryRPC.want
@@ -8,6 +8,8 @@ func (c *fooRESTClient) UnaryRPC(ctx context.Context, req *foopb.Foo, opts ...ga
 	baseUrl, _ := url.Parse(c.endpoint)
 	baseUrl.Path += fmt.Sprintf("/v1/foo")
 
+	// Build HTTP headers from client and context metadata.
+	headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &foopb.Foo{}
 	e := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
@@ -16,11 +18,7 @@ func (c *fooRESTClient) UnaryRPC(ctx context.Context, req *foopb.Foo, opts ...ga
 			return err
 		}
 		httpReq = httpReq.WithContext(ctx)
-		// Set the headers
-		for k, v := range c.xGoogMetadata {
-			httpReq.Header[k] = v
-		}
-		httpReq.Header["Content-Type"] = []string{"application/json",}
+		httpReq.Header = headers
 
 		httpRsp, err := c.httpClient.Do(httpReq)
 		if err != nil{


### PR DESCRIPTION
This adds a `buildHeaders` helper to REGAPIC clients that takes `metadata.MD` from the outgoing `context.Context`, joins it with other `metadata.MD` (like `xGoogMetadata` and the `Content-Type` header), and converts it into an `http.Header` for use on each `http.Request`. This extends the existing code by pulling `metadata.MD` from the outgoing `context.Context` which allows end-users to continue to set metadata/headers the way our GAPIC/gRPC already supports.

The client method builds the `http.Header` once and reuses it for each new `http.Request` built per attempt. This saves a small bit of processing time.

Fixes #855 