### PR TITLE
feat: make versionClient a var

### DIFF
--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -134,7 +134,7 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("var versionClient string")
 	p("")
 	p("func getVersionClient() string {")
-	p("  if versionClient == \"\" {")
+	p(`  if versionClient == "" {`)
 	p("    return %q", "UNKNOWN")
 	p("  }")
 	p("  return versionClient")

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -135,7 +135,7 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("")
 	p("func getVersionClient() string {")
 	p(`  if versionClient == "" {`)
-	p("    return %q", "UNKNOWN")
+	p(`    return "UNKNOWN"`)
 	p("  }")
 	p("  return versionClient")
 	p("}")

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -131,7 +131,14 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)")
 	p("")
 
-	p("const versionClient = %q", "UNKNOWN")
+	p("var versionClient string")
+	p("")
+	p("func getVersionClient() string {")
+	p("  if versionClient == \"\" {")
+	p("    return %q", "UNKNOWN")
+	p("  }")
+	p("  return versionClient")
+	p("}")
 	p("")
 
 	p("func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {")

--- a/internal/gengapic/gengrpc.go
+++ b/internal/gengapic/gengrpc.go
@@ -393,7 +393,7 @@ func (g *generator) grpcClientUtilities(serv *descriptor.ServiceDescriptorProto,
 	p("// use by Google-written clients.")
 	p("func (c *%s) setGoogleClientInfo(keyval ...string) {", lowcaseServName)
 	p(`  kv := append([]string{"gl-go", versionGo()}, keyval...)`)
-	p(`  kv = append(kv, "gapic", versionClient, "gax", gax.Version, "grpc", grpc.Version)`)
+	p(`  kv = append(kv, "gapic", getVersionClient(), "gax", gax.Version, "grpc", grpc.Version)`)
 	p(`  c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))`)
 	p("}")
 	p("")

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -160,7 +160,7 @@ func (g *generator) restClientUtilities(serv *descriptor.ServiceDescriptorProto,
 	p("// use by Google-written clients.")
 	p("func (c *%s) setGoogleClientInfo(keyval ...string) {", lowcaseServName)
 	p(`  kv := append([]string{"gl-go", versionGo()}, keyval...)`)
-	p(`  kv = append(kv, "gapic", versionClient, "gax", gax.Version, "rest", "UNKNOWN")`)
+	p(`  kv = append(kv, "gapic", getVersionClient(), "gax", gax.Version, "rest", "UNKNOWN")`)
 	p(`  c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))`)
 	p("}")
 	p("")

--- a/internal/gengapic/testdata/custom_op_init.want
+++ b/internal/gengapic/testdata/custom_op_init.want
@@ -95,7 +95,7 @@ func NewRESTClient(ctx context.Context, opts ...option.ClientOption) (*Client, e
 // use by Google-written clients.
 func (c *restClient) setGoogleClientInfo(keyval ...string) {
 	kv := append([]string{"gl-go", versionGo()}, keyval...)
-	kv = append(kv, "gapic", versionClient, "gax", gax.Version, "rest", "UNKNOWN")
+	kv = append(kv, "gapic", getVersionClient(), "gax", gax.Version, "rest", "UNKNOWN")
 	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 

--- a/internal/gengapic/testdata/deprecated_client_init.want
+++ b/internal/gengapic/testdata/deprecated_client_init.want
@@ -121,7 +121,7 @@ func (c *gRPCClient) Connection() *grpc.ClientConn {
 // use by Google-written clients.
 func (c *gRPCClient) setGoogleClientInfo(keyval ...string) {
 	kv := append([]string{"gl-go", versionGo()}, keyval...)
-	kv = append(kv, "gapic", versionClient, "gax", gax.Version, "grpc", grpc.Version)
+	kv = append(kv, "gapic", getVersionClient(), "gax", gax.Version, "grpc", grpc.Version)
 	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 
@@ -169,7 +169,7 @@ func NewRESTClient(ctx context.Context, opts ...option.ClientOption) (*Client, e
 // use by Google-written clients.
 func (c *restClient) setGoogleClientInfo(keyval ...string) {
 	kv := append([]string{"gl-go", versionGo()}, keyval...)
-	kv = append(kv, "gapic", versionClient, "gax", gax.Version, "rest", "UNKNOWN")
+	kv = append(kv, "gapic", getVersionClient(), "gax", gax.Version, "rest", "UNKNOWN")
 	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -88,7 +88,14 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient string
+
+func getVersionClient() string {
+	if versionClient == "" {
+		return "UNKNOWN"
+	}
+	return versionClient
+}
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -90,7 +90,14 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient string
+
+func getVersionClient() string {
+	if versionClient == "" {
+		return "UNKNOWN"
+	}
+	return versionClient
+}
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/gengapic/testdata/doc_file_alpha_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_alpha_emptyservice.want
@@ -66,7 +66,14 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient string
+
+func getVersionClient() string {
+	if versionClient == "" {
+		return "UNKNOWN"
+	}
+	return versionClient
+}
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -90,7 +90,14 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient string
+
+func getVersionClient() string {
+	if versionClient == "" {
+		return "UNKNOWN"
+	}
+	return versionClient
+}
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/gengapic/testdata/doc_file_beta_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_beta_emptyservice.want
@@ -66,7 +66,14 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient string
+
+func getVersionClient() string {
+	if versionClient == "" {
+		return "UNKNOWN"
+	}
+	return versionClient
+}
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/gengapic/testdata/doc_file_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_emptyservice.want
@@ -64,7 +64,14 @@ import (
 type clientHookParams struct{}
 type clientHook func(context.Context, clientHookParams) ([]option.ClientOption, error)
 
-const versionClient = "UNKNOWN"
+var versionClient string
+
+func getVersionClient() string {
+	if versionClient == "" {
+		return "UNKNOWN"
+	}
+	return versionClient
+}
 
 func insertMetadata(ctx context.Context, mds ...metadata.MD) context.Context {
 	out, _ := metadata.FromOutgoingContext(ctx)

--- a/internal/gengapic/testdata/empty_client_init.want
+++ b/internal/gengapic/testdata/empty_client_init.want
@@ -117,7 +117,7 @@ func (c *gRPCClient) Connection() *grpc.ClientConn {
 // use by Google-written clients.
 func (c *gRPCClient) setGoogleClientInfo(keyval ...string) {
 	kv := append([]string{"gl-go", versionGo()}, keyval...)
-	kv = append(kv, "gapic", versionClient, "gax", gax.Version, "grpc", grpc.Version)
+	kv = append(kv, "gapic", getVersionClient(), "gax", gax.Version, "grpc", grpc.Version)
 	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 
@@ -163,7 +163,7 @@ func NewRESTClient(ctx context.Context, opts ...option.ClientOption) (*Client, e
 // use by Google-written clients.
 func (c *restClient) setGoogleClientInfo(keyval ...string) {
 	kv := append([]string{"gl-go", versionGo()}, keyval...)
-	kv = append(kv, "gapic", versionClient, "gax", gax.Version, "rest", "UNKNOWN")
+	kv = append(kv, "gapic", getVersionClient(), "gax", gax.Version, "rest", "UNKNOWN")
 	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 

--- a/internal/gengapic/testdata/foo_client_init.want
+++ b/internal/gengapic/testdata/foo_client_init.want
@@ -148,7 +148,7 @@ func (c *fooGRPCClient) Connection() *grpc.ClientConn {
 // use by Google-written clients.
 func (c *fooGRPCClient) setGoogleClientInfo(keyval ...string) {
 	kv := append([]string{"gl-go", versionGo()}, keyval...)
-	kv = append(kv, "gapic", versionClient, "gax", gax.Version, "grpc", grpc.Version)
+	kv = append(kv, "gapic", getVersionClient(), "gax", gax.Version, "grpc", grpc.Version)
 	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 

--- a/internal/gengapic/testdata/foo_rest_client_init.want
+++ b/internal/gengapic/testdata/foo_rest_client_init.want
@@ -107,7 +107,7 @@ func NewFooRESTClient(ctx context.Context, opts ...option.ClientOption) (*FooCli
 // use by Google-written clients.
 func (c *fooRESTClient) setGoogleClientInfo(keyval ...string) {
 	kv := append([]string{"gl-go", versionGo()}, keyval...)
-	kv = append(kv, "gapic", versionClient, "gax", gax.Version, "rest", "UNKNOWN")
+	kv = append(kv, "gapic", getVersionClient(), "gax", gax.Version, "rest", "UNKNOWN")
 	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 

--- a/internal/gengapic/testdata/lro_client_init.want
+++ b/internal/gengapic/testdata/lro_client_init.want
@@ -173,7 +173,7 @@ func (c *fooGRPCClient) Connection() *grpc.ClientConn {
 // use by Google-written clients.
 func (c *fooGRPCClient) setGoogleClientInfo(keyval ...string) {
 	kv := append([]string{"gl-go", versionGo()}, keyval...)
-	kv = append(kv, "gapic", versionClient, "gax", gax.Version, "grpc", grpc.Version)
+	kv = append(kv, "gapic", getVersionClient(), "gax", gax.Version, "grpc", grpc.Version)
 	c.xGoogMetadata = metadata.Pairs("x-goog-api-client", gax.XGoogHeader(kv...))
 }
 


### PR DESCRIPTION
This will allow us to override the value after the client has been
generated in an init function. For that code please see
https://github.com/googleapis/google-cloud-go/pull/5687

Previous "UNKNOWN" version behaviour in maintained in a new
function. 