### PR TITLE
chore(bazel): update rules_gapic to 0.14.1

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -19,7 +19,7 @@ load(
     gazelle_go_repository = "go_repository",
 )
 
-_rules_gapic_version = "0.5.4"
+_rules_gapic_version = "0.14.1"
 
 def com_googleapis_gapic_generator_go_repositories():
     go_repository(


### PR DESCRIPTION
This repo uses rules_gapic for very few things in the go_gapic_library/assembly_pkg implementations, but we should make sure it is up to date.