### PR TITLE
fix(bazel): add repo_mapping to all go_repository deps

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1223,4 +1223,5 @@ def go_repository(name, importpath, sum, version, build_file_proto_mode = "", bu
         version = version,
         build_file_proto_mode = build_file_proto_mode,
         build_extra_args = build_extra_args,
+        repo_mapping = {"@go_googleapis": "@com_google_googleapis"},
     )


### PR DESCRIPTION
In order to align on the `go_proto_library` targets used during generator compilation, map use of `@go_googleapis` to `@com_google_googleapis` in every `go_repository` dependency listed in `repositories.bzl`.

cc @vam-google 