### PR TITLE
fix(gengapic): fix linkParser regexp to support multi-line link tags

### DIFF
--- a/internal/gengapic/markdown.go
+++ b/internal/gengapic/markdown.go
@@ -26,7 +26,7 @@ import (
 	"gitlab.com/golang-commonmark/markdown"
 )
 
-var linkParser = regexp.MustCompile(`<a href=["'](.+)["']`)
+var linkParser = regexp.MustCompile(`<a\s+href=["'](.+)["']`)
 var referenceParser = regexp.MustCompile(`\[([a-zA-Z1-9._]+)\]\[[a-zA-Z1-9._]*\]`)
 
 func mdPlain(s string) string {

--- a/internal/gengapic/markdown_test.go
+++ b/internal/gengapic/markdown_test.go
@@ -74,10 +74,19 @@ func TestMDPlain(t *testing.T) {
 			want: "html with a softbreak (at /link/to/some#thing) \n test",
 		},
 		{
+			in:   "html <a \n  href=\"/link/to/some#thing\">\n with a linebreak in tag</a> <br> test",
+			want: "html with a linebreak in tag (at /link/to/some#thing) \n test",
+		},
+		{
 			in:   "link to [a search engine](https://www.google.com) with request type [Search][foo.bar_baz.v1.Search], [biz][][buz][baz].",
 			want: "link to a search engine (at https://www.google.com) with request type Search, bizbuz.",
 		},
 	} {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("%s resulted in a panic: %v", tst.in, r)
+			}
+		}()
 		got := mdPlain(tst.in)
 		if got != tst.want {
 			t.Errorf("MDPlain(%q)=%q, want %q", tst.in, got, tst.want)

--- a/internal/gengapic/markdown_test.go
+++ b/internal/gengapic/markdown_test.go
@@ -82,11 +82,6 @@ func TestMDPlain(t *testing.T) {
 			want: "link to a search engine (at https://www.google.com) with request type Search, bizbuz.",
 		},
 	} {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Errorf("%s resulted in a panic: %v", tst.in, r)
-			}
-		}()
 		got := mdPlain(tst.in)
 		if got != tst.want {
 			t.Errorf("MDPlain(%q)=%q, want %q", tst.in, got, tst.want)


### PR DESCRIPTION
closes: #1097