### PR TITLE
fix(gengapic): document client/bidi streaming unsupported in REST

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -479,6 +479,9 @@ func (g *generator) methodDoc(m *descriptor.MethodDescriptorProto) {
 		return
 	}
 
+	if containsTransport(g.opts.transports, rest) && m.GetClientStreaming() {
+		com = fmt.Sprintf("%s\n\nThis method is not supported for the REST transport.", com)
+	}
 	// If the method is marked as deprecated and there is no comment, then add default deprecation comment.
 	// If the method has a comment but it does not include a deprecation notice, then append a default deprecation notice.
 	// If the method includes a deprecation notice at the beginning of the comment, prepend a comment stating the method is deprecated and use the included deprecation notice.


### PR DESCRIPTION
Generate interface-level, method documentation for Client and Bi-Di streaming methods when `rest` transport is selected that indicates that the method is unsupported for the REST transport. This should help reduce confusion when the method returns an error saying the same thing.

Note: `m.GetClientStreaming()` covers both streaming types in scope becaus Bi-Di stream is just `ClientStreaming: true` && `ServerStreaming: true`.