### PR TITLE
chore(showcase): bump Wait test ttl

### DIFF
--- a/showcase/echo_test.go
+++ b/showcase/echo_test.go
@@ -296,7 +296,7 @@ func TestWait(t *testing.T) {
 	content := "hello world!"
 	req := &showcasepb.WaitRequest{
 		End: &showcasepb.WaitRequest_Ttl{
-			Ttl: &durationpb.Duration{Nanos: 100},
+			Ttl: &durationpb.Duration{Seconds: 2},
 		},
 		Response: &showcasepb.WaitRequest_Success{
 			Success: &showcasepb.WaitResponse{Content: content},


### PR DESCRIPTION
Bump the `Ttl` used in the Showcase integration test for `Wait` in order to force polling with `GetOperation`.