### PR TITLE
fix(bazel): downgrade lro dep to pre-alias

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -965,8 +965,6 @@ def com_googleapis_gapic_generator_go_repositories():
     )
     go_repository(
         name = "com_google_cloud_go",
-        # This is part of a fix for https://github.com/googleapis/gapic-generator-go/issues/387.
-        build_extra_args = ["-exclude=longrunning/autogen/info.go"],
         importpath = "cloud.google.com/go",
         sum = "h1:AWaMWuZb2oFeiV91OfNHZbmwUhMVuXEaLPm9sqDAOl8=",
         version = "v0.106.0",
@@ -1361,8 +1359,10 @@ def com_googleapis_gapic_generator_go_repositories():
     go_repository(
         name = "com_google_cloud_go_longrunning",
         importpath = "cloud.google.com/go/longrunning",
-        sum = "h1:NjljC+FYPV3uh5/OwWT6pVU+doBqMg2x/rZlE+CamDs=",
-        version = "v0.3.0",
+        # This must remain at this version until the googleapis bazel workspace
+        # is updated to handle the new pb directories.
+        sum = "h1:y50CXG4j0+qvEukslYFBCrzaXX0qpFbBzc3PchSu/LE=",
+        version = "v0.1.1",
     )
     go_repository(
         name = "com_google_cloud_go_managedidentities",


### PR DESCRIPTION
In more recent versions of the new longrunning submodule, the interface parameter/return types changed to the aliased versions. This is fine, except that in the googleapis Bazel workspace, this causes some problems when trying to depend on the yet-to-be migrated longrunning_go_gapic target. So for now, we downgrade the dependency to when it still depended on genproto, until we migrate our googleapis bazel workspace to consume the subdirectory of proto stubs instead of genproto.