### PR TITLE
fix(gengapic): REGAPIC encode enums as numbers

### DIFF
--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -548,7 +548,7 @@ func (g *generator) serverStreamRESTCall(servName string, s *descriptor.ServiceD
 		if verb == http.MethodGet || verb == http.MethodDelete {
 			return fmt.Errorf("invalid use of body parameter for a get/delete method %q", m.GetName())
 		}
-		p("m := protojson.MarshalOptions{AllowPartial: true}")
+		p("m := protojson.MarshalOptions{AllowPartial: true, UseEnumNumbers: true}")
 		requestObject := "req"
 		if info.body != "*" {
 			requestObject = "body"
@@ -733,7 +733,7 @@ func (g *generator) pagingRESTCall(servName string, m *descriptor.MethodDescript
 
 	maybeReqBytes := "nil"
 	if info.body != "" {
-		p("m := protojson.MarshalOptions{AllowPartial: true, UseProtoNames: false}")
+		p("m := protojson.MarshalOptions{AllowPartial: true, UseEnumNumbers: true}")
 		maybeReqBytes = "bytes.NewReader(jsonReq)"
 		g.imports[pbinfo.ImportSpec{Path: "bytes"}] = true
 	}
@@ -846,7 +846,7 @@ func (g *generator) lroRESTCall(servName string, m *descriptor.MethodDescriptorP
 		if verb == http.MethodGet || verb == http.MethodDelete {
 			return fmt.Errorf("invalid use of body parameter for a get/delete method %q", m.GetName())
 		}
-		p("m := protojson.MarshalOptions{AllowPartial: true}")
+		p("m := protojson.MarshalOptions{AllowPartial: true, UseEnumNumbers: true}")
 		requestObject := "req"
 		if info.body != "*" {
 			requestObject = "body"
@@ -952,7 +952,7 @@ func (g *generator) emptyUnaryRESTCall(servName string, m *descriptor.MethodDesc
 		if verb == http.MethodGet || verb == http.MethodDelete {
 			return fmt.Errorf("invalid use of body parameter for a get/delete method %q", m.GetName())
 		}
-		p("m := protojson.MarshalOptions{AllowPartial: true, UseProtoNames: false}")
+		p("m := protojson.MarshalOptions{AllowPartial: true, UseEnumNumbers: true}")
 		requestObject := "req"
 		if info.body != "*" {
 			requestObject = "body"
@@ -1045,7 +1045,7 @@ func (g *generator) unaryRESTCall(servName string, m *descriptor.MethodDescripto
 		if verb == http.MethodGet || verb == http.MethodDelete {
 			return fmt.Errorf("invalid use of body parameter for a get/delete method %q", m.GetName())
 		}
-		p("m := protojson.MarshalOptions{AllowPartial: true}")
+		p("m := protojson.MarshalOptions{AllowPartial: true, UseEnumNumbers: true}")
 		requestObject := "req"
 		if info.body != "*" {
 			requestObject = "body"

--- a/internal/gengapic/testdata/rest_LongrunningRPC.want
+++ b/internal/gengapic/testdata/rest_LongrunningRPC.want
@@ -1,5 +1,5 @@
 func (c *fooRESTClient) LongrunningRPC(ctx context.Context, req *foopb.Foo, opts ...gax.CallOption) (*LongrunningRPCOperation, error) {
-	m := protojson.MarshalOptions{AllowPartial: true}
+	m := protojson.MarshalOptions{AllowPartial: true, UseEnumNumbers: true}
 	jsonReq, err := m.Marshal(req)
 	if err != nil {
 		return nil, err

--- a/internal/gengapic/testdata/rest_ServerStreamRPC.want
+++ b/internal/gengapic/testdata/rest_ServerStreamRPC.want
@@ -1,5 +1,5 @@
 func (c *fooRESTClient) ServerStreamRPC(ctx context.Context, req *foopb.Foo, opts ...gax.CallOption) (foopb.FooService_ServerStreamRPCClient, error) {
-	m := protojson.MarshalOptions{AllowPartial: true}
+	m := protojson.MarshalOptions{AllowPartial: true, UseEnumNumbers: true}
 	jsonReq, err := m.Marshal(req)
 	if err != nil {
 		return nil, err

--- a/internal/gengapic/testdata/rest_UnaryRPC.want
+++ b/internal/gengapic/testdata/rest_UnaryRPC.want
@@ -1,5 +1,5 @@
 func (c *fooRESTClient) UnaryRPC(ctx context.Context, req *foopb.Foo, opts ...gax.CallOption) (*foopb.Foo, error) {
-	m := protojson.MarshalOptions{AllowPartial: true}
+	m := protojson.MarshalOptions{AllowPartial: true, UseEnumNumbers: true}
 	jsonReq, err := m.Marshal(req)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Part of our REGAPIC effort to standardize JSON (de)serialization of enums as numbers to avoid the "unknown enum" error that comes with using the string identifiers instead.

Note: I've removed the use of `UseProtoNames: false` option because it is `false` by default so stating that explicitly is unnecessary and it was done inconsistently.