### PR TITLE
chore(showcase): lookup showcase version in go.mod

### DIFF
--- a/showcase/main_test.go
+++ b/showcase/main_test.go
@@ -38,8 +38,6 @@ func init() {
 	registerIgnoreGoroutine("google.golang.org/grpc.(*addrConn).connect")
 }
 
-const showcaseSemver = "0.20.0"
-
 var restClientOpts = []option.ClientOption{
 	option.WithEndpoint("http://localhost:7469"),
 	option.WithoutAuthentication(),


### PR DESCRIPTION
Allows us to remove the `showcaseSemver` variable and update the gapic-showcase dependency used in our integration tests via renovate.