### PR TITLE
feat(gengapic): regapic implicit/explicit header injection

### DIFF
--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -823,11 +823,7 @@ func Test_parseImplicitRequestHeaders(t *testing.T) {
 			setHTTPOption(m.Options, tst.pattern)
 		}
 
-		got, err := parseImplicitRequestHeaders(m)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
+		got := parseImplicitRequestHeaders(m)
 
 		if diff := cmp.Diff(got, tst.want); diff != "" {
 			t.Errorf("parseImplicitRequestHeaders(%s) = got(-), want(+):\n%s", tst.name, diff)

--- a/internal/gengapic/gengrpc.go
+++ b/internal/gengapic/gengrpc.go
@@ -105,10 +105,7 @@ func (g *generator) unaryGRPCCall(servName string, m *descriptor.MethodDescripto
 
 	g.deadline(sFQN, m.GetName())
 
-	err = g.insertMetadata(m)
-	if err != nil {
-		return err
-	}
+	g.insertRequestHeaders(m, grpc)
 	g.appendCallOpts(m)
 
 	p("var resp *%s.%s", outSpec.Name, outType.GetName())
@@ -150,10 +147,7 @@ func (g *generator) emptyUnaryGRPCCall(servName string, m *descriptor.MethodDesc
 
 	g.deadline(sFQN, m.GetName())
 
-	err = g.insertMetadata(m)
-	if err != nil {
-		return err
-	}
+	g.insertRequestHeaders(m, grpc)
 	g.appendCallOpts(m)
 	p("err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")
 	p("  var err error")

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -546,7 +546,7 @@ func (g *generator) serverStreamRESTCall(servName string, s *descriptor.ServiceD
 	g.generateURLString(info, "return nil, err")
 	g.generateQueryString(m)
 	p("// Build HTTP headers from client and context metadata.")
-	p(`headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))`)
+	g.insertRequestHeaders(m, rest)
 	p("var streamClient *%s", streamClient)
 	p("e := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")
 	p(`  httpReq, err := http.NewRequest("%s", baseUrl.String(), %s)`, verb, body)
@@ -858,7 +858,7 @@ func (g *generator) emptyUnaryRESTCall(servName string, m *descriptor.MethodDesc
 	g.generateURLString(info, "return err")
 	g.generateQueryString(m)
 	p("// Build HTTP headers from client and context metadata.")
-	p(`headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))`)
+	g.insertRequestHeaders(m, rest)
 	p("return gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")
 	p(`  httpReq, err := http.NewRequest("%s", baseUrl.String(), %s)`, verb, body)
 	p("  if err != nil {")
@@ -948,7 +948,7 @@ func (g *generator) unaryRESTCall(servName string, m *descriptor.MethodDescripto
 	g.generateURLString(info, "return nil, err")
 	g.generateQueryString(m)
 	p("// Build HTTP headers from client and context metadata.")
-	p(`headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))`)
+	g.insertRequestHeaders(m, rest)
 	if !isHTTPBodyMessage {
 		p("unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}")
 	}

--- a/internal/gengapic/genrest_test.go
+++ b/internal/gengapic/genrest_test.go
@@ -493,7 +493,7 @@ func TestGenRestMethod(t *testing.T) {
 	emptyRPCOpt := &descriptor.MethodOptions{}
 	proto.SetExtension(emptyRPCOpt, annotations.E_Http, &annotations.HttpRule{
 		Pattern: &annotations.HttpRule_Delete{
-			Delete: "/v1/foo",
+			Delete: "/v1/foo/{other=*}",
 		},
 	})
 
@@ -510,6 +510,11 @@ func TestGenRestMethod(t *testing.T) {
 			Post: "/v1/foo",
 		},
 		Body: "*",
+	})
+	proto.SetExtension(unaryRPCOpt, annotations.E_Routing, &annotations.RoutingRule{
+		RoutingParameters: []*annotations.RoutingParameter{
+			{Field: "other"},
+		},
 	})
 
 	unaryRPC := &descriptor.MethodDescriptorProto{
@@ -619,7 +624,9 @@ func TestGenRestMethod(t *testing.T) {
 			method:  emptyRPC,
 			options: &options{},
 			imports: map[pbinfo.ImportSpec]bool{
+				{Path: "fmt"}: true,
 				{Path: "google.golang.org/api/googleapi"}:                        true,
+				{Path: "net/url"}:                                                true,
 				{Name: "foopb", Path: "google.golang.org/genproto/cloud/foo/v1"}: true,
 			},
 		},
@@ -629,8 +636,12 @@ func TestGenRestMethod(t *testing.T) {
 			options: &options{},
 			imports: map[pbinfo.ImportSpec]bool{
 				{Path: "bytes"}: true,
-				{Path: "google.golang.org/protobuf/encoding/protojson"}:          true,
-				{Path: "google.golang.org/api/googleapi"}:                        true,
+				{Path: "fmt"}:   true,
+				{Path: "google.golang.org/protobuf/encoding/protojson"}: true,
+				{Path: "google.golang.org/api/googleapi"}:               true,
+				{Path: "net/url"}: true,
+				{Path: "regexp"}:  true,
+				{Path: "strings"}: true,
 				{Name: "foopb", Path: "google.golang.org/genproto/cloud/foo/v1"}: true,
 			},
 		},
@@ -656,6 +667,9 @@ func TestGenRestMethod(t *testing.T) {
 				{Path: "context"}: true,
 				{Path: "fmt"}:     true,
 				{Path: "google.golang.org/api/googleapi"}:                        true,
+				{Path: "net/url"}:                                                true,
+				{Path: "regexp"}:                                                 true,
+				{Path: "strings"}:                                                true,
 				{Path: "google.golang.org/grpc/metadata"}:                        true,
 				{Path: "google.golang.org/protobuf/encoding/protojson"}:          true,
 				{Name: "foopb", Path: "google.golang.org/genproto/cloud/foo/v1"}: true,

--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -49,10 +49,7 @@ func (g *generator) lroCall(servName string, m *descriptor.MethodDescriptorProto
 
 	g.deadline(sFQN, m.GetName())
 
-	err = g.insertMetadata(m)
-	if err != nil {
-		return err
-	}
+	g.insertRequestHeaders(m, grpc)
 	g.appendCallOpts(m)
 
 	p("  var resp *%s.%s", outSpec.Name, outType.GetName())

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -290,10 +290,7 @@ func (g *generator) pagingCall(servName string, m *descriptor.MethodDescriptorPr
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) *%s {",
 		lowcaseServName, *m.Name, inSpec.Name, inType.GetName(), pt.iterTypeName)
 
-	err = g.insertMetadata(m)
-	if err != nil {
-		return err
-	}
+	g.insertRequestHeaders(m, grpc)
 	g.appendCallOpts(m)
 	pageSizeFieldName := snakeToCamel(pageSize.GetName())
 	p("it := &%s{}", pt.iterTypeName)

--- a/internal/gengapic/stream.go
+++ b/internal/gengapic/stream.go
@@ -31,7 +31,7 @@ func (g *generator) noRequestStreamCall(servName string, s *descriptor.ServiceDe
 
 	p("func (c *%s) %s(ctx context.Context, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 		lowcaseServName, m.GetName(), servSpec.Name, s.GetName(), m.GetName())
-	g.insertMetadata(nil)
+	g.insertRequestHeaders(nil, grpc)
 	p("  var resp %s.%s_%sClient", servSpec.Name, s.GetName(), m.GetName())
 
 	g.appendCallOpts(m)
@@ -71,10 +71,7 @@ func (g *generator) serverStreamCall(servName string, s *descriptor.ServiceDescr
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
 		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), servSpec.Name, s.GetName(), m.GetName())
 
-	err = g.insertMetadata(m)
-	if err != nil {
-		return err
-	}
+	g.insertRequestHeaders(m, grpc)
 
 	p("  var resp %s.%s_%sClient", servSpec.Name, s.GetName(), m.GetName())
 	p("err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")

--- a/internal/gengapic/testdata/rest_EmptyRPC.want
+++ b/internal/gengapic/testdata/rest_EmptyRPC.want
@@ -3,7 +3,7 @@ func (c *fooRESTClient) EmptyRPC(ctx context.Context, req *foopb.Foo, opts ...ga
 	if err != nil {
 		return err
 	}
-	baseUrl.Path += fmt.Sprintf("/v1/foo")
+	baseUrl.Path += fmt.Sprintf("/v1/foo/%v", req.GetOther())
 
 	params := url.Values{}
 	if req != nil && req.Other != nil {
@@ -14,7 +14,9 @@ func (c *fooRESTClient) EmptyRPC(ctx context.Context, req *foopb.Foo, opts ...ga
 	baseUrl.RawQuery = params.Encode()
 
 	// Build HTTP headers from client and context metadata.
-	headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))
+	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v", "other", url.QueryEscape(req.GetOther())))
+
+	headers := buildHeaders(ctx, c.xGoogMetadata, md, metadata.Pairs("Content-Type", "application/json"))
 	return gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		httpReq, err := http.NewRequest("DELETE", baseUrl.String(), nil)
 		if err != nil {

--- a/internal/gengapic/testdata/rest_ServerStreamRPC.want
+++ b/internal/gengapic/testdata/rest_ServerStreamRPC.want
@@ -12,7 +12,18 @@ func (c *fooRESTClient) ServerStreamRPC(ctx context.Context, req *foopb.Foo, opt
 	baseUrl.Path += fmt.Sprintf("/v1/foo")
 
 	// Build HTTP headers from client and context metadata.
-	headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))
+	routingHeaders := ""
+	routingHeadersMap := make(map[string]string)
+	if reg := regexp.MustCompile("(.*)"); reg.MatchString(req.GetOther()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])) > 0 {
+		routingHeadersMap["other"] = url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])
+	}
+	for headerName, headerValue := range routingHeadersMap {
+		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, headerName, headerValue)
+	}
+	routingHeaders = strings.TrimSuffix(routingHeaders, "&")
+	md := metadata.Pairs("x-goog-request-params", routingHeaders)
+
+	headers := buildHeaders(ctx, c.xGoogMetadata, md, metadata.Pairs("Content-Type", "application/json"))
 	var streamClient *serverStreamRPCRESTClient
 	e := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		httpReq, err := http.NewRequest("POST", baseUrl.String(), bytes.NewReader(jsonReq))

--- a/internal/gengapic/testdata/rest_UnaryRPC.want
+++ b/internal/gengapic/testdata/rest_UnaryRPC.want
@@ -12,7 +12,18 @@ func (c *fooRESTClient) UnaryRPC(ctx context.Context, req *foopb.Foo, opts ...ga
 	baseUrl.Path += fmt.Sprintf("/v1/foo")
 
 	// Build HTTP headers from client and context metadata.
-	headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))
+	routingHeaders := ""
+	routingHeadersMap := make(map[string]string)
+	if reg := regexp.MustCompile("(.*)"); reg.MatchString(req.GetOther()) && len(url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])) > 0 {
+		routingHeadersMap["other"] = url.QueryEscape(reg.FindStringSubmatch(req.GetOther())[1])
+	}
+	for headerName, headerValue := range routingHeadersMap {
+		routingHeaders = fmt.Sprintf("%s%s=%s&", routingHeaders, headerName, headerValue)
+	}
+	routingHeaders = strings.TrimSuffix(routingHeaders, "&")
+	md := metadata.Pairs("x-goog-request-params", routingHeaders)
+
+	headers := buildHeaders(ctx, c.xGoogMetadata, md, metadata.Pairs("Content-Type", "application/json"))
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &foopb.Foo{}
 	e := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/showcase/go.sum
+++ b/showcase/go.sum
@@ -126,6 +126,7 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
Support injection of either implicit (derived from `google.api.http`) or explicit headers (derived from `google.api.routing`) in REGAPICs. Fixes #844 

Minor refactoring to remove unnecessary `error` return types and reduce indentation. 