### PR TITLE
feat: set version equal to module version

### DIFF
--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -15,6 +15,7 @@
 package gengapic
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -105,6 +106,7 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("//")
 	p("// For information about setting deadlines, reusing contexts, and more")
 	p("// please visit https://pkg.go.dev/cloud.google.com/go.")
+	//TODO(codyoss): use the pkgPath opt
 	p("package %s // import %q", g.opts.pkgName, g.opts.pkgPath)
 	p("")
 
@@ -119,6 +121,7 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("%s%q", "\t", "strings")
 	p("%s%q", "\t", "unicode")
 	p("")
+	p("%s%q", "\t", resolveModuleInternalPkg(g.opts.pkgPath))
 	if hasREST {
 		p("%s%q", "\t", "golang.org/x/xerrors")
 	}
@@ -133,7 +136,7 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)")
 	p("")
 
-	p("const versionClient = %q", "UNKNOWN")
+	p("var versionClient = internal.Version")
 	p("")
 
 	p("func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {")
@@ -270,4 +273,10 @@ func wrapString(str string, max int) []string {
 	lines = append(lines, line)
 
 	return lines
+}
+
+func resolveModuleInternalPkg(pkgPath string) string {
+	pkgSuffix := strings.TrimPrefix(pkgPath, "cloud.google.com/go/")
+	pkg := strings.Split(pkgSuffix, "/")[0]
+	return fmt.Sprintf("cloud.google.com/go/%s/internal", pkg)
 }

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -106,7 +106,6 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("//")
 	p("// For information about setting deadlines, reusing contexts, and more")
 	p("// please visit https://pkg.go.dev/cloud.google.com/go.")
-	//TODO(codyoss): use the pkgPath opt
 	p("package %s // import %q", g.opts.pkgName, g.opts.pkgPath)
 	p("")
 

--- a/internal/gengapic/doc_file_test.go
+++ b/internal/gengapic/doc_file_test.go
@@ -147,3 +147,12 @@ func TestDocFileEmptyService(t *testing.T) {
 		g.reset()
 	}
 }
+
+func TestResolveModuleInternalPkg(t *testing.T) {
+	in := "cloud.google.com/go/foo/apiv1"
+	want := "cloud.google.com/go/foo/internal"
+	got := resolveModuleInternalPkg("cloud.google.com/go/foo/apiv1")
+	if got != want {
+		t.Fatalf("resolveModuleInternalPkg(%q) = %q, want %q", in, got, want)
+	}
+}

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -78,6 +78,7 @@ import (
 	"strings"
 	"unicode"
 
+	"cloud.google.com/go/path/internal"
 	"golang.org/x/xerrors"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
@@ -88,7 +89,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient = internal.Version
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -80,6 +80,7 @@ import (
 	"strings"
 	"unicode"
 
+	"cloud.google.com/go/path/internal"
 	"golang.org/x/xerrors"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
@@ -90,7 +91,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient = internal.Version
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/gengapic/testdata/doc_file_alpha_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_alpha_emptyservice.want
@@ -57,6 +57,7 @@ import (
 	"strings"
 	"unicode"
 
+	"cloud.google.com/go/path/internal"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
 )
@@ -66,7 +67,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient = internal.Version
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -80,6 +80,7 @@ import (
 	"strings"
 	"unicode"
 
+	"cloud.google.com/go/path/internal"
 	"golang.org/x/xerrors"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
@@ -90,7 +91,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient = internal.Version
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/gengapic/testdata/doc_file_beta_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_beta_emptyservice.want
@@ -57,6 +57,7 @@ import (
 	"strings"
 	"unicode"
 
+	"cloud.google.com/go/path/internal"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
 )
@@ -66,7 +67,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient = internal.Version
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/gengapic/testdata/doc_file_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_emptyservice.want
@@ -55,6 +55,7 @@ import (
 	"strings"
 	"unicode"
 
+	"cloud.google.com/go/path/internal"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc/metadata"
 )
@@ -64,7 +65,7 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient = internal.Version
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)


### PR DESCRIPTION
As of https://github.com/googleapis/google-cloud-go/pull/5517 we
now have a version file in the internal package for every module.
This change reads variable and uses it for the client version. This
means all autogenerated clients will now get a meaningful realease
version in thier call metadata.