### PR TITLE
chore(gengapic): add fqn helper

### DIFF
--- a/internal/gengapic/generator.go
+++ b/internal/gengapic/generator.go
@@ -232,3 +232,18 @@ func (g *generator) reset() {
 		delete(g.imports, k)
 	}
 }
+
+// fqn recursively builds the fully qualified proto element name,
+// but omits the leading ".". For example, google.foo.v1.FooMessage.
+func (g *generator) fqn(p pbinfo.ProtoType) string {
+	// Base case. Use proto package instead of relative file name.
+	if f, isFile := p.(*descriptor.FileDescriptorProto); isFile {
+		return f.GetPackage()
+	}
+
+	parent := g.descInfo.ParentElement[p]
+	if parent == nil {
+		parent = g.descInfo.ParentFile[p]
+	}
+	return fmt.Sprintf("%s.%s", g.fqn(parent), p.GetName())
+}

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -470,12 +470,6 @@ func (g *generator) isLRO(m *descriptor.MethodDescriptorProto) bool {
 	return m.GetOutputType() == lroType && g.descInfo.ParentFile[m].GetPackage() != "google.longrunning"
 }
 
-func (g *generator) getServiceName(m *descriptor.MethodDescriptorProto) string {
-	f := g.descInfo.ParentFile[m].GetPackage()
-	s := g.descInfo.ParentElement[m].GetName()
-	return fmt.Sprintf("%s.%s", f, s)
-}
-
 func (g *generator) returnType(m *descriptor.MethodDescriptorProto) (string, error) {
 	outType := g.descInfo.Type[m.GetOutputType()]
 	outSpec, err := g.descInfo.ImportSpec(outType)

--- a/internal/gengapic/gengrpc.go
+++ b/internal/gengapic/gengrpc.go
@@ -83,8 +83,7 @@ func (g *generator) genGRPCMethod(servName string, serv *descriptor.ServiceDescr
 }
 
 func (g *generator) unaryGRPCCall(servName string, m *descriptor.MethodDescriptorProto) error {
-	s := g.descInfo.ParentElement[m]
-	sFQN := fmt.Sprintf("%s.%s", g.descInfo.ParentFile[s].GetPackage(), s.GetName())
+	sFQN := g.fqn(g.descInfo.ParentElement[m])
 	inType := g.descInfo.Type[*m.InputType]
 	outType := g.descInfo.Type[*m.OutputType]
 
@@ -219,7 +218,7 @@ func (g *generator) grpcCallOptions(serv *descriptor.ServiceDescriptorProto, ser
 	p("func default%[1]sCallOptions() *%[1]sCallOptions {", servName)
 	p("  return &%sCallOptions{", servName)
 	for _, m := range methods {
-		sFQN := g.getServiceName(m)
+		sFQN := g.fqn(g.descInfo.ParentElement[m])
 		mn := m.GetName()
 		p("%s: []gax.CallOption{", mn)
 		if maxReq, ok := c.RequestLimit(sFQN, mn); ok {

--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -25,8 +25,7 @@ import (
 )
 
 func (g *generator) lroCall(servName string, m *descriptor.MethodDescriptorProto) error {
-	s := g.descInfo.ParentElement[m]
-	sFQN := fmt.Sprintf("%s.%s", g.descInfo.ParentFile[s].GetPackage(), s.GetName())
+	sFQN := g.fqn(g.descInfo.ParentElement[m])
 	inType := g.descInfo.Type[m.GetInputType()]
 	outType := g.descInfo.Type[m.GetOutputType()]
 


### PR DESCRIPTION
Adds a helper that builds the fully-qualified proto element name for a given element, changes some places where it can be used, and removes an extraneous helper `getServiceName` replaced by `fqn` calls. This helper aids me in other code I'm writing.