### PR TITLE
feat(gengapic): REGAPIC retry support

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -55,8 +55,7 @@ func (g *generator) clientOptions(serv *descriptor.ServiceDescriptorProto, servN
 			}
 			g.grpcCallOptions(serv, servName)
 		case rest:
-			// TODO(dovs)
-			continue
+			g.restCallOptions(serv, servName)
 		default:
 			return fmt.Errorf("unexpected transport variant (supported variants are %q, %q): %d",
 				v, grpc, rest)

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -68,6 +68,7 @@ func TestClientOpt(t *testing.T) {
 						BackoffMultiplier: 1.3,
 						RetryableStatusCodes: []code.Code{
 							code.Code_UNKNOWN,
+							code.Code_UNAVAILABLE,
 						},
 					},
 				},
@@ -124,7 +125,7 @@ func TestClientOpt(t *testing.T) {
 				{Name: "google.longrunning.Operations"},
 			},
 		},
-		opts:     &options{transports: []transport{grpc}},
+		opts:     &options{transports: []transport{grpc, rest}},
 		grpcConf: grpcConf,
 	}
 

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -1184,7 +1184,7 @@ func (g *generator) restCallOptions(serv *descriptor.ServiceDescriptorProto, ser
 		sFQN := g.fqn(g.descInfo.ParentElement[m])
 		mn := m.GetName()
 		p("%s: []gax.CallOption{", mn)
-		if rp, ok := c.RetryPolicy(sFQN, mn); ok && rp != nil {
+		if rp, ok := c.RetryPolicy(sFQN, mn); ok && rp != nil && len(rp.GetRetryableStatusCodes()) > 0 {
 			p("gax.WithRetry(func() gax.Retryer {")
 			p("  return gax.OnHTTPCodes(gax.Backoff{")
 			// this ignores max_attempts

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -23,12 +23,35 @@ import (
 
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-generator-go/internal/errors"
+	conf "github.com/googleapis/gapic-generator-go/internal/grpc_service_config"
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/genproto/googleapis/rpc/code"
 	"google.golang.org/protobuf/proto"
 )
 
 var httpPatternVarRegex = regexp.MustCompile(`{([a-zA-Z0-9_.]+?)(=[^{}]+)?}`)
+
+// Derived from internal source: go/http-canonical-mapping.
+var gRPCToHTTP map[code.Code]string = map[code.Code]string{
+	code.Code_OK:                  "http.StatusOK",
+	code.Code_CANCELLED:           "499", // There isn't a Go constant ClientClosedConnection
+	code.Code_UNKNOWN:             "http.StatusInternalServerError",
+	code.Code_INVALID_ARGUMENT:    "http.StatusBadRequest",
+	code.Code_DEADLINE_EXCEEDED:   "http.StatusGatewayTimeout",
+	code.Code_NOT_FOUND:           "http.StatusNotFound",
+	code.Code_ALREADY_EXISTS:      "http.StatusConflict",
+	code.Code_PERMISSION_DENIED:   "http.StatusForbidden",
+	code.Code_UNAUTHENTICATED:     "http.StatusUnauthorized",
+	code.Code_RESOURCE_EXHAUSTED:  "http.StatusTooManyRequests",
+	code.Code_FAILED_PRECONDITION: "http.StatusBadRequest",
+	code.Code_ABORTED:             "http.StatusConflict",
+	code.Code_OUT_OF_RANGE:        "http.StatusBadRequest",
+	code.Code_UNIMPLEMENTED:       "http.StatusNotImplemented",
+	code.Code_INTERNAL:            "http.StatusInternalServerError",
+	code.Code_UNAVAILABLE:         "http.StatusServiceUnavailable",
+	code.Code_DATA_LOSS:           "http.StatusInternalServerError",
+}
 
 func lowcaseRestClientName(servName string) string {
 	if servName == "" {
@@ -66,6 +89,9 @@ func (g *generator) restClientInit(serv *descriptor.ServiceDescriptorProto, serv
 	}
 	p("	 // The x-goog-* metadata to be sent with each request.")
 	p("	 xGoogMetadata metadata.MD")
+	p("")
+	p("  // Points back to the CallOptions field of the containing %sClient", servName)
+	p("  CallOptions **%sCallOptions", servName)
 	p("}")
 	p("")
 	g.restClientUtilities(serv, servName, imp, hasRPCForLRO)
@@ -136,9 +162,11 @@ func (g *generator) restClientUtilities(serv *descriptor.ServiceDescriptorProto,
 	p("        return nil, err")
 	p("    }")
 	p("")
+	p("    callOpts := default%sRESTCallOptions()", servName)
 	p("    c := &%s{", lowcaseServName)
 	p("        endpoint: endpoint,")
 	p("        httpClient: httpClient,")
+	p("        CallOptions: &callOpts,")
 	p("    }")
 	p("    c.setGoogleClientInfo()")
 	p("")
@@ -168,9 +196,9 @@ func (g *generator) restClientUtilities(serv *descriptor.ServiceDescriptorProto,
 		p("")
 		g.imports[pbinfo.ImportSpec{Path: "google.golang.org/api/option"}] = true
 	}
-	// TODO(dovs): make rest default call options
+
 	// TODO(dovs): set the LRO client
-	p("    return &%[1]sClient{internalClient: c, CallOptions: &%[1]sCallOptions{}}, nil", servName)
+	p("    return &%[1]sClient{internalClient: c, CallOptions: callOpts}, nil", servName)
 	p("}")
 	p("")
 
@@ -1065,6 +1093,7 @@ func (g *generator) unaryRESTCall(servName string, m *descriptor.MethodDescripto
 	g.generateQueryString(m)
 	p("// Build HTTP headers from client and context metadata.")
 	g.insertRequestHeaders(m, rest)
+	g.appendCallOpts(m)
 	if !isHTTPBodyMessage {
 		p("unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}")
 	}
@@ -1138,4 +1167,49 @@ func (g *generator) protoJSONMarshaler() {
 		marshalOpts = "AllowPartial: true"
 	}
 	g.pt.Printf("m := protojson.MarshalOptions{%s}", marshalOpts)
+}
+
+func (g *generator) restCallOptions(serv *descriptor.ServiceDescriptorProto, servName string) {
+	p := g.printf
+
+	// defaultCallOptions
+	c := g.grpcConf
+
+	methods := append(serv.GetMethod(), g.getMixinMethods()...)
+
+	// read retry params from gRPC ServiceConfig
+	p("func default%[1]sRESTCallOptions() *%[1]sCallOptions {", servName)
+	p("  return &%sCallOptions{", servName)
+	for _, m := range methods {
+		sFQN := g.fqn(g.descInfo.ParentElement[m])
+		mn := m.GetName()
+		p("%s: []gax.CallOption{", mn)
+		if rp, ok := c.RetryPolicy(sFQN, mn); ok && rp != nil {
+			p("gax.WithRetry(func() gax.Retryer {")
+			p("  return gax.OnHTTPCodes(gax.Backoff{")
+			// this ignores max_attempts
+			p("    Initial:    %d * time.Millisecond,", conf.ToMillis(rp.GetInitialBackoff()))
+			p("    Max:        %d * time.Millisecond,", conf.ToMillis(rp.GetMaxBackoff()))
+			p("    Multiplier: %.2f,", rp.GetBackoffMultiplier())
+			p("	 },")
+
+			rc := rp.GetRetryableStatusCodes()
+			for ndx, c := range rc {
+				s := fmt.Sprintf("%s,", gRPCToHTTP[c])
+				if ndx == len(rc)-1 {
+					s = strings.ReplaceAll(s, ",", ")")
+				}
+
+				p(s)
+			}
+			p("}),")
+
+			// include imports necessary for retry configuration
+			g.imports[pbinfo.ImportSpec{Path: "time"}] = true
+		}
+		p("},")
+	}
+	p("  }")
+	p("}")
+	p("")
 }

--- a/internal/gengapic/testdata/custom_op_init.want
+++ b/internal/gengapic/testdata/custom_op_init.want
@@ -59,6 +59,9 @@ type restClient struct {
 
 	// The x-goog-* metadata to be sent with each request.
 	xGoogMetadata metadata.MD
+
+	// Points back to the CallOptions field of the containing Client
+	CallOptions **CallOptions
 }
 
 // NewRESTClient creates a new foo rest client.
@@ -71,9 +74,11 @@ func NewRESTClient(ctx context.Context, opts ...option.ClientOption) (*Client, e
 		return nil, err
 	}
 
+	callOpts := defaultRESTCallOptions()
 	c := &restClient{
 		endpoint: endpoint,
 		httpClient: httpClient,
+		CallOptions: &callOpts,
 	}
 	c.setGoogleClientInfo()
 
@@ -87,7 +92,7 @@ func NewRESTClient(ctx context.Context, opts ...option.ClientOption) (*Client, e
 	}
 	c.operationClient = opC
 
-	return &Client{internalClient: c, CallOptions: &CallOptions{}}, nil
+	return &Client{internalClient: c, CallOptions: callOpts}, nil
 }
 
 // setGoogleClientInfo sets the name and version of the application in

--- a/internal/gengapic/testdata/deprecated_client_init.want
+++ b/internal/gengapic/testdata/deprecated_client_init.want
@@ -141,6 +141,9 @@ type restClient struct {
 
 	// The x-goog-* metadata to be sent with each request.
 	xGoogMetadata metadata.MD
+
+	// Points back to the CallOptions field of the containing Client
+	CallOptions **CallOptions
 }
 
 // NewRESTClient creates a new foo rest client.
@@ -155,13 +158,15 @@ func NewRESTClient(ctx context.Context, opts ...option.ClientOption) (*Client, e
 		return nil, err
 	}
 
+	callOpts := defaultRESTCallOptions()
 	c := &restClient{
 		endpoint: endpoint,
 		httpClient: httpClient,
+		CallOptions: &callOpts,
 	}
 	c.setGoogleClientInfo()
 
-	return &Client{internalClient: c, CallOptions: &CallOptions{}}, nil
+	return &Client{internalClient: c, CallOptions: callOpts}, nil
 }
 
 // setGoogleClientInfo sets the name and version of the application in

--- a/internal/gengapic/testdata/empty_client_init.want
+++ b/internal/gengapic/testdata/empty_client_init.want
@@ -137,6 +137,9 @@ type restClient struct {
 
 	// The x-goog-* metadata to be sent with each request.
 	xGoogMetadata metadata.MD
+
+	// Points back to the CallOptions field of the containing Client
+	CallOptions **CallOptions
 }
 
 // NewRESTClient creates a new foo rest client.
@@ -149,13 +152,15 @@ func NewRESTClient(ctx context.Context, opts ...option.ClientOption) (*Client, e
 		return nil, err
 	}
 
+	callOpts := defaultRESTCallOptions()
 	c := &restClient{
 		endpoint: endpoint,
 		httpClient: httpClient,
+		CallOptions: &callOpts,
 	}
 	c.setGoogleClientInfo()
 
-	return &Client{internalClient: c, CallOptions: &CallOptions{}}, nil
+	return &Client{internalClient: c, CallOptions: callOpts}, nil
 }
 
 // setGoogleClientInfo sets the name and version of the application in

--- a/internal/gengapic/testdata/empty_opt.want
+++ b/internal/gengapic/testdata/empty_opt.want
@@ -35,6 +35,7 @@ func defaultCallOptions() *CallOptions {
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
 					codes.Unknown,
+					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    100 * time.Millisecond,
 					Max:        60000 * time.Millisecond,
@@ -66,6 +67,62 @@ func defaultCallOptions() *CallOptions {
 					Max:        7000 * time.Millisecond,
 					Multiplier: 1.10,
 				})
+			}),
+		},
+		ListLocations: []gax.CallOption{
+		},
+		GetLocation: []gax.CallOption{
+		},
+		SetIamPolicy: []gax.CallOption{
+		},
+		GetIamPolicy: []gax.CallOption{
+		},
+		TestIamPermissions: []gax.CallOption{
+		},
+		ListOperations: []gax.CallOption{
+		},
+		GetOperation: []gax.CallOption{
+		},
+		DeleteOperation: []gax.CallOption{
+		},
+		CancelOperation: []gax.CallOption{
+		},
+		WaitOperation: []gax.CallOption{
+		},
+	}
+}
+
+func defaultRESTCallOptions() *CallOptions {
+	return &CallOptions{
+		Zip: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnHTTPCodes(gax.Backoff{
+					Initial:    100 * time.Millisecond,
+					Max:        60000 * time.Millisecond,
+					Multiplier: 1.30,
+				},
+				http.StatusInternalServerError,
+				http.StatusServiceUnavailable)
+			}),
+		},
+		Zap: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnHTTPCodes(gax.Backoff{
+					Initial:    10 * time.Millisecond,
+					Max:        7000 * time.Millisecond,
+					Multiplier: 1.10,
+				},
+				http.StatusInternalServerError)
+			}),
+		},
+		Smack: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnHTTPCodes(gax.Backoff{
+					Initial:    10 * time.Millisecond,
+					Max:        7000 * time.Millisecond,
+					Multiplier: 1.10,
+				},
+				http.StatusInternalServerError)
 			}),
 		},
 		ListLocations: []gax.CallOption{

--- a/internal/gengapic/testdata/foo_opt.want
+++ b/internal/gengapic/testdata/foo_opt.want
@@ -35,6 +35,7 @@ func defaultFooCallOptions() *FooCallOptions {
 			gax.WithRetry(func() gax.Retryer {
 				return gax.OnCodes([]codes.Code{
 					codes.Unknown,
+					codes.Unavailable,
 				}, gax.Backoff{
 					Initial:    100 * time.Millisecond,
 					Max:        60000 * time.Millisecond,
@@ -66,6 +67,62 @@ func defaultFooCallOptions() *FooCallOptions {
 					Max:        7000 * time.Millisecond,
 					Multiplier: 1.10,
 				})
+			}),
+		},
+		ListLocations: []gax.CallOption{
+		},
+		GetLocation: []gax.CallOption{
+		},
+		SetIamPolicy: []gax.CallOption{
+		},
+		GetIamPolicy: []gax.CallOption{
+		},
+		TestIamPermissions: []gax.CallOption{
+		},
+		ListOperations: []gax.CallOption{
+		},
+		GetOperation: []gax.CallOption{
+		},
+		DeleteOperation: []gax.CallOption{
+		},
+		CancelOperation: []gax.CallOption{
+		},
+		WaitOperation: []gax.CallOption{
+		},
+	}
+}
+
+func defaultFooRESTCallOptions() *FooCallOptions {
+	return &FooCallOptions{
+		Zip: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnHTTPCodes(gax.Backoff{
+					Initial:    100 * time.Millisecond,
+					Max:        60000 * time.Millisecond,
+					Multiplier: 1.30,
+				},
+				http.StatusInternalServerError,
+				http.StatusServiceUnavailable)
+			}),
+		},
+		Zap: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnHTTPCodes(gax.Backoff{
+					Initial:    10 * time.Millisecond,
+					Max:        7000 * time.Millisecond,
+					Multiplier: 1.10,
+				},
+				http.StatusInternalServerError)
+			}),
+		},
+		Smack: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnHTTPCodes(gax.Backoff{
+					Initial:    10 * time.Millisecond,
+					Max:        7000 * time.Millisecond,
+					Multiplier: 1.10,
+				},
+				http.StatusInternalServerError)
 			}),
 		},
 		ListLocations: []gax.CallOption{

--- a/internal/gengapic/testdata/foo_rest_client_init.want
+++ b/internal/gengapic/testdata/foo_rest_client_init.want
@@ -81,6 +81,9 @@ type fooRESTClient struct {
 
 	// The x-goog-* metadata to be sent with each request.
 	xGoogMetadata metadata.MD
+
+	// Points back to the CallOptions field of the containing FooClient
+	CallOptions **FooCallOptions
 }
 
 // NewFooRESTClient creates a new foo rest client.
@@ -93,13 +96,15 @@ func NewFooRESTClient(ctx context.Context, opts ...option.ClientOption) (*FooCli
 		return nil, err
 	}
 
+	callOpts := defaultFooRESTCallOptions()
 	c := &fooRESTClient{
 		endpoint: endpoint,
 		httpClient: httpClient,
+		CallOptions: &callOpts,
 	}
 	c.setGoogleClientInfo()
 
-	return &FooClient{internalClient: c, CallOptions: &FooCallOptions{}}, nil
+	return &FooClient{internalClient: c, CallOptions: callOpts}, nil
 }
 
 // setGoogleClientInfo sets the name and version of the application in

--- a/internal/gengapic/testdata/host_port_opt.want
+++ b/internal/gengapic/testdata/host_port_opt.want
@@ -63,3 +63,38 @@ func defaultBarCallOptions() *BarCallOptions {
 	}
 }
 
+func defaultBarRESTCallOptions() *BarCallOptions {
+	return &BarCallOptions{
+		Smack: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnHTTPCodes(gax.Backoff{
+					Initial:    10 * time.Millisecond,
+					Max:        7000 * time.Millisecond,
+					Multiplier: 1.10,
+				},
+				http.StatusInternalServerError)
+			}),
+		},
+		ListLocations: []gax.CallOption{
+		},
+		GetLocation: []gax.CallOption{
+		},
+		SetIamPolicy: []gax.CallOption{
+		},
+		GetIamPolicy: []gax.CallOption{
+		},
+		TestIamPermissions: []gax.CallOption{
+		},
+		ListOperations: []gax.CallOption{
+		},
+		GetOperation: []gax.CallOption{
+		},
+		DeleteOperation: []gax.CallOption{
+		},
+		CancelOperation: []gax.CallOption{
+		},
+		WaitOperation: []gax.CallOption{
+		},
+	}
+}
+

--- a/internal/gengapic/testdata/iam_override_opt.want
+++ b/internal/gengapic/testdata/iam_override_opt.want
@@ -82,3 +82,52 @@ func defaultBazCallOptions() *BazCallOptions {
 	}
 }
 
+func defaultBazRESTCallOptions() *BazCallOptions {
+	return &BazCallOptions{
+		GetIamPolicy: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnHTTPCodes(gax.Backoff{
+					Initial:    10 * time.Millisecond,
+					Max:        7000 * time.Millisecond,
+					Multiplier: 1.10,
+				},
+				http.StatusInternalServerError)
+			}),
+		},
+		SetIamPolicy: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnHTTPCodes(gax.Backoff{
+					Initial:    10 * time.Millisecond,
+					Max:        7000 * time.Millisecond,
+					Multiplier: 1.10,
+				},
+				http.StatusInternalServerError)
+			}),
+		},
+		TestIamPermissions: []gax.CallOption{
+			gax.WithRetry(func() gax.Retryer {
+				return gax.OnHTTPCodes(gax.Backoff{
+					Initial:    10 * time.Millisecond,
+					Max:        7000 * time.Millisecond,
+					Multiplier: 1.10,
+				},
+				http.StatusInternalServerError)
+			}),
+		},
+		ListLocations: []gax.CallOption{
+		},
+		GetLocation: []gax.CallOption{
+		},
+		ListOperations: []gax.CallOption{
+		},
+		GetOperation: []gax.CallOption{
+		},
+		DeleteOperation: []gax.CallOption{
+		},
+		CancelOperation: []gax.CallOption{
+		},
+		WaitOperation: []gax.CallOption{
+		},
+	}
+}
+

--- a/internal/gengapic/testdata/rest_CustomOp.want
+++ b/internal/gengapic/testdata/rest_CustomOp.want
@@ -15,6 +15,7 @@ func (c *fooRESTClient) CustomOp(ctx context.Context, req *foopb.Foo, opts ...ga
 
 	// Build HTTP headers from client and context metadata.
 	headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))
+	opts = append((*c.CallOptions).CustomOp[0:len((*c.CallOptions).CustomOp):len((*c.CallOptions).CustomOp)], opts...)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &foopb.Operation{}
 	e := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/internal/gengapic/testdata/rest_UnaryRPC.want
+++ b/internal/gengapic/testdata/rest_UnaryRPC.want
@@ -24,6 +24,7 @@ func (c *fooRESTClient) UnaryRPC(ctx context.Context, req *foopb.Foo, opts ...ga
 	md := metadata.Pairs("x-goog-request-params", routingHeaders)
 
 	headers := buildHeaders(ctx, c.xGoogMetadata, md, metadata.Pairs("Content-Type", "application/json"))
+	opts = append((*c.CallOptions).UnaryRPC[0:len((*c.CallOptions).UnaryRPC):len((*c.CallOptions).UnaryRPC)], opts...)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	resp := &foopb.Foo{}
 	e := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/showcase/main_test.go
+++ b/showcase/main_test.go
@@ -40,6 +40,11 @@ func init() {
 
 const showcaseSemver = "0.20.0"
 
+var restClientOpts = []option.ClientOption{
+	option.WithEndpoint("http://localhost:7469"),
+	option.WithoutAuthentication(),
+}
+
 func TestMain(m *testing.M) {
 	flag.Parse()
 
@@ -57,8 +62,7 @@ func TestMain(m *testing.M) {
 	}
 	defer echo.Close()
 
-	// The custom endpoint bypasses https.
-	echoREST, err = showcase.NewEchoRESTClient(ctx, option.WithEndpoint("http://localhost:7469"), option.WithoutAuthentication())
+	echoREST, err = showcase.NewEchoRESTClient(ctx, restClientOpts...)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -76,8 +80,13 @@ func TestMain(m *testing.M) {
 	}
 	defer sequenceClient.Close()
 
-	// The custom endpoint bypasses https.
-	complianceClient, err = showcase.NewComplianceRESTClient(ctx, option.WithEndpoint("http://localhost:7469"), option.WithoutAuthentication())
+	sequenceRESTClient, err = showcase.NewSequenceRESTClient(ctx, restClientOpts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer sequenceRESTClient.Close()
+
+	complianceClient, err = showcase.NewComplianceRESTClient(ctx, restClientOpts...)
 
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This adds generation for default retry config for REGAPIC clients. The status codes in the retry configuration used today for gRPC are converted into HTTP status codes according to a canonical mapping that all languages are using.

Fixes #843.