### PR TITLE
chore(ci): use go verison in go.mod

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -20,10 +20,10 @@ jobs:
           - os: windows
             arch: amd64
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.17.13'
-      - uses: actions/checkout@v3
+          go-version-file: 'go.mod'
       # The generator does not use these,  but we need them to build the
       # binaries.
       #

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -128,7 +128,6 @@ jobs:
       run: |
         export CLOUD_GO=$(pwd)
         cd internal/gapicgen
-        go mod tidy
         go run cloud.google.com/go/internal/gapicgen/cmd/genbot \
           -local \
           -regen-only \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18.3'
+        go-version-file: 'go.mod'
     - name: Check formatting
       run: gofmt -l ./ > gofmt.txt && ! [ -s gofmt.txt ]
     - name: Install golint
@@ -44,7 +44,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18.3'
+        go-version-file: 'go.mod'
     - run: go test ./...
   integration-tests:
     runs-on: ubuntu-latest
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18.3'
+        go-version-file: 'go.mod'
     - name: Install protoc
       run: |
         sudo mkdir -p /usr/src/protoc/
@@ -90,7 +90,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19'
+        go-version-file: 'go.mod'
     - name: Install protoc
       run: |
         sudo mkdir -p /usr/src/protoc/
@@ -116,6 +116,9 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: googleapis/google-cloud-go
+    - uses: actions/setup-go@v3
+      with:
+        go-version-file: 'compute/go.mod'
     - name: Create Go package API baseline
       if: "!contains(github.event.pull_request.labels.*.name, 'breaking change allowed')"
       run: |

--- a/internal/grpc_service_config/config_test.go
+++ b/internal/grpc_service_config/config_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//	https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/showcase/main_test.go
+++ b/showcase/main_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//	https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
Modifies our CI use of the `setup-go` Action to pull the Go version from our `go.mod` file(s).

Removes unnecessary `go mod tidy` step in `compute-regen`.

Fixes some extraneous whitespace that `gofmt` complained about.