### PR TITLE
fix(gengapic): fix service-specific constructor name in doc_file.go

### DIFF
--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -70,9 +70,10 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("//")
 	p("// To get started with this package, create a client.")
 	// Code block for client creation
+	servName := pbinfo.ReduceServName(serv.GetName(), g.opts.pkgName)
 	tmpClient := g.pt
 	g.pt = printer.P{}
-	g.exampleInitClient(g.opts.pkgName, pbinfo.ReduceServName(serv.GetName(), g.opts.pkgName))
+	g.exampleInitClient(g.opts.pkgName, servName)
 	snipClient := g.pt.String()
 	g.pt = tmpClient
 	g.codesnippet(snipClient)
@@ -89,7 +90,7 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 		// Code block for client using the first method of the service
 		tmpMethod := g.pt
 		g.pt = printer.P{}
-		g.exampleMethodBody(g.opts.pkgName, pbinfo.ReduceServName(serv.GetName(), g.opts.pkgName), serv.GetMethod()[0])
+		g.exampleMethodBody(g.opts.pkgName, servName, serv.GetMethod()[0])
 		snipMethod := g.pt.String()
 		g.pt = tmpMethod
 		g.codesnippet(snipMethod)
@@ -97,7 +98,7 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 
 	p("// Use of Context")
 	p("//")
-	p("// The ctx passed to NewClient is used for authentication requests and")
+	p("// The ctx passed to New%sClient is used for authentication requests and", servName)
 	p("// for creating the underlying connection, but is not used for subsequent calls.")
 	p("// Individual methods on the client use the ctx given to them.")
 	p("//")

--- a/internal/gengapic/doc_file_test.go
+++ b/internal/gengapic/doc_file_test.go
@@ -15,6 +15,7 @@
 package gengapic
 
 import (
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -143,7 +144,8 @@ func TestDocFileEmptyService(t *testing.T) {
 	} {
 		g.opts.relLvl = tst.relLvl
 		g.genDocFile(43, []string{"https://foo.bar.com/auth", "https://zip.zap.com/auth"}, serv)
-		txtdiff.Diff(t, "doc_file", g.pt.String(), tst.want)
+		name := fmt.Sprintf("doc_file: %s", tst.want)
+		txtdiff.Diff(t, name, g.pt.String(), tst.want)
 		g.reset()
 	}
 }

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -59,7 +59,7 @@
 //
 // Use of Context
 //
-// The ctx passed to NewClient is used for authentication requests and
+// The ctx passed to NewFooClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -61,7 +61,7 @@
 //
 // Use of Context
 //
-// The ctx passed to NewClient is used for authentication requests and
+// The ctx passed to NewFooClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/internal/gengapic/testdata/doc_file_alpha_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_alpha_emptyservice.want
@@ -39,7 +39,7 @@
 //
 // Use of Context
 //
-// The ctx passed to NewClient is used for authentication requests and
+// The ctx passed to NewFooClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -61,7 +61,7 @@
 //
 // Use of Context
 //
-// The ctx passed to NewClient is used for authentication requests and
+// The ctx passed to NewFooClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/internal/gengapic/testdata/doc_file_beta_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_beta_emptyservice.want
@@ -39,7 +39,7 @@
 //
 // Use of Context
 //
-// The ctx passed to NewClient is used for authentication requests and
+// The ctx passed to NewFooClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //

--- a/internal/gengapic/testdata/doc_file_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_emptyservice.want
@@ -37,7 +37,7 @@
 //
 // Use of Context
 //
-// The ctx passed to NewClient is used for authentication requests and
+// The ctx passed to NewFooClient is used for authentication requests and
 // for creating the underlying connection, but is not used for subsequent calls.
 // Individual methods on the client use the ctx given to them.
 //


### PR DESCRIPTION
closes: #1077