### PR TITLE
chore(bazel): include bazel-skylib to fix gazelle

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,21 @@ workspace(name = "com_googleapis_gapic_generator_go")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# Workaround for https://github.com/bazelbuild/bazel-gazelle/issues/1285. Ideally,
+# we can remove this if gazelle ships a fix since we didn't need it before.
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.2.1/bazel-skylib-1.2.1.tar.gz",
+    ],
+    sha256 = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
 http_archive(
     name = "com_google_protobuf",
     sha256 = "66e1156ac78290db81335c79d1fc5a54123ebb62a43eb2e5b42a44ca23087517",


### PR DESCRIPTION
Tested locally with `make update-bazel-repos`. Should unblock execution of the `deps` workflow. Workaround mentioned in  https://github.com/bazelbuild/bazel-gazelle/issues/1285.