### PR TITLE
fix(gengapic): separate repeated prim qp values

### DIFF
--- a/internal/gengapic/genrest_test.go
+++ b/internal/gengapic/genrest_test.go
@@ -499,9 +499,16 @@ func TestGenRestMethod(t *testing.T) {
 		TypeName: proto.String(".google.protobuf.FieldMask"),
 	}
 
+	repeatedPrimField := &descriptor.FieldDescriptorProto{
+		Name:     proto.String("primitives"),
+		Type:     descriptor.FieldDescriptorProto_TYPE_STRING.Enum().Enum(),
+		TypeName: proto.String(foofqn),
+		Label:    descriptor.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+	}
+
 	updateReq := &descriptor.DescriptorProto{
 		Name:  proto.String("UpdateRequest"),
-		Field: []*descriptor.FieldDescriptorProto{fooField, maskField},
+		Field: []*descriptor.FieldDescriptorProto{fooField, maskField, repeatedPrimField},
 	}
 	updateReqFqn := fmt.Sprintf(".%s.UpdateRequest", pkg)
 

--- a/internal/gengapic/testdata/rest_UpdateRPC.want
+++ b/internal/gengapic/testdata/rest_UpdateRPC.want
@@ -14,6 +14,11 @@ func (c *fooRESTClient) UpdateRPC(ctx context.Context, req *foopb.UpdateRequest,
 
 	params := url.Values{}
 	params.Add("$alt", "json;enum-encoding=int")
+	if items := req.GetPrimitives(); len(items) > 0 {
+		for _, item := range items {
+		  params.Add("primitives", fmt.Sprintf("%v", item))
+		}
+	}
 	if req.GetUpdateMask() != nil {
 		updateMask, err := protojson.Marshal(req.GetUpdateMask())
 		if err != nil {


### PR DESCRIPTION
For REGAPIC query params, repeated non-message fields should be included in the query params as multiple, individual key-value pairs using the same field name as the key and each item in the slice as a singular value.

Fixes #1160 