### PR TITLE
feat: add dynamic routing header generation

### DIFF
--- a/cmd/protoc-gen-go_cli/test.sh
+++ b/cmd/protoc-gen-go_cli/test.sh
@@ -30,7 +30,7 @@ mkdir -p "$OUT/showcase"
 # make test proto directories
 mkdir -p $SHOW_PROTOS
 
-SHOWCASE_VERSION=0.9.0
+SHOWCASE_VERSION=0.19.0
 
 # download gapic-showcase proto descriptor set
 curl -L -O https://github.com/googleapis/gapic-showcase/releases/download/v$SHOWCASE_VERSION/gapic-showcase-$SHOWCASE_VERSION.desc

--- a/internal/gengapic/fuzz.go
+++ b/internal/gengapic/fuzz.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build gofuzz
 // +build gofuzz
 
 package gengapic

--- a/internal/gengapic/fuzz.go
+++ b/internal/gengapic/fuzz.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build gofuzz
 // +build gofuzz
 
 package gengapic

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -330,7 +330,8 @@ func (g *generator) insertDynamicRequestHeaders(m *descriptor.MethodDescriptorPr
 			if err != nil {
 				return err
 			}
-			g.printf("if reg := regexp.MustCompile(%q); reg.MatchString(%s) {", namedCaptureRegex, accessor)
+			// There could be an edge case where the request field is empty and the path template is a wildcard. In that case, we still don't want to send an empty header name.
+			g.printf("if reg := regexp.MustCompile(%q); reg.MatchString(%s) && len(%s) > 0 {", namedCaptureRegex, accessor, regexHelper)
 			g.printf("  routingHeadersMap[%q] = %s", headerName, regexHelper)
 			g.printf("}")
 		}

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -273,6 +273,10 @@ func TestGenMethod(t *testing.T) {
 				PathTemplate: "{foo_name=projects/*/foos/*}/bars/*/**",
 			},
 			{
+				Field:        "another",
+				PathTemplate: "{foo_name=**}",
+			},
+			{
 				Field:        "field_name.nested",
 				PathTemplate: "{nested_name=**}",
 			},

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -254,6 +254,40 @@ func TestGenMethod(t *testing.T) {
 	}
 	proto.SetExtension(opts, annotations.E_Http, ext)
 
+	optsGetAnotherThing := &descriptor.MethodOptions{}
+	extGetAnotherThing := &annotations.RoutingRule{
+		RoutingParameters: []*annotations.RoutingParameter{
+			{
+				Field: "other",
+			},
+			{
+				Field:        "other",
+				PathTemplate: "{name=projects/*}/foos",
+			},
+			{
+				Field:        "another",
+				PathTemplate: "{foo_name=projects/*}/bars/*/**",
+			},
+			{
+				Field:        "another",
+				PathTemplate: "{foo_name=projects/*/foos/*}/bars/*/**",
+			},
+			{
+				Field:        "field_name.nested",
+				PathTemplate: "{nested_name=**}",
+			},
+			{
+				Field:        "field_name.nested",
+				PathTemplate: "{part_of_nested=projects/*}/bars",
+			},
+		},
+	}
+	proto.SetExtension(optsGetAnotherThing, annotations.E_Routing, extGetAnotherThing)
+
+	optsGetManyOtherThings := &descriptor.MethodOptions{}
+	extGetManyOtherThings := &annotations.RoutingRule{}
+	proto.SetExtension(optsGetManyOtherThings, annotations.E_Routing, extGetManyOtherThings)
+
 	file := &descriptor.FileDescriptorProto{
 		Package: proto.String("my.pkg"),
 		Options: &descriptor.FileOptions{
@@ -411,6 +445,36 @@ methods:
 			},
 			imports: map[pbinfo.ImportSpec]bool{
 				{Name: "mypackagepb", Path: "mypackage"}: true,
+			},
+		},
+		// Test for dynamic routing header annotations.
+		{
+			m: &descriptor.MethodDescriptorProto{
+				Name:       proto.String("GetAnotherThing"),
+				InputType:  proto.String(".my.pkg.InputType"),
+				OutputType: proto.String(".my.pkg.OutputType"),
+				Options:    optsGetAnotherThing,
+			},
+			imports: map[pbinfo.ImportSpec]bool{
+				{Path: "fmt"}:                            true,
+				{Path: "net/url"}:                        true,
+				{Path: "regexp"}:                         true,
+				{Path: "time"}:                           true,
+				{Name: "mypackagepb", Path: "mypackage"}: true,
+			},
+		},
+		// Test for empty dynamic routing annotation, so no headers should be sent.
+		{
+			m: &descriptor.MethodDescriptorProto{
+				Name:       proto.String("GetManyOtherThings"),
+				InputType:  proto.String(".my.pkg.PageInputType"),
+				OutputType: proto.String(".my.pkg.PageOutputType"),
+				Options:    optsGetManyOtherThings,
+			},
+			imports: map[pbinfo.ImportSpec]bool{
+				{Path: "google.golang.org/api/iterator"}:   true,
+				{Path: "google.golang.org/protobuf/proto"}: true,
+				{Name: "mypackagepb", Path: "mypackage"}:   true,
 			},
 		},
 	} {

--- a/internal/gengapic/helpers.go
+++ b/internal/gengapic/helpers.go
@@ -168,7 +168,7 @@ func isRequired(field *descriptor.FieldDescriptorProto) bool {
 // The named capture is the named segment portion for the header itself.
 func convertPathTemplateToRegex(pattern string) string {
 	// If path template doesn't exist, then use a wildcard.
-	if len(pattern) < 1 {
+	if pattern == "" {
 		return "(.*)"
 	}
 	// Replace name of header to named capture.
@@ -198,13 +198,15 @@ func getHeaderName(pattern string) string {
 	// a collectionId, and should be contained within curly braces.
 	if strings.Count(pattern, "=") > 1 || !curlyBraceRegex.MatchString(pattern) {
 		return ""
-	} else if strings.Count(pattern, "=") < 1 {
-		// If there is no equal sign, then the path template is a collectionId which is its own name.
-		// and both the named segment and path template are wildcards.
-		return curlyBraceRegex.FindStringSubmatch(pattern)[1]
 	}
-	helperSegment := curlyBraceRegex.FindStringSubmatch(pattern)[1]
-	getBeforeAfterEqualsSign := regexp.MustCompile("(?P<before>[^=]*)=(?P<after>.*)")
-	matches := getBeforeAfterEqualsSign.FindStringSubmatch(helperSegment)
+	// curlyBraceSegment returns the named capture within the path template that is within the curly braces.
+	curlyBraceSegment := curlyBraceRegex.FindStringSubmatch(pattern)[1]
+	// If there is no equal sign, then the path template is a collectionId which is its own name.
+	// and both the named segment and path template are wildcards.
+	if strings.Count(pattern, "=") < 1 {
+		return curlyBraceSegment
+	}
+	getBeforeEqualsSign := regexp.MustCompile("(?P<before>[^=]*)=.*")
+	matches := getBeforeEqualsSign.FindStringSubmatch(curlyBraceSegment)
 	return matches[1]
 }

--- a/internal/gengapic/helpers_test.go
+++ b/internal/gengapic/helpers_test.go
@@ -15,7 +15,6 @@
 package gengapic
 
 import (
-	//"reflect"
 	"testing"
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"

--- a/internal/gengapic/testdata/method_GetAnotherThing.want
+++ b/internal/gengapic/testdata/method_GetAnotherThing.want
@@ -6,35 +6,29 @@ func (c *fooGRPCClient) GetAnotherThing(ctx context.Context, req *mypackagepb.In
 	}
 	routingHeaders := ""
 	routingHeadersMap := make(map[string]string)
-	if reg := regexp.MustCompile("(.*)");
-	reg.MatchString(req.GetOther()) {
+	if reg := regexp.MustCompile("(.*)"); reg.MatchString(req.GetOther()) {
 		routingHeadersMap["other"] = url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])
 	}
-	if reg := regexp.MustCompile("(?P<name>projects/[^/]+)/foos");
-	reg.MatchString(req.GetOther()) {
+	if reg := regexp.MustCompile("(?P<name>projects/[^/]+)/foos"); reg.MatchString(req.GetOther()) {
 		routingHeadersMap["name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])
 	}
-	if reg := regexp.MustCompile("(?P<foo_name>projects/[^/]+)/bars/[^/]+(?:/.*)?");
-	reg.MatchString(req.GetAnother()) {
-		routingHeadersMap["foo_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])
-	} else if reg = regexp.MustCompile("(?P<foo_name>projects/[^/]+/foos/[^/]+)/bars/[^/]+(?:/.*)?");
-	reg.MatchString(req.GetAnother()) {
+	if reg := regexp.MustCompile("(?P<foo_name>projects/[^/]+)/bars/[^/]+(?:/.*)?"); reg.MatchString(req.GetAnother()) {
 		routingHeadersMap["foo_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])
 	}
-	if reg := regexp.MustCompile("(?P<foo_name>projects/[^/]+/foos/[^/]+)/bars/[^/]+(?:/.*)?");
-	reg.MatchString(req.GetAnother()) {
+	if reg := regexp.MustCompile("(?P<foo_name>projects/[^/]+/foos/[^/]+)/bars/[^/]+(?:/.*)?"); reg.MatchString(req.GetAnother()) {
 		routingHeadersMap["foo_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])
 	}
-	if reg := regexp.MustCompile("(?P<nested_name>.*)");
-	reg.MatchString(req.GetFieldName().GetNested()) {
+	if reg := regexp.MustCompile("(?P<foo_name>.*)"); reg.MatchString(req.GetAnother()) {
+		routingHeadersMap["foo_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])
+	}
+	if reg := regexp.MustCompile("(?P<nested_name>.*)"); reg.MatchString(req.GetFieldName().GetNested()) {
 		routingHeadersMap["nested_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetFieldName().GetNested())[1])
 	}
-	if reg := regexp.MustCompile("(?P<part_of_nested>projects/[^/]+)/bars");
-	reg.MatchString(req.GetFieldName().GetNested()) {
+	if reg := regexp.MustCompile("(?P<part_of_nested>projects/[^/]+)/bars"); reg.MatchString(req.GetFieldName().GetNested()) {
 		routingHeadersMap["part_of_nested"] = url.QueryEscape(reg.FindStringSubmatch(req.GetFieldName().GetNested())[1])
 	}
 	for headerName, headerValue := range routingHeadersMap {
-		routingHeaders = routingHeaders + fmt.Sprintf("%s=%s&", headerName, headerValue)
+		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, headerName, headerValue)
 	}
 	routingHeaders = strings.TrimSuffix(routingHeaders, "&")
 	md := metadata.Pairs("x-goog-request-params", routingHeaders)

--- a/internal/gengapic/testdata/method_GetAnotherThing.want
+++ b/internal/gengapic/testdata/method_GetAnotherThing.want
@@ -1,0 +1,55 @@
+func (c *fooGRPCClient) GetAnotherThing(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
+	if _, ok := ctx.Deadline(); !ok && !c.disableDeadlines {
+		cctx, cancel := context.WithTimeout(ctx, 10000 * time.Millisecond)
+		defer cancel()
+		ctx = cctx
+	}
+	routingHeaders := ""
+	routingHeadersMap := make(map[string]string)
+	routingRegexp0 := regexp.MustCompile("(.*)")
+	headerName0 := "other"
+	headerValue0 := ""
+	if routingRegexp0.MatchString(req.GetOther()){headerValue0 = url.QueryEscape(routingRegexp0.FindStringSubmatch(req.GetOther())[1])}
+	if len(headerValue0) > 0{routingHeadersMap[headerName0] = headerValue0}
+	routingRegexp1 := regexp.MustCompile("(?P<name>projects/[^/]+)/foos")
+	headerName1 := "name"
+	headerValue1 := ""
+	if routingRegexp1.MatchString(req.GetOther()){headerValue1 = url.QueryEscape(routingRegexp1.FindStringSubmatch(req.GetOther())[1])}
+	if len(headerValue1) > 0{routingHeadersMap[headerName1] = headerValue1}
+	routingRegexp2 := regexp.MustCompile("(?P<foo_name>projects/[^/]+)/bars/[^/]+(?:/.*)?")
+	headerName2 := "foo_name"
+	headerValue2 := ""
+	if routingRegexp2.MatchString(req.GetAnother()){headerValue2 = url.QueryEscape(routingRegexp2.FindStringSubmatch(req.GetAnother())[1])}
+	if len(headerValue2) > 0{routingHeadersMap[headerName2] = headerValue2}
+	routingRegexp3 := regexp.MustCompile("(?P<foo_name>projects/[^/]+/foos/[^/]+)/bars/[^/]+(?:/.*)?")
+	headerName3 := "foo_name"
+	headerValue3 := ""
+	if routingRegexp3.MatchString(req.GetAnother()){headerValue3 = url.QueryEscape(routingRegexp3.FindStringSubmatch(req.GetAnother())[1])}
+	if len(headerValue3) > 0{routingHeadersMap[headerName3] = headerValue3}
+	routingRegexp4 := regexp.MustCompile("(?P<nested_name>.*)")
+	headerName4 := "nested_name"
+	headerValue4 := ""
+	if routingRegexp4.MatchString(req.GetFieldName().GetNested()){headerValue4 = url.QueryEscape(routingRegexp4.FindStringSubmatch(req.GetFieldName().GetNested())[1])}
+	if len(headerValue4) > 0{routingHeadersMap[headerName4] = headerValue4}
+	routingRegexp5 := regexp.MustCompile("(?P<part_of_nested>projects/[^/]+)/bars")
+	headerName5 := "part_of_nested"
+	headerValue5 := ""
+	if routingRegexp5.MatchString(req.GetFieldName().GetNested()){headerValue5 = url.QueryEscape(routingRegexp5.FindStringSubmatch(req.GetFieldName().GetNested())[1])}
+	if len(headerValue5) > 0{routingHeadersMap[headerName5] = headerValue5}
+	for headerName, headerValue := range routingHeadersMap {routingHeaders = routingHeaders + fmt.Sprintf("%s=%s&", headerName, headerValue)}
+	if len(routingHeaders) > 0{routingHeaders = routingHeaders[:len(routingHeaders)-1]}
+	md := metadata.Pairs("x-goog-request-params", routingHeaders)
+	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
+	opts = append((*c.CallOptions).GetAnotherThing[0:len((*c.CallOptions).GetAnotherThing):len((*c.CallOptions).GetAnotherThing)], opts...)
+	var resp *mypackagepb.OutputType
+	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+		var err error
+		resp, err = c.fooClient.GetAnotherThing(ctx, req, settings.GRPC...)
+		return err
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+

--- a/internal/gengapic/testdata/method_GetAnotherThing.want
+++ b/internal/gengapic/testdata/method_GetAnotherThing.want
@@ -6,25 +6,25 @@ func (c *fooGRPCClient) GetAnotherThing(ctx context.Context, req *mypackagepb.In
 	}
 	routingHeaders := ""
 	routingHeadersMap := make(map[string]string)
-	if reg := regexp.MustCompile("(.*)"); reg.MatchString(req.GetOther()) {
+	if reg := regexp.MustCompile("(.*)"); reg.MatchString(req.GetOther()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])) > 0 {
 		routingHeadersMap["other"] = url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])
 	}
-	if reg := regexp.MustCompile("(?P<name>projects/[^/]+)/foos"); reg.MatchString(req.GetOther()) {
+	if reg := regexp.MustCompile("(?P<name>projects/[^/]+)/foos"); reg.MatchString(req.GetOther()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])) > 0 {
 		routingHeadersMap["name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])
 	}
-	if reg := regexp.MustCompile("(?P<foo_name>projects/[^/]+)/bars/[^/]+(?:/.*)?"); reg.MatchString(req.GetAnother()) {
+	if reg := regexp.MustCompile("(?P<foo_name>projects/[^/]+)/bars/[^/]+(?:/.*)?"); reg.MatchString(req.GetAnother()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])) > 0 {
 		routingHeadersMap["foo_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])
 	}
-	if reg := regexp.MustCompile("(?P<foo_name>projects/[^/]+/foos/[^/]+)/bars/[^/]+(?:/.*)?"); reg.MatchString(req.GetAnother()) {
+	if reg := regexp.MustCompile("(?P<foo_name>projects/[^/]+/foos/[^/]+)/bars/[^/]+(?:/.*)?"); reg.MatchString(req.GetAnother()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])) > 0 {
 		routingHeadersMap["foo_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])
 	}
-	if reg := regexp.MustCompile("(?P<foo_name>.*)"); reg.MatchString(req.GetAnother()) {
+	if reg := regexp.MustCompile("(?P<foo_name>.*)"); reg.MatchString(req.GetAnother()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])) > 0 {
 		routingHeadersMap["foo_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])
 	}
-	if reg := regexp.MustCompile("(?P<nested_name>.*)"); reg.MatchString(req.GetFieldName().GetNested()) {
+	if reg := regexp.MustCompile("(?P<nested_name>.*)"); reg.MatchString(req.GetFieldName().GetNested()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetFieldName().GetNested())[1])) > 0 {
 		routingHeadersMap["nested_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetFieldName().GetNested())[1])
 	}
-	if reg := regexp.MustCompile("(?P<part_of_nested>projects/[^/]+)/bars"); reg.MatchString(req.GetFieldName().GetNested()) {
+	if reg := regexp.MustCompile("(?P<part_of_nested>projects/[^/]+)/bars"); reg.MatchString(req.GetFieldName().GetNested()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetFieldName().GetNested())[1])) > 0 {
 		routingHeadersMap["part_of_nested"] = url.QueryEscape(reg.FindStringSubmatch(req.GetFieldName().GetNested())[1])
 	}
 	for headerName, headerValue := range routingHeadersMap {

--- a/internal/gengapic/testdata/method_GetAnotherThing.want
+++ b/internal/gengapic/testdata/method_GetAnotherThing.want
@@ -6,39 +6,39 @@ func (c *fooGRPCClient) GetAnotherThing(ctx context.Context, req *mypackagepb.In
 	}
 	routingHeaders := ""
 	routingHeadersMap := make(map[string]string)
-	routingRegexp0 := regexp.MustCompile("(.*)")
-	headerName0 := "other"
-	headerValue0 := ""
-	if routingRegexp0.MatchString(req.GetOther()){headerValue0 = url.QueryEscape(routingRegexp0.FindStringSubmatch(req.GetOther())[1])}
-	if len(headerValue0) > 0{routingHeadersMap[headerName0] = headerValue0}
-	routingRegexp1 := regexp.MustCompile("(?P<name>projects/[^/]+)/foos")
-	headerName1 := "name"
-	headerValue1 := ""
-	if routingRegexp1.MatchString(req.GetOther()){headerValue1 = url.QueryEscape(routingRegexp1.FindStringSubmatch(req.GetOther())[1])}
-	if len(headerValue1) > 0{routingHeadersMap[headerName1] = headerValue1}
-	routingRegexp2 := regexp.MustCompile("(?P<foo_name>projects/[^/]+)/bars/[^/]+(?:/.*)?")
-	headerName2 := "foo_name"
-	headerValue2 := ""
-	if routingRegexp2.MatchString(req.GetAnother()){headerValue2 = url.QueryEscape(routingRegexp2.FindStringSubmatch(req.GetAnother())[1])}
-	if len(headerValue2) > 0{routingHeadersMap[headerName2] = headerValue2}
-	routingRegexp3 := regexp.MustCompile("(?P<foo_name>projects/[^/]+/foos/[^/]+)/bars/[^/]+(?:/.*)?")
-	headerName3 := "foo_name"
-	headerValue3 := ""
-	if routingRegexp3.MatchString(req.GetAnother()){headerValue3 = url.QueryEscape(routingRegexp3.FindStringSubmatch(req.GetAnother())[1])}
-	if len(headerValue3) > 0{routingHeadersMap[headerName3] = headerValue3}
-	routingRegexp4 := regexp.MustCompile("(?P<nested_name>.*)")
-	headerName4 := "nested_name"
-	headerValue4 := ""
-	if routingRegexp4.MatchString(req.GetFieldName().GetNested()){headerValue4 = url.QueryEscape(routingRegexp4.FindStringSubmatch(req.GetFieldName().GetNested())[1])}
-	if len(headerValue4) > 0{routingHeadersMap[headerName4] = headerValue4}
-	routingRegexp5 := regexp.MustCompile("(?P<part_of_nested>projects/[^/]+)/bars")
-	headerName5 := "part_of_nested"
-	headerValue5 := ""
-	if routingRegexp5.MatchString(req.GetFieldName().GetNested()){headerValue5 = url.QueryEscape(routingRegexp5.FindStringSubmatch(req.GetFieldName().GetNested())[1])}
-	if len(headerValue5) > 0{routingHeadersMap[headerName5] = headerValue5}
-	for headerName, headerValue := range routingHeadersMap {routingHeaders = routingHeaders + fmt.Sprintf("%s=%s&", headerName, headerValue)}
-	if len(routingHeaders) > 0{routingHeaders = routingHeaders[:len(routingHeaders)-1]}
+	if reg := regexp.MustCompile("(.*)");
+	reg.MatchString(req.GetOther()) {
+		routingHeadersMap["other"] = url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])
+	}
+	if reg := regexp.MustCompile("(?P<name>projects/[^/]+)/foos");
+	reg.MatchString(req.GetOther()) {
+		routingHeadersMap["name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])
+	}
+	if reg := regexp.MustCompile("(?P<foo_name>projects/[^/]+)/bars/[^/]+(?:/.*)?");
+	reg.MatchString(req.GetAnother()) {
+		routingHeadersMap["foo_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])
+	} else if reg = regexp.MustCompile("(?P<foo_name>projects/[^/]+/foos/[^/]+)/bars/[^/]+(?:/.*)?");
+	reg.MatchString(req.GetAnother()) {
+		routingHeadersMap["foo_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])
+	}
+	if reg := regexp.MustCompile("(?P<foo_name>projects/[^/]+/foos/[^/]+)/bars/[^/]+(?:/.*)?");
+	reg.MatchString(req.GetAnother()) {
+		routingHeadersMap["foo_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetAnother())[1])
+	}
+	if reg := regexp.MustCompile("(?P<nested_name>.*)");
+	reg.MatchString(req.GetFieldName().GetNested()) {
+		routingHeadersMap["nested_name"] = url.QueryEscape(reg.FindStringSubmatch(req.GetFieldName().GetNested())[1])
+	}
+	if reg := regexp.MustCompile("(?P<part_of_nested>projects/[^/]+)/bars");
+	reg.MatchString(req.GetFieldName().GetNested()) {
+		routingHeadersMap["part_of_nested"] = url.QueryEscape(reg.FindStringSubmatch(req.GetFieldName().GetNested())[1])
+	}
+	for headerName, headerValue := range routingHeadersMap {
+		routingHeaders = routingHeaders + fmt.Sprintf("%s=%s&", headerName, headerValue)
+	}
+	routingHeaders = strings.TrimSuffix(routingHeaders, "&")
 	md := metadata.Pairs("x-goog-request-params", routingHeaders)
+
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append((*c.CallOptions).GetAnotherThing[0:len((*c.CallOptions).GetAnotherThing):len((*c.CallOptions).GetAnotherThing)], opts...)
 	var resp *mypackagepb.OutputType

--- a/internal/gengapic/testdata/method_GetEmptyThing.want
+++ b/internal/gengapic/testdata/method_GetEmptyThing.want
@@ -5,6 +5,7 @@ func (c *fooGRPCClient) GetEmptyThing(ctx context.Context, req *mypackagepb.Inpu
 		ctx = cctx
 	}
 	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[int32(req.GetTopLevelEnum())], "nested_enum", mypackagepb.InputType_NestedEnum_name[int32(req.GetNestedEnum())]))
+
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append((*c.CallOptions).GetEmptyThing[0:len((*c.CallOptions).GetEmptyThing):len((*c.CallOptions).GetEmptyThing)], opts...)
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/method_GetManyOtherThings.want
+++ b/internal/gengapic/testdata/method_GetManyOtherThings.want
@@ -1,0 +1,90 @@
+func (c *fooGRPCClient) GetManyOtherThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
+	ctx = insertMetadata(ctx, c.xGoogMetadata)
+	opts = append((*c.CallOptions).GetManyOtherThings[0:len((*c.CallOptions).GetManyOtherThings):len((*c.CallOptions).GetManyOtherThings)], opts...)
+	it := &StringIterator{}
+	req = proto.Clone(req).(*mypackagepb.PageInputType)
+	it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
+		resp := &mypackagepb.PageOutputType{}
+		if pageToken != "" {
+			req.PageToken = pageToken
+		}
+		if pageSize > math.MaxInt32 {
+			req.PageSize = math.MaxInt32
+		} else if pageSize != 0 {
+			req.PageSize = int32(pageSize)
+		}
+		err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+			var err error
+			resp, err = c.fooClient.GetManyOtherThings(ctx, req, settings.GRPC...)
+			return err
+		}, opts...)
+		if err != nil {
+			return nil, "", err
+		}
+
+		it.Response = resp
+		return resp.GetItems(), resp.GetNextPageToken(), nil
+	}
+	fetch := func(pageSize int, pageToken string) (string, error) {
+		items, nextPageToken, err := it.InternalFetch(pageSize, pageToken)
+		if err != nil {
+			return "", err
+		}
+		it.items = append(it.items, items...)
+		return nextPageToken, nil
+	}
+
+	it.pageInfo, it.nextFunc = iterator.NewPageInfo(fetch, it.bufLen, it.takeBuf)
+	it.pageInfo.MaxSize = int(req.GetPageSize())
+	it.pageInfo.Token = req.GetPageToken()
+
+	return it
+}
+
+// StringIterator manages a stream of string.
+type StringIterator struct {
+	items    []string
+	pageInfo *iterator.PageInfo
+	nextFunc func() error
+
+	// Response is the raw response for the current page.
+	// It must be cast to the RPC response type.
+	// Calling Next() or InternalFetch() updates this value.
+	Response interface{}
+
+	// InternalFetch is for use by the Google Cloud Libraries only.
+	// It is not part of the stable interface of this package.
+	//
+	// InternalFetch returns results from a single call to the underlying RPC.
+	// The number of results is no greater than pageSize.
+	// If there are no more results, nextPageToken is empty and err is nil.
+	InternalFetch func(pageSize int, pageToken string) (results []string, nextPageToken string, err error)
+}
+
+// PageInfo supports pagination. See the google.golang.org/api/iterator package for details.
+func (it *StringIterator) PageInfo() *iterator.PageInfo {
+	return it.pageInfo
+}
+
+// Next returns the next result. Its second return value is iterator.Done if there are no more
+// results. Once Next returns Done, all subsequent calls will return Done.
+func (it *StringIterator) Next() (string, error) {
+	var item string
+	if err := it.nextFunc(); err != nil {
+		return item, err
+	}
+	item = it.items[0]
+	it.items = it.items[1:]
+	return item, nil
+}
+
+func (it *StringIterator) bufLen() int {
+	return len(it.items)
+}
+
+func (it *StringIterator) takeBuf() interface{} {
+	b := it.items
+	it.items = nil
+	return b
+}
+

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -1,5 +1,6 @@
 func (c *fooGRPCClient) GetManyThings(ctx context.Context, req *mypackagepb.PageInputType, opts ...gax.CallOption) *StringIterator {
 	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[int32(req.GetTopLevelEnum())], "nested_enum", mypackagepb.InputType_NestedEnum_name[int32(req.GetNestedEnum())]))
+
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append((*c.CallOptions).GetManyThings[0:len((*c.CallOptions).GetManyThings):len((*c.CallOptions).GetManyThings)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetManyThingsOptional.want
+++ b/internal/gengapic/testdata/method_GetManyThingsOptional.want
@@ -1,5 +1,6 @@
 func (c *fooGRPCClient) GetManyThingsOptional(ctx context.Context, req *mypackagepb.PageInputTypeOptional, opts ...gax.CallOption) *StringIterator {
 	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[int32(req.GetTopLevelEnum())], "nested_enum", mypackagepb.InputType_NestedEnum_name[int32(req.GetNestedEnum())]))
+
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append((*c.CallOptions).GetManyThingsOptional[0:len((*c.CallOptions).GetManyThingsOptional):len((*c.CallOptions).GetManyThingsOptional)], opts...)
 	it := &StringIterator{}

--- a/internal/gengapic/testdata/method_GetOneThing.want
+++ b/internal/gengapic/testdata/method_GetOneThing.want
@@ -5,6 +5,7 @@ func (c *fooGRPCClient) GetOneThing(ctx context.Context, req *mypackagepb.InputT
 		ctx = cctx
 	}
 	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[int32(req.GetTopLevelEnum())], "nested_enum", mypackagepb.InputType_NestedEnum_name[int32(req.GetNestedEnum())]))
+
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	opts = append((*c.CallOptions).GetOneThing[0:len((*c.CallOptions).GetOneThing):len((*c.CallOptions).GetOneThing)], opts...)
 	var resp *mypackagepb.OutputType

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -1,5 +1,6 @@
 func (c *fooGRPCClient) ServerThings(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (mypackagepb.Foo_ServerThingsClient, error) {
 	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[int32(req.GetTopLevelEnum())], "nested_enum", mypackagepb.InputType_NestedEnum_name[int32(req.GetNestedEnum())]))
+
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
 	var resp mypackagepb.Foo_ServerThingsClient
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/showcase/main_test.go
+++ b/showcase/main_test.go
@@ -37,7 +37,7 @@ func init() {
 	registerIgnoreGoroutine("google.golang.org/grpc.(*addrConn).connect")
 }
 
-const showcaseSemver = "0.15.0"
+const showcaseSemver = "0.19.0"
 
 func TestMain(m *testing.M) {
 	flag.Parse()


### PR DESCRIPTION
Add support for the [google.api.routing](https://github.com/googleapis/googleapis/blob/master/google/api/routing.proto) annotation. In short, this annotation allows API producers to explicitly define those request fields should be include in request headers/metadata. Furthermore, it enables API producers to define simple segment matchers (primarily for resource name values) that are generated into regular expressions in the client that extract segments of a field's value to be sent in the header. Finally, it enables API producers to specify a key other than the field name to use in the header key-value-pair. In relation to the implicit headers (extraced from google.api.http annotations), the google.api.routing annotation takes precedence. Please read the annotation documentation for more information on the annotation resolution logic.

- This includes a `gapic-showcase` integration test