### PR TITLE
Update cli generator to handle LROs with empty response types.

### DIFF
--- a/internal/gencli/BUILD.bazel
+++ b/internal/gencli/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "@com_github_golang_protobuf//proto:go_default_library",
         "@com_github_jhump_protoreflect//desc",
         "@go_googleapis//google/api:annotations_go_proto",
+        "@go_googleapis//google/longrunning:longrunning_go_proto",
         "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
     ],

--- a/internal/gencli/cmd_file.go
+++ b/internal/gencli/cmd_file.go
@@ -407,7 +407,11 @@ var {{ $pollingCmdVar }} = &cobra.Command{
 		}
 		{{ end }}
 
-		fmt.Println(fmt.Sprintf("Operation %s not done", op.Name()))
+		if op.Done() {
+			fmt.Println(fmt.Sprintf("Operation %s is done", op.Name()))
+		} else {
+			fmt.Println(fmt.Sprintf("Operation %s not done", op.Name()))
+		}
 
 		return err
 	},

--- a/internal/gencli/cmd_file.go
+++ b/internal/gencli/cmd_file.go
@@ -352,7 +352,8 @@ var {{$methodCmdVar}} = &cobra.Command{
 			return err
 		}
 
-		result, err := resp.Wait(ctx)
+		{{ if .IsLRORespEmpty }}err = resp.Wait(ctx)
+		{{else}}result, err := resp.Wait(ctx)
 		if err != nil {
 			return err
 		}
@@ -360,7 +361,7 @@ var {{$methodCmdVar}} = &cobra.Command{
 		if Verbose {
 			fmt.Print("Output: ")
 		}
-		printMessage(result)
+		printMessage(result){{ end }}
 		{{ end }}
 		{{ end }}
 		return err
@@ -375,7 +376,7 @@ var {{ $pollingCmdVar }} = &cobra.Command{
 		op := {{ $serviceClient }}.{{ .Method }}Operation({{ $pollingOperationVar }})
 
 		if {{ $followVar }} {
-			resp, err := op.Wait(ctx)
+			{{ if .IsLRORespEmpty }}return op.Wait(ctx){{ else }}resp, err := op.Wait(ctx)
 			if err != nil {
 				return err
 			}
@@ -384,9 +385,15 @@ var {{ $pollingCmdVar }} = &cobra.Command{
 				fmt.Print("Output: ")
 			}
 			printMessage(resp)
-			return err
+			return err{{ end }}
 		}
 
+		{{ if .IsLRORespEmpty }}
+		err = op.Poll(ctx)
+		if err != nil {
+			return err
+		}
+		{{ else }}
 		resp, err := op.Poll(ctx)
 		if err != nil {
 			return err
@@ -398,6 +405,7 @@ var {{ $pollingCmdVar }} = &cobra.Command{
 			printMessage(resp)
 			return
 		}
+		{{ end }}
 
 		fmt.Println(fmt.Sprintf("Operation %s not done", op.Name()))
 

--- a/internal/gencli/testdata/start-todo.want
+++ b/internal/gencli/testdata/start-todo.want
@@ -132,7 +132,11 @@ var StartTodoPollCmd = &cobra.Command{
 			return
 		}
 
-		fmt.Println(fmt.Sprintf("Operation %s not done", op.Name()))
+		if op.Done() {
+			fmt.Println(fmt.Sprintf("Operation %s is done", op.Name()))
+		} else {
+			fmt.Println(fmt.Sprintf("Operation %s not done", op.Name()))
+		}
 
 		return err
 	},


### PR DESCRIPTION
I have a generated CLI for an API that just added an LRO with an empty response type:
```
  rpc DeleteInstance(DeleteInstanceRequest) returns (google.longrunning.Operation) {
    option (google.api.http) = {
      delete: "/v1/{name=projects/*/locations/*/instances/*}"
    };
    option (google.api.method_signature) = "name";
    option (google.longrunning.operation_info) = {
      response_type: "google.protobuf.Empty"
      metadata_type: "OperationMetadata"
    };
  }
```

Because the response type was empty, the generated grpc `Wait()` and `Poll()` methods returned single values (`error` only), which broke the generated CLI.

This change gets the generated CLI to compile but I have not yet verified the functionality. (I'll follow up when I do)