### PR TITLE
fix(gengapic): regapic handle url.Parse error

### DIFF
--- a/internal/gengapic/testdata/rest_CustomOp.want
+++ b/internal/gengapic/testdata/rest_CustomOp.want
@@ -1,5 +1,8 @@
 func (c *fooRESTClient) CustomOp(ctx context.Context, req *foopb.Foo, opts ...gax.CallOption) (*Operation, error) {
-	baseUrl, _ := url.Parse(c.endpoint)
+	baseUrl, err := url.Parse(c.endpoint)
+	if err != nil {
+		return nil, err
+	}
 	baseUrl.Path += fmt.Sprintf("/v1/foo")
 
 	params := url.Values{}

--- a/internal/gengapic/testdata/rest_EmptyRPC.want
+++ b/internal/gengapic/testdata/rest_EmptyRPC.want
@@ -1,5 +1,8 @@
 func (c *fooRESTClient) EmptyRPC(ctx context.Context, req *foopb.Foo, opts ...gax.CallOption) error {
-	baseUrl, _ := url.Parse(c.endpoint)
+	baseUrl, err := url.Parse(c.endpoint)
+	if err != nil {
+		return nil, err
+	}
 	baseUrl.Path += fmt.Sprintf("/v1/foo")
 
 	params := url.Values{}

--- a/internal/gengapic/testdata/rest_PagingRPC.want
+++ b/internal/gengapic/testdata/rest_PagingRPC.want
@@ -12,7 +12,10 @@ func (c *fooRESTClient) PagingRPC(ctx context.Context, req *foopb.PagedFooReques
 		} else if pageSize != 0 {
 			req.PageSize = int32(pageSize)
 		}
-		baseUrl, _ := url.Parse(c.endpoint)
+		baseUrl, err := url.Parse(c.endpoint)
+		if err != nil {
+			return nil, err
+		}
 		baseUrl.Path += fmt.Sprintf("/v1/foo")
 
 		params := url.Values{}

--- a/internal/gengapic/testdata/rest_ServerStreamRPC.want
+++ b/internal/gengapic/testdata/rest_ServerStreamRPC.want
@@ -5,7 +5,10 @@ func (c *fooRESTClient) ServerStreamRPC(ctx context.Context, req *foopb.Foo, opt
 		return nil, err
 	}
 
-	baseUrl, _ := url.Parse(c.endpoint)
+	baseUrl, err := url.Parse(c.endpoint)
+	if err != nil {
+		return nil, err
+	}
 	baseUrl.Path += fmt.Sprintf("/v1/foo")
 
 	// Build HTTP headers from client and context metadata.

--- a/internal/gengapic/testdata/rest_UnaryRPC.want
+++ b/internal/gengapic/testdata/rest_UnaryRPC.want
@@ -5,7 +5,10 @@ func (c *fooRESTClient) UnaryRPC(ctx context.Context, req *foopb.Foo, opts ...ga
 		return nil, err
 	}
 
-	baseUrl, _ := url.Parse(c.endpoint)
+	baseUrl, err := url.Parse(c.endpoint)
+	if err != nil {
+		return nil, err
+	}
 	baseUrl.Path += fmt.Sprintf("/v1/foo")
 
 	// Build HTTP headers from client and context metadata.


### PR DESCRIPTION
Updates regapic code to handle `error` returned by `url.Parse`, and refactors the helper `generateURLString` to accept `*httpInfo` and return nothing, rather than accept a `MethodDescriptorProto` to parse `httpInfo` from and only return an error in that situation (even though every call site has already parse the httpInfo).