### PR TITLE
fix: omit-snippets for bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ following attributes:
     * Default is `False`.
     * Only effective when `rest` is included as a `transport` to be generated.
 
-  * `omit_snippets`: if `True`, code snippets will be generated to the `internal/generated/snippets` path. The default is `false`.
+  * `omit_snippets`: if `True`, code snippets will be generated to the `internal/generated/snippets` path. The default is `True`.
 
 Docker Wrapper
 --------------

--- a/rules_go_gapic/go_gapic.bzl
+++ b/rules_go_gapic/go_gapic.bzl
@@ -94,7 +94,7 @@ def go_gapic_library(
   transport = "grpc",
   diregapic = False,
   rest_numeric_enums = False,
-  omit_snippets = False,
+  omit_snippets = True,
   **kwargs):
 
   file_args = {}


### PR DESCRIPTION
Temporarily omit snippets during bazel-based generation.