### PR TITLE
chore(ci): update Go to v1.18.3 in ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.16.7'
+        go-version: '1.18.3'
     - name: Check formatting
       run: gofmt -l ./ > gofmt.txt && ! [ -s gofmt.txt ]
     - name: Install golint
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.16.7'
+        go-version: '1.18.3'
     - run: go test ./...
   integration-tests:
     runs-on: ubuntu-latest
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.16.7'
+        go-version: '1.18.3'
     - name: Install protoc
       run: |
         sudo mkdir -p /usr/src/protoc/
@@ -90,7 +90,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.16.7'
+        go-version: '1.18.3'
     - name: Install protoc
       run: |
         sudo mkdir -p /usr/src/protoc/

--- a/internal/gengapic/fuzz.go
+++ b/internal/gengapic/fuzz.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build gofuzz
 // +build gofuzz
 
 package gengapic


### PR DESCRIPTION
This is necessary to use `apidiff`, the module for which specifies Go 1.18 now.