### PR TITLE
fix(gengapic): REGAPIC fix path param parsing remove duped query param

### DIFF
--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -227,7 +227,7 @@ func (g *generator) pathParams(m *descriptor.MethodDescriptorProto) map[string]*
 		// In the returned slice, the zeroth element is the full regex match,
 		// and the subsequent elements are the sub group matches.
 		// See the docs for FindStringSubmatch for further details.
-		param := p[1]
+		param := strings.Split(p[1], "=")[0]
 		field := g.lookupField(m.GetInputType(), param)
 		if field == nil {
 			continue

--- a/internal/gengapic/testdata/rest_EmptyRPC.want
+++ b/internal/gengapic/testdata/rest_EmptyRPC.want
@@ -6,9 +6,6 @@ func (c *fooRESTClient) EmptyRPC(ctx context.Context, req *foopb.Foo, opts ...ga
 	baseUrl.Path += fmt.Sprintf("/v1/foo/%v", req.GetOther())
 
 	params := url.Values{}
-	if req != nil && req.Other != nil {
-		params.Add("other", fmt.Sprintf("%v", req.GetOther()))
-	}
 	params.Add("size", fmt.Sprintf("%v", req.GetSize()))
 
 	baseUrl.RawQuery = params.Encode()


### PR DESCRIPTION
When an HTTP path param encompassed multiple segements e.g. `{name=blah/blah}`, the `=blah/blah` portion wasn't stripped when attempting to look up the field, which resulted in it being considered a query param in addition to a path param.