### PR TITLE
fix(gengapic): inject gRPC server stream call opts

### DIFF
--- a/internal/gengapic/stream.go
+++ b/internal/gengapic/stream.go
@@ -72,6 +72,7 @@ func (g *generator) serverStreamCall(servName string, s *descriptor.ServiceDescr
 		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), servSpec.Name, s.GetName(), m.GetName())
 
 	g.insertRequestHeaders(m, grpc)
+	g.appendCallOpts(m)
 
 	p("  var resp %s.%s_%sClient", servSpec.Name, s.GetName(), m.GetName())
 	p("err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")

--- a/internal/gengapic/testdata/method_ServerThings.want
+++ b/internal/gengapic/testdata/method_ServerThings.want
@@ -2,6 +2,7 @@ func (c *fooGRPCClient) ServerThings(ctx context.Context, req *mypackagepb.Input
 	md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v&%s=%v&%s=%v&%s=%v&%s=%v", "field_name.nested", url.QueryEscape(req.GetFieldName().GetNested()), "other", url.QueryEscape(req.GetOther()), "another", url.QueryEscape(req.GetAnother()), "biz", url.QueryEscape(fmt.Sprintf("%g", req.GetBiz())), "top_level_enum", mypackagepb.TopLevelEnum_name[int32(req.GetTopLevelEnum())], "nested_enum", mypackagepb.InputType_NestedEnum_name[int32(req.GetNestedEnum())]))
 
 	ctx = insertMetadata(ctx, c.xGoogMetadata, md)
+	opts = append((*c.CallOptions).ServerThings[0:len((*c.CallOptions).ServerThings):len((*c.CallOptions).ServerThings)], opts...)
 	var resp mypackagepb.Foo_ServerThingsClient
 	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
 		var err error


### PR DESCRIPTION
Inject default call options for server-stream, gRPC calls. This includes default retry options that will work when trying to establish a new stream.

It looks like, unfortunately, this was errantly removed in #577 and it snuck through review.

Addresses the generator issue mentioned in https://github.com/googleapis/google-cloud-go/issues/5906.