### PR TITLE
chore(ci): use bazel 6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,7 @@ jobs:
   bazel-build:
     runs-on: ubuntu-latest
     env:
-      USE_BAZEL_VERSION: 5.0.0
+      USE_BAZEL_VERSION: 6.0.0
     container: gcr.io/gapic-images/googleapis:latest
     # Dockerfile for this image: https://github.com/googleapis/googleapis-discovery/blob/master/Dockerfile
     steps:

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -15,7 +15,7 @@ jobs:
       changed: ${{ steps.update.outputs.changed }}
     runs-on: ubuntu-latest
     env:
-      USE_BAZEL_VERSION: 5.0.0
+      USE_BAZEL_VERSION: 6.0.0
     container: gcr.io/gapic-images/googleapis:latest
     # Dockerfile for this image: https://github.com/googleapis/googleapis-discovery/blob/master/Dockerfile
     steps:


### PR DESCRIPTION
We recently updated the target bazel version in googleapis to 6.0.0, so let's do the same here.