### PR TITLE
fix: regapic support for proto wkt in query params

### DIFF
--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -420,9 +420,8 @@ func (g *generator) generateQueryString(m *descriptor.MethodDescriptorProto) {
 		singularPrimitive := field.GetType() != fieldTypeMessage &&
 			field.GetType() != fieldTypeBytes &&
 			field.GetLabel() != fieldLabelRepeated
-		g.imports[pbinfo.ImportSpec{Path: "fmt"}] = true
-		paramAdd := fmt.Sprintf("params.Add(%q, fmt.Sprintf(%q, req%s))", lowerFirst(snakeToCamel(path)), "%v", accessor)
 
+		var paramAdd string
 		// Handle well known protobuf types with special JSON encodings.
 		if strContains(wellKnownTypes, field.GetTypeName()) {
 			b := strings.Builder{}
@@ -436,6 +435,9 @@ func (g *generator) generateQueryString(m *descriptor.MethodDescriptorProto) {
 			b.WriteString("}\n")
 			b.WriteString(fmt.Sprintf("params.Add(%q, string(%s))", lowerFirst(snakeToCamel(path)), field.GetJsonName()))
 			paramAdd = b.String()
+		} else {
+			paramAdd = fmt.Sprintf("params.Add(%q, fmt.Sprintf(%q, req%s))", lowerFirst(snakeToCamel(path)), "%v", accessor)
+			g.imports[pbinfo.ImportSpec{Path: "fmt"}] = true
 		}
 
 		// Only required, singular, primitive field types should be added regardless.

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -57,6 +57,17 @@ var wellKnownTypes = []string{
 	".google.protobuf.FieldMask",
 	".google.protobuf.Timestamp",
 	".google.protobuf.Duration",
+	".google.protobuf.DoubleValue",
+	".google.protobuf.FloatValue",
+	".google.protobuf.Int64Value",
+	".google.protobuf.UInt64Value",
+	".google.protobuf.Int32Value",
+	".google.protobuf.UInt32Value",
+	".google.protobuf.BoolValue",
+	".google.protobuf.StringValue",
+	".google.protobuf.BytesValue",
+	".google.protobuf.Value",
+	".google.protobuf.ListValue",
 }
 
 func lowcaseRestClientName(servName string) string {

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -436,15 +436,6 @@ func (g *generator) generateQueryString(m *descriptor.MethodDescriptorProto) {
 			b.WriteString("}\n")
 			b.WriteString(fmt.Sprintf("params.Add(%q, string(%s))", lowerFirst(snakeToCamel(path)), field.GetJsonName()))
 			paramAdd = b.String()
-
-			// Ignore errors here, because we should always have the protobuf well known types available to us.
-			// If something is wrong, static analysis will catch it.
-			if desc, ok := g.descInfo.Type[field.GetTypeName()]; ok {
-				imp, err := g.descInfo.ImportSpec(desc)
-				if err == nil {
-					g.imports[imp] = true
-				}
-			}
 		}
 
 		// Only required, singular, primitive field types should be added regardless.

--- a/internal/gengapic/genrest_test.go
+++ b/internal/gengapic/genrest_test.go
@@ -34,6 +34,7 @@ import (
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/runtime/protoiface"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // Note: the fields parameter contains the names of _all_ the request message's fields,
@@ -337,6 +338,18 @@ func TestLeafFields(t *testing.T) {
 		},
 	}
 
+	wellKnownMsg := &descriptor.DescriptorProto{
+		Name: proto.String("Update"),
+		Field: []*descriptor.FieldDescriptorProto{
+			{
+				Name:     proto.String("update_mask"),
+				Number:   proto.Int32(int32(0)),
+				Type:     typep(descriptor.FieldDescriptorProto_TYPE_MESSAGE),
+				TypeName: proto.String(".google.protobuf.FieldMask"),
+			},
+		},
+	}
+
 	file := &descriptor.FileDescriptorProto{
 		Package: proto.String("animalia.mollusca"),
 		Options: &descriptor.FileOptions{
@@ -349,6 +362,7 @@ func TestLeafFields(t *testing.T) {
 			complexMsg,
 			recursiveMsg,
 			overarchingMsg,
+			wellKnownMsg,
 		},
 	}
 	req := plugin.CodeGeneratorRequest{
@@ -404,6 +418,13 @@ func TestLeafFields(t *testing.T) {
 			msg:  overarchingMsg,
 			expected: map[string]*descriptor.FieldDescriptorProto{
 				"mass_kg": overarchingMsg.GetField()[1],
+			},
+		},
+		{
+			name: "well_known_message_test",
+			msg:  wellKnownMsg,
+			expected: map[string]*descriptor.FieldDescriptorProto{
+				"update_mask": wellKnownMsg.GetField()[0],
 			},
 		},
 	} {
@@ -465,6 +486,27 @@ func TestGenRestMethod(t *testing.T) {
 		Field: []*descriptor.FieldDescriptorProto{foosField, nextPageTokenField},
 	}
 	pagedFooResFQN := fmt.Sprintf(".%s.PagedFooResponse", pkg)
+
+	fooField := &descriptor.FieldDescriptorProto{
+		Name:     proto.String("foo"),
+		Type:     descriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		TypeName: proto.String(foofqn),
+	}
+
+	maskDesc := protodesc.ToDescriptorProto((&fieldmaskpb.FieldMask{}).ProtoReflect().Descriptor())
+	maskFqn := ".google.protobuf.FieldMask"
+	maskField := &descriptor.FieldDescriptorProto{
+		Name:     proto.String("update_mask"),
+		JsonName: proto.String("updateMask"),
+		Type:     descriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+		TypeName: proto.String(maskFqn),
+	}
+
+	updateReq := &descriptor.DescriptorProto{
+		Name:  proto.String("UpdateRequest"),
+		Field: []*descriptor.FieldDescriptorProto{fooField, maskField},
+	}
+	updateReqFqn := fmt.Sprintf(".%s.UpdateRequest", pkg)
 
 	nameOpts := &descriptor.FieldOptions{}
 	proto.SetExtension(nameOpts, extendedops.E_OperationField, extendedops.OperationResponseMapping_NAME)
@@ -600,6 +642,21 @@ func TestGenRestMethod(t *testing.T) {
 		Options:    httpBodyRPCOpt,
 	}
 
+	updateRPCOpt := &descriptor.MethodOptions{}
+	proto.SetExtension(updateRPCOpt, annotations.E_Http, &annotations.HttpRule{
+		Pattern: &annotations.HttpRule_Post{
+			Post: "/v1/foo",
+		},
+		Body: "foo",
+	})
+
+	updateRPC := &descriptor.MethodDescriptorProto{
+		Name:       proto.String("UpdateRPC"),
+		InputType:  proto.String(updateReqFqn),
+		OutputType: proto.String(foofqn),
+		Options:    updateRPCOpt,
+	}
+
 	s := &descriptor.ServiceDescriptorProto{
 		Name: proto.String("FooService"),
 	}
@@ -633,12 +690,15 @@ func TestGenRestMethod(t *testing.T) {
 				opS:          f,
 				opRPC:        f,
 				lroRPC:       f,
+				updateRPC:    f,
 				foo:          f,
 				s:            f,
 				pagedFooReq:  f,
 				pagedFooRes:  f,
 				lroDesc:      protodesc.ToFileDescriptorProto(longrunning.File_google_longrunning_operations_proto),
 				httpBodyDesc: protodesc.ToFileDescriptorProto(httpbody.File_google_api_httpbody_proto),
+				maskDesc:     protodesc.ToFileDescriptorProto(fieldmaskpb.File_google_protobuf_field_mask_proto),
+				updateReq:    f,
 			},
 			ParentElement: map[pbinfo.ProtoType]pbinfo.ProtoType{
 				opRPC:           s,
@@ -649,9 +709,11 @@ func TestGenRestMethod(t *testing.T) {
 				clientStreamRPC: s,
 				lroRPC:          s,
 				httpBodyRPC:     s,
+				updateRPC:       s,
 				nameField:       op,
 				sizeField:       foo,
 				otherField:      foo,
+				maskField:       updateReq,
 			},
 			Type: map[string]pbinfo.ProtoType{
 				opfqn:          op,
@@ -661,6 +723,8 @@ func TestGenRestMethod(t *testing.T) {
 				pagedFooResFQN: pagedFooRes,
 				lroType:        lroDesc,
 				httpBodyType:   httpBodyDesc,
+				updateReqFqn:   updateReq,
+				maskFqn:        maskDesc,
 			},
 		},
 	}
@@ -787,6 +851,21 @@ func TestGenRestMethod(t *testing.T) {
 				{Path: "strings"}:                         true,
 				{Name: "foopb", Path: "google.golang.org/genproto/cloud/foo/v1"}:                 true,
 				{Name: "httpbodypb", Path: "google.golang.org/genproto/googleapis/api/httpbody"}: true,
+			},
+		},
+		{
+			name:    "update_rpc",
+			method:  updateRPC,
+			options: &options{restNumericEnum: true},
+			imports: map[pbinfo.ImportSpec]bool{
+				{Path: "bytes"}: true,
+				{Path: "fmt"}:   true,
+				{Path: "google.golang.org/protobuf/encoding/protojson"}: true,
+				{Path: "io/ioutil"}:                       true,
+				{Path: "google.golang.org/api/googleapi"}: true,
+				{Path: "net/url"}:                         true,
+				{Name: "fieldmaskpb", Path: "google.golang.org/protobuf/types/known/fieldmaskpb"}: true,
+				{Name: "foopb", Path: "google.golang.org/genproto/cloud/foo/v1"}:                  true,
 			},
 		},
 	} {

--- a/internal/gengapic/genrest_test.go
+++ b/internal/gengapic/genrest_test.go
@@ -34,7 +34,6 @@ import (
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/runtime/protoiface"
 	"google.golang.org/protobuf/types/known/emptypb"
-	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 // Note: the fields parameter contains the names of _all_ the request message's fields,
@@ -493,13 +492,11 @@ func TestGenRestMethod(t *testing.T) {
 		TypeName: proto.String(foofqn),
 	}
 
-	maskDesc := protodesc.ToDescriptorProto((&fieldmaskpb.FieldMask{}).ProtoReflect().Descriptor())
-	maskFqn := ".google.protobuf.FieldMask"
 	maskField := &descriptor.FieldDescriptorProto{
 		Name:     proto.String("update_mask"),
 		JsonName: proto.String("updateMask"),
 		Type:     descriptor.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
-		TypeName: proto.String(maskFqn),
+		TypeName: proto.String(".google.protobuf.FieldMask"),
 	}
 
 	updateReq := &descriptor.DescriptorProto{
@@ -697,7 +694,6 @@ func TestGenRestMethod(t *testing.T) {
 				pagedFooRes:  f,
 				lroDesc:      protodesc.ToFileDescriptorProto(longrunning.File_google_longrunning_operations_proto),
 				httpBodyDesc: protodesc.ToFileDescriptorProto(httpbody.File_google_api_httpbody_proto),
-				maskDesc:     protodesc.ToFileDescriptorProto(fieldmaskpb.File_google_protobuf_field_mask_proto),
 				updateReq:    f,
 			},
 			ParentElement: map[pbinfo.ProtoType]pbinfo.ProtoType{
@@ -724,7 +720,6 @@ func TestGenRestMethod(t *testing.T) {
 				lroType:        lroDesc,
 				httpBodyType:   httpBodyDesc,
 				updateReqFqn:   updateReq,
-				maskFqn:        maskDesc,
 			},
 		},
 	}
@@ -864,8 +859,7 @@ func TestGenRestMethod(t *testing.T) {
 				{Path: "io/ioutil"}:                       true,
 				{Path: "google.golang.org/api/googleapi"}: true,
 				{Path: "net/url"}:                         true,
-				{Name: "fieldmaskpb", Path: "google.golang.org/protobuf/types/known/fieldmaskpb"}: true,
-				{Name: "foopb", Path: "google.golang.org/genproto/cloud/foo/v1"}:                  true,
+				{Name: "foopb", Path: "google.golang.org/genproto/cloud/foo/v1"}: true,
 			},
 		},
 	} {

--- a/internal/gengapic/testdata/rest_UpdateRPC.want
+++ b/internal/gengapic/testdata/rest_UpdateRPC.want
@@ -1,0 +1,68 @@
+func (c *fooRESTClient) UpdateRPC(ctx context.Context, req *foopb.UpdateRequest, opts ...gax.CallOption) (*foopb.Foo, error) {
+	m := protojson.MarshalOptions{AllowPartial: true, UseEnumNumbers: true}
+	body := req.GetFoo()
+	jsonReq, err := m.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	baseUrl, err := url.Parse(c.endpoint)
+	if err != nil {
+		return nil, err
+	}
+	baseUrl.Path += fmt.Sprintf("/v1/foo")
+
+	params := url.Values{}
+	params.Add("$alt", "json;enum-encoding=int")
+	if req.GetUpdateMask() != nil {
+		updateMask, err := protojson.Marshal(req.GetUpdateMask())
+		if err != nil {
+		  return nil, err
+		}
+		params.Add("updateMask", string(updateMask))
+	}
+
+	baseUrl.RawQuery = params.Encode()
+
+	// Build HTTP headers from client and context metadata.
+	headers := buildHeaders(ctx, c.xGoogMetadata, metadata.Pairs("Content-Type", "application/json"))
+	opts = append((*c.CallOptions).UpdateRPC[0:len((*c.CallOptions).UpdateRPC):len((*c.CallOptions).UpdateRPC)], opts...)
+	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
+	resp := &foopb.Foo{}
+	e := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+		if settings.Path != "" {
+			baseUrl.Path = settings.Path
+		}
+		httpReq, err := http.NewRequest("POST", baseUrl.String(), bytes.NewReader(jsonReq))
+		if err != nil {
+			return err
+		}
+		httpReq = httpReq.WithContext(ctx)
+		httpReq.Header = headers
+
+		httpRsp, err := c.httpClient.Do(httpReq)
+		if err != nil{
+			return err
+		}
+		defer httpRsp.Body.Close()
+
+		if err = googleapi.CheckResponse(httpRsp); err != nil {
+			return err
+		}
+
+		buf, err := ioutil.ReadAll(httpRsp.Body)
+		if err != nil {
+			return err
+		}
+
+		if err := unm.Unmarshal(buf, resp); err != nil {
+			return maybeUnknownEnum(err)
+		}
+
+		return nil
+	}, opts...)
+	if e != nil {
+		return nil, e
+	}
+	return resp, nil
+}

--- a/showcase/compliance_test.go
+++ b/showcase/compliance_test.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// Client is initialized in main_test.go.
 var complianceClient *showcase.ComplianceClient
 
 // method is the function type that implements any of the Compliance.RepeatData* RPCs, which all have the same signature.

--- a/showcase/echo_test.go
+++ b/showcase/echo_test.go
@@ -44,8 +44,11 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-var echo *showcase.EchoClient
-var echoREST *showcase.EchoClient
+// Clients are initialized in main_test.go.
+var (
+	echo     *showcase.EchoClient
+	echoREST *showcase.EchoClient
+)
 
 func TestEcho(t *testing.T) {
 	defer check(t)

--- a/showcase/go.mod
+++ b/showcase/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	cloud.google.com/go v0.104.0
 	github.com/google/go-cmp v0.5.8
-	github.com/googleapis/gapic-showcase v0.24.0
+	github.com/googleapis/gapic-showcase v0.25.0
 	github.com/googleapis/gax-go/v2 v2.5.1
 	google.golang.org/api v0.94.0
 	google.golang.org/genproto v0.0.0-20220829175752-36a9c930ecbf

--- a/showcase/go.sum
+++ b/showcase/go.sum
@@ -729,11 +729,8 @@ google.golang.org/api v0.80.0/go.mod h1:xY3nI94gbvBrE0J6NHXhxOmW97HG7Khjkku6AFB3
 google.golang.org/api v0.81.0/go.mod h1:FA6Mb/bZxj706H2j+j2d6mHEEaHBmbbWnkfvmorOCko=
 google.golang.org/api v0.84.0/go.mod h1:NTsGnUFJMYROtiquksZHBWtHfeMC7iYthki7Eq3pa8o=
 google.golang.org/api v0.85.0/go.mod h1:AqZf8Ep9uZ2pyTvgL+x0D3Zt0eoT9b5E8fmzfu6FO2g=
-google.golang.org/api v0.86.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
-google.golang.org/api v0.89.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
 google.golang.org/api v0.90.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
 google.golang.org/api v0.93.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
-google.golang.org/api v0.94.0 h1:KtKM9ru3nzQioV1HLlUf1cR7vMYJIpgls5VhAYQXIwA=
 google.golang.org/api v0.94.0/go.mod h1:eADj+UBuxkh5zlrSntJghuNeg8HwQ1w5lTKkuqaETEI=
 google.golang.org/api v0.95.0 h1:d1c24AAS01DYqXreBeuVV7ewY/U8Mnhh47pwtsgVtYg=
 google.golang.org/api v0.95.0/go.mod h1:eADj+UBuxkh5zlrSntJghuNeg8HwQ1w5lTKkuqaETEI=

--- a/showcase/go.sum
+++ b/showcase/go.sum
@@ -31,7 +31,6 @@ cloud.google.com/go v0.99.0/go.mod h1:w0Xx2nLzqWJPuozYQX+hFfCSI8WioryfRDzkoI/Y2Z
 cloud.google.com/go v0.100.2/go.mod h1:4Xra9TjzAeYHrl5+oeLlzbM2k3mjVhZh4UqTZ//w99A=
 cloud.google.com/go v0.102.0/go.mod h1:oWcCzKlqJ5zgHQt9YsaeTY9KzIvjyy0ArmiBUgpQ+nc=
 cloud.google.com/go v0.102.1/go.mod h1:XZ77E9qnTEnrgEOvr4xzfdX5TRo7fB4T2F4O6+34hIU=
-cloud.google.com/go v0.103.0/go.mod h1:vwLx1nqLrzLX/fpwSMOXmFIqBOyHsvHbnAdbGSJ+mKk=
 cloud.google.com/go v0.104.0 h1:gSmWO7DY1vOm0MVU6DNXM11BWHHsTUmsC5cv1fuW5X8=
 cloud.google.com/go v0.104.0/go.mod h1:OO6xxXdJyvuJPcEPBLN9BJPD+jep5G1+2U5B5gkRYtA=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
@@ -214,8 +213,6 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/googleapis/enterprise-certificate-proxy v0.0.0-20220520183353-fd19c99a87aa/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/enterprise-certificate-proxy v0.1.0 h1:zO8WHNx/MYiAKJ3d5spxZXZE6KHmIQGQcAzwUzV7qQw=
 github.com/googleapis/enterprise-certificate-proxy v0.1.0/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
-github.com/googleapis/gapic-showcase v0.24.0 h1:YDNng6apgYYbw5AKTUdBLQ8pk5QjNAdHRSvd5sdRZSs=
-github.com/googleapis/gapic-showcase v0.24.0/go.mod h1:pBv821ueIBdk6qC9nrBZePZYBG9VdutF2omq3dlp5mU=
 github.com/googleapis/gapic-showcase v0.25.0 h1:Ui32sbsvvmvpQok07xMwrAI0yDBlruLwcJ10Mn9CyNs=
 github.com/googleapis/gapic-showcase v0.25.0/go.mod h1:lkwLil+VrQ5vrOL8+rexI+VZSG2QmzS3W2jaygrGu58=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -514,7 +511,6 @@ golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a/go.mod h1:DAh4E804XQdzx2j
 golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5/go.mod h1:DAh4E804XQdzx2j+YRIaUnCqCV2RuMz24cGBJ5QYIrc=
 golang.org/x/oauth2 v0.0.0-20220608161450-d0670ef3b1eb/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
 golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2/go.mod h1:jaDAt6Dkxork7LmZnYtzbRWj0W47D86a3TGe0YHBvmE=
-golang.org/x/oauth2 v0.0.0-20220722155238-128564f6959c/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094 h1:2o1E+E8TpNLklK9nHiPiK1uzIYrIHt+cQx3ynCwq9V8=
 golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094/go.mod h1:h4gKUeWbJ4rQPri7E0u6Gs4e9Ri2zaLxzw5DI5XGrYg=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -530,7 +526,6 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -734,8 +729,6 @@ google.golang.org/api v0.80.0/go.mod h1:xY3nI94gbvBrE0J6NHXhxOmW97HG7Khjkku6AFB3
 google.golang.org/api v0.81.0/go.mod h1:FA6Mb/bZxj706H2j+j2d6mHEEaHBmbbWnkfvmorOCko=
 google.golang.org/api v0.84.0/go.mod h1:NTsGnUFJMYROtiquksZHBWtHfeMC7iYthki7Eq3pa8o=
 google.golang.org/api v0.85.0/go.mod h1:AqZf8Ep9uZ2pyTvgL+x0D3Zt0eoT9b5E8fmzfu6FO2g=
-google.golang.org/api v0.86.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
-google.golang.org/api v0.89.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
 google.golang.org/api v0.90.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
 google.golang.org/api v0.93.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
 google.golang.org/api v0.94.0 h1:KtKM9ru3nzQioV1HLlUf1cR7vMYJIpgls5VhAYQXIwA=
@@ -834,12 +827,11 @@ google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljW
 google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220624142145-8cd45d7dbd1f/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
-google.golang.org/genproto v0.0.0-20220628213854-d9e0b6570c03/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220722212130-b98a9ff5e252/go.mod h1:GkXuJDJ6aQ7lnJcRF+SJVgFdQhypqgl3LB1C9vabdRE=
-google.golang.org/genproto v0.0.0-20220725144611-272f38e5d71b/go.mod h1:iHe1svFLAZg9VWz891+QbRMwUv9O/1Ww+/mngYeThbc=
 google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
-google.golang.org/genproto v0.0.0-20220829175752-36a9c930ecbf h1:Q5xNKbTSFwkuaaGaR7CMcXEM5sy19KYdUU8iF8/iRC0=
 google.golang.org/genproto v0.0.0-20220829175752-36a9c930ecbf/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
+google.golang.org/genproto v0.0.0-20220902135211-223410557253 h1:vXJMM8Shg7TGaYxZsQ++A/FOSlbDmDtWhS/o+3w/hj4=
+google.golang.org/genproto v0.0.0-20220902135211-223410557253/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=

--- a/showcase/go.sum
+++ b/showcase/go.sum
@@ -216,6 +216,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.1.0 h1:zO8WHNx/MYiAKJ3d5sp
 github.com/googleapis/enterprise-certificate-proxy v0.1.0/go.mod h1:17drOmN3MwGY7t0e+Ei9b45FFGA3fBs3x36SsCg1hq8=
 github.com/googleapis/gapic-showcase v0.24.0 h1:YDNng6apgYYbw5AKTUdBLQ8pk5QjNAdHRSvd5sdRZSs=
 github.com/googleapis/gapic-showcase v0.24.0/go.mod h1:pBv821ueIBdk6qC9nrBZePZYBG9VdutF2omq3dlp5mU=
+github.com/googleapis/gapic-showcase v0.25.0 h1:Ui32sbsvvmvpQok07xMwrAI0yDBlruLwcJ10Mn9CyNs=
+github.com/googleapis/gapic-showcase v0.25.0/go.mod h1:lkwLil+VrQ5vrOL8+rexI+VZSG2QmzS3W2jaygrGu58=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
@@ -529,6 +531,7 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220819030929-7fc1605a5dde/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -733,6 +736,8 @@ google.golang.org/api v0.84.0/go.mod h1:NTsGnUFJMYROtiquksZHBWtHfeMC7iYthki7Eq3p
 google.golang.org/api v0.85.0/go.mod h1:AqZf8Ep9uZ2pyTvgL+x0D3Zt0eoT9b5E8fmzfu6FO2g=
 google.golang.org/api v0.86.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
 google.golang.org/api v0.89.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
+google.golang.org/api v0.90.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
+google.golang.org/api v0.93.0/go.mod h1:+Sem1dnrKlrXMR/X0bPnMWyluQe4RsNoYfmNLhOIkzw=
 google.golang.org/api v0.94.0 h1:KtKM9ru3nzQioV1HLlUf1cR7vMYJIpgls5VhAYQXIwA=
 google.golang.org/api v0.94.0/go.mod h1:eADj+UBuxkh5zlrSntJghuNeg8HwQ1w5lTKkuqaETEI=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
@@ -830,7 +835,9 @@ google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljW
 google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220624142145-8cd45d7dbd1f/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220628213854-d9e0b6570c03/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
+google.golang.org/genproto v0.0.0-20220722212130-b98a9ff5e252/go.mod h1:GkXuJDJ6aQ7lnJcRF+SJVgFdQhypqgl3LB1C9vabdRE=
 google.golang.org/genproto v0.0.0-20220725144611-272f38e5d71b/go.mod h1:iHe1svFLAZg9VWz891+QbRMwUv9O/1Ww+/mngYeThbc=
+google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
 google.golang.org/genproto v0.0.0-20220829175752-36a9c930ecbf h1:Q5xNKbTSFwkuaaGaR7CMcXEM5sy19KYdUU8iF8/iRC0=
 google.golang.org/genproto v0.0.0-20220829175752-36a9c930ecbf/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/showcase/identity_test.go
+++ b/showcase/identity_test.go
@@ -26,8 +26,11 @@ import (
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
-var identity *showcase.IdentityClient
-var identityREST *showcase.IdentityClient
+// Clients are initialized in main_test.go.
+var (
+	identity     *showcase.IdentityClient
+	identityREST *showcase.IdentityClient
+)
 
 func TestUserCRUD(t *testing.T) {
 	defer check(t)

--- a/showcase/identity_test.go
+++ b/showcase/identity_test.go
@@ -23,134 +23,139 @@ import (
 	showcasepb "github.com/googleapis/gapic-showcase/server/genproto"
 	"google.golang.org/api/iterator"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 )
 
 var identity *showcase.IdentityClient
+var identityREST *showcase.IdentityClient
 
 func TestUserCRUD(t *testing.T) {
 	defer check(t)
 	ctx := context.Background()
 
-	create := &showcasepb.CreateUserRequest{
-		User: &showcasepb.User{
-			DisplayName: "Jane Doe",
-			Email:       "janedoe@example.com",
-			Nickname:    proto.String("Doe"),
-			HeightFeet:  proto.Float64(6.2),
-		},
-	}
+	for _, client := range map[string]*showcase.IdentityClient{"grpc": identity, "rest": identityREST} {
+		create := &showcasepb.CreateUserRequest{
+			User: &showcasepb.User{
+				DisplayName: "Jane Doe",
+				Email:       "janedoe@example.com",
+				Nickname:    proto.String("Doe"),
+				HeightFeet:  proto.Float64(6.2),
+			},
+		}
 
-	usr, err := identity.CreateUser(ctx, create)
-	if err != nil {
-		t.Fatal(err)
-	}
+		usr, err := client.CreateUser(ctx, create)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	want := create.GetUser()
-	if usr.GetName() == "" {
-		t.Errorf("CreateUser().Name was unexpectedly empty")
-	}
-	if usr.GetDisplayName() != want.GetDisplayName() {
-		t.Errorf("CreateUser().DisplayName = %q, want = %q", usr.GetDisplayName(), want.GetDisplayName())
-	}
-	if usr.GetEmail() != want.GetEmail() {
-		t.Errorf("CreateUser().Email = %q, want = %q", usr.GetEmail(), want.GetEmail())
-	}
-	if usr.GetCreateTime() == nil {
-		t.Errorf("CreateUser().CreateTime was unexpectedly empty")
-	}
-	if usr.GetUpdateTime() == nil {
-		t.Errorf("CreateUser().UpdateTime was unexpectedly empty")
-	}
-	if usr.GetNickname() != want.GetNickname() {
-		t.Errorf("CreateUser().Nickname = %q, want = %q", usr.GetNickname(), want.GetNickname())
-	}
-	if usr.GetHeightFeet() != want.GetHeightFeet() {
-		t.Errorf("CreateUser().HeightFeet = %f, want = %f", usr.GetHeightFeet(), want.GetHeightFeet())
-	}
-	if usr.Age != nil {
-		t.Errorf("CreateUser().Age was unexpectedly set to: %d", usr.GetAge())
-	}
-	if usr.EnableNotifications != nil {
-		t.Errorf("CreateUser().EnableNotifications was unexpectedly set to: %v", usr.GetEnableNotifications())
-	}
+		want := create.GetUser()
+		if usr.GetName() == "" {
+			t.Errorf("CreateUser().Name was unexpectedly empty")
+		}
+		if usr.GetDisplayName() != want.GetDisplayName() {
+			t.Errorf("CreateUser().DisplayName = %q, want = %q", usr.GetDisplayName(), want.GetDisplayName())
+		}
+		if usr.GetEmail() != want.GetEmail() {
+			t.Errorf("CreateUser().Email = %q, want = %q", usr.GetEmail(), want.GetEmail())
+		}
+		if usr.GetCreateTime() == nil {
+			t.Errorf("CreateUser().CreateTime was unexpectedly empty")
+		}
+		if usr.GetUpdateTime() == nil {
+			t.Errorf("CreateUser().UpdateTime was unexpectedly empty")
+		}
+		if usr.GetNickname() != want.GetNickname() {
+			t.Errorf("CreateUser().Nickname = %q, want = %q", usr.GetNickname(), want.GetNickname())
+		}
+		if usr.GetHeightFeet() != want.GetHeightFeet() {
+			t.Errorf("CreateUser().HeightFeet = %f, want = %f", usr.GetHeightFeet(), want.GetHeightFeet())
+		}
+		if usr.Age != nil {
+			t.Errorf("CreateUser().Age was unexpectedly set to: %d", usr.GetAge())
+		}
+		if usr.EnableNotifications != nil {
+			t.Errorf("CreateUser().EnableNotifications was unexpectedly set to: %v", usr.GetEnableNotifications())
+		}
 
-	list := &showcasepb.ListUsersRequest{
-		PageSize: 5,
-	}
+		list := &showcasepb.ListUsersRequest{
+			PageSize: 5,
+		}
 
-	iter := identity.ListUsers(context.Background(), list)
+		iter := client.ListUsers(context.Background(), list)
 
-	if max := iter.PageInfo().MaxSize; max != int(list.PageSize) {
-		t.Errorf("PageInfo().MaxSize = %d, want %d", max, list.PageSize)
-	}
+		if max := iter.PageInfo().MaxSize; max != int(list.PageSize) {
+			t.Errorf("PageInfo().MaxSize = %d, want %d", max, list.PageSize)
+		}
 
-	listed, err := iter.Next()
-	if err != nil {
-		t.Fatal(err)
-	}
+		listed, err := iter.Next()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if diff := cmp.Diff(listed, usr, cmp.Comparer(proto.Equal)); diff != "" {
-		t.Errorf("ListUsers() got=-, want=+:%s", diff)
-	}
+		if diff := cmp.Diff(listed, usr, cmp.Comparer(proto.Equal)); diff != "" {
+			t.Errorf("ListUsers() got=-, want=+:%s", diff)
+		}
 
-	get := &showcasepb.GetUserRequest{
-		Name: usr.GetName(),
-	}
+		get := &showcasepb.GetUserRequest{
+			Name: usr.GetName(),
+		}
 
-	got, err := identity.GetUser(ctx, get)
-	if err != nil {
-		t.Fatal(err)
-	}
+		got, err := client.GetUser(ctx, get)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if diff := cmp.Diff(got, usr, cmp.Comparer(proto.Equal)); diff != "" {
-		t.Errorf("GetUser() got=-, want=+:%s", diff)
-	}
+		if diff := cmp.Diff(got, usr, cmp.Comparer(proto.Equal)); diff != "" {
+			t.Errorf("GetUser() got=-, want=+:%s", diff)
+		}
 
-	update := &showcasepb.UpdateUserRequest{
-		User: &showcasepb.User{
-			Name:                got.GetName(),
-			DisplayName:         got.GetDisplayName(),
-			Email:               "janedoe@jane.com",
-			HeightFeet:          proto.Float64(6.0),
-			EnableNotifications: proto.Bool(true),
-		},
-	}
+		update := &showcasepb.UpdateUserRequest{
+			User: &showcasepb.User{
+				Name:                got.GetName(),
+				DisplayName:         got.GetDisplayName(),
+				Email:               "janedoe@jane.com",
+				HeightFeet:          proto.Float64(6.0),
+				EnableNotifications: proto.Bool(true),
+			},
+			UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"email", "height_feet", "enable_notifications"}},
+		}
 
-	updated, err := identity.UpdateUser(ctx, update)
-	if err != nil {
-		t.Fatal(err)
-	}
+		updated, err := client.UpdateUser(ctx, update)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if diff := cmp.Diff(updated, usr, cmp.Comparer(proto.Equal)); diff == "" {
-		t.Errorf("UpdateUser() users were the same, update failed")
-	}
-	if updated.GetEmail() == usr.GetEmail() {
-		t.Errorf("UpdateUser().Email was not updated as expected")
-	}
-	if updated.GetNickname() != usr.GetNickname() {
-		t.Errorf("UpdateUser().Nickname = %q, want = %q", updated.GetNickname(), usr.GetNickname())
-	}
-	if updated.GetHeightFeet() == usr.GetHeightFeet() {
-		t.Errorf("UpdateUser().HeightFeet was not updated as expected")
-	}
-	if updated.EnableNotifications == nil || !updated.GetEnableNotifications() {
-		t.Errorf("UpdateUser().EnableNotifications was not updated as expected")
-	}
-	if updated.Age != nil {
-		t.Errorf("UpdateUser().Age was unexpectedly updated")
-	}
+		if diff := cmp.Diff(updated, usr, cmp.Comparer(proto.Equal)); diff == "" {
+			t.Errorf("UpdateUser() users were the same, update failed")
+		}
+		if updated.GetEmail() == usr.GetEmail() {
+			t.Errorf("UpdateUser().Email was not updated as expected")
+		}
+		if updated.GetNickname() != usr.GetNickname() {
+			t.Errorf("UpdateUser().Nickname = %q, want = %q", updated.GetNickname(), usr.GetNickname())
+		}
+		if updated.GetHeightFeet() == usr.GetHeightFeet() {
+			t.Errorf("UpdateUser().HeightFeet was not updated as expected")
+		}
+		if updated.EnableNotifications == nil || !updated.GetEnableNotifications() {
+			t.Errorf("UpdateUser().EnableNotifications was not updated as expected")
+		}
+		if updated.Age != nil {
+			t.Errorf("UpdateUser().Age was unexpectedly updated")
+		}
 
-	err = identity.DeleteUser(ctx, &showcasepb.DeleteUserRequest{
-		Name: usr.GetName(),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
+		err = client.DeleteUser(ctx, &showcasepb.DeleteUserRequest{
+			Name: usr.GetName(),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	iter = identity.ListUsers(ctx, &showcasepb.ListUsersRequest{})
+		iter = client.ListUsers(ctx, &showcasepb.ListUsersRequest{})
 
-	_, err = iter.Next()
-	if err != iterator.Done {
-		t.Errorf("ListUsers() = %q, want %q", err, iterator.Done)
+		_, err = iter.Next()
+		if err != iterator.Done {
+			t.Errorf("ListUsers() = %q, want %q", err, iterator.Done)
+		}
 	}
 }

--- a/showcase/main_test.go
+++ b/showcase/main_test.go
@@ -72,6 +72,12 @@ func TestMain(m *testing.M) {
 	}
 	defer identity.Close()
 
+	identityREST, err = showcase.NewIdentityRESTClient(ctx, restClientOpts...)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer identityREST.Close()
+
 	sequenceClient, err = showcase.NewSequenceClient(ctx, opt)
 	if err != nil {
 		log.Fatal(err)

--- a/showcase/sequence_test.go
+++ b/showcase/sequence_test.go
@@ -28,8 +28,11 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-var sequenceClient *showcase.SequenceClient
-var sequenceRESTClient *showcase.SequenceClient
+// Clients are initialized in main_test.go.
+var (
+	sequenceClient     *showcase.SequenceClient
+	sequenceRESTClient *showcase.SequenceClient
+)
 
 func Test_Sequence_Empty(t *testing.T) {
 	defer check(t)


### PR DESCRIPTION
Properly handle protobuf well known message types that have special JSON mappings e.g. `google.protobuf.FieldMask` when they appear as query parameters.

The list of well known types is defined here: https://developers.google.com/protocol-buffers/docs/proto3#json

Update gapic-showcase to v0.25.0 that exercises this code, and update the Identity service tests to run against REST as well, to exercise the FieldMask encoding.