### PR TITLE
fix(gengapic): only gen REST client for RESTable services

### DIFF
--- a/internal/gengapic/helpers.go
+++ b/internal/gengapic/helpers.go
@@ -122,6 +122,19 @@ func hasMethod(service *descriptor.ServiceDescriptorProto, method string) bool {
 	return false
 }
 
+// hasRESTMethod reports if there is at least one RPC on the Service that
+// has a gRPC-HTTP transcoding, or REST, annotation on it.
+func hasRESTMethod(service *descriptor.ServiceDescriptorProto) bool {
+	for _, m := range service.GetMethod() {
+		eHTTP := proto.GetExtension(m.GetOptions(), annotations.E_Http)
+		if h := eHTTP.(*annotations.HttpRule); h.GetPattern() != nil {
+			return true
+		}
+	}
+
+	return false
+}
+
 // getMethod returns the MethodDescriptorProto for the given service RPC and simple method name.
 func getMethod(service *descriptor.ServiceDescriptorProto, method string) *descriptor.MethodDescriptorProto {
 	for _, m := range service.GetMethod() {

--- a/internal/gengapic/helpers_test.go
+++ b/internal/gengapic/helpers_test.go
@@ -272,3 +272,26 @@ func TestGetHeaderName(t *testing.T) {
 		}
 	}
 }
+
+func TestHasRESTMethod(t *testing.T) {
+	for _, tst := range []struct {
+		name string
+		want bool
+	}{
+		{"has_rest_method", true},
+		{"does_not_have_rest_method", false},
+	} {
+		opts := &descriptor.MethodOptions{}
+		if tst.want {
+			proto.SetExtension(opts, annotations.E_Http, &annotations.HttpRule{Pattern: &annotations.HttpRule_Get{Get: "/foo"}})
+		}
+		s := &descriptor.ServiceDescriptorProto{
+			Method: []*descriptor.MethodDescriptorProto{
+				{Options: opts},
+			},
+		}
+		if got := hasRESTMethod(s); got != tst.want {
+			t.Fatalf("%s: expected %v, got %v", tst.name, tst.want, got)
+		}
+	}
+}

--- a/test.sh
+++ b/test.sh
@@ -51,6 +51,9 @@ generate --go_gapic_opt 'go-gapic-package=cloud.google.com/go/storage/internal/a
 echo "Generating Cloud Retail v2"
 generate --go_gapic_opt 'go-gapic-package=cloud.google.com/go/retail/apiv2;retail,transport=rest' $GOOGLEAPIS/google/cloud/retail/v2/*.proto
 
+echo "Generating Apigee Connect v1 - Dual Transport, partial REGAPIC"
+generate --go_gapic_opt 'go-gapic-package=cloud.google.com/go/apigeeconnect/apiv1;apigeeconnect,transport=grpc+rest' $GOOGLEAPIS/google/cloud/apigeeconnect/v1/*.proto
+
 echo "Generation complete"
 
 echo "Running gofmt to check for syntax errors"


### PR DESCRIPTION
This is a fix, and introduces the possibility of a breaking change, in generation of clients when `rest` is a selected transport. If a proto service being generated doesn't have any RPCs with `google.api.http` annotations i.e. they are not "REST-able", then a REST client is not generated for the proto service.

I've added a sanity check but based on where the code is placed it is really hard to test without setting up the entire generator in code. I have tested this in local generation and with the known example added to `test.sh`.