### PR TITLE
chore(ci): tidy compute job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,6 +125,7 @@ jobs:
       run: |
         export CLOUD_GO=$(pwd)
         cd internal/gapicgen
+        go mod tidy
         go run cloud.google.com/go/internal/gapicgen/cmd/genbot \
           -local \
           -regen-only \
@@ -132,7 +133,7 @@ jobs:
           -gapic=cloud.google.com/go/compute/apiv1 \
           -gocloud-dir=$CLOUD_GO \
           -googleapis-dir=$GOOGLEAPIS
-        cd $CLOUD_GO/compute && go get -u ./apiv1
+        cd $CLOUD_GO/compute && go get -u ./apiv1 && go mod tidy
     - name: Compare regenerated code to baseline
       if: "!contains(github.event.pull_request.labels.*.name, 'breaking change allowed')"
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,7 +90,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18.3'
+        go-version: '1.19'
     - name: Install protoc
       run: |
         sudo mkdir -p /usr/src/protoc/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,7 +125,6 @@ jobs:
       run: |
         export CLOUD_GO=$(pwd)
         cd internal/gapicgen
-        go mod tidy
         go run cloud.google.com/go/internal/gapicgen/cmd/genbot \
           -local \
           -regen-only \
@@ -133,7 +132,7 @@ jobs:
           -gapic=cloud.google.com/go/compute/apiv1 \
           -gocloud-dir=$CLOUD_GO \
           -googleapis-dir=$GOOGLEAPIS
-        cd $CLOUD_GO/compute && go get -u ./apiv1 && go mod tidy
+        cd $CLOUD_GO/compute && go get -u ./apiv1
     - name: Compare regenerated code to baseline
       if: "!contains(github.event.pull_request.labels.*.name, 'breaking change allowed')"
       run: |


### PR DESCRIPTION
Raises Go runtime version of the `compute-regen` job in order to align with `google-cloud-go` where it tries to run sanity checks. Also runs `go mod tidy` before other `go` tool commands.