### PR TITLE
fix: restore omit-snippets for bazel

### DIFF
--- a/internal/gengapic/snippets.go
+++ b/internal/gengapic/snippets.go
@@ -95,7 +95,7 @@ func (g *generator) genAndCommitSnippets(s *descriptor.ServiceDescriptorProto) e
 		// Get the original proto service for the method (different from `s` only for mixins).
 		methodServ := (g.descInfo.ParentElement[m]).(*descriptor.ServiceDescriptorProto)
 		lineCount := g.commit(filepath.Join(g.opts.outDir, "internal",
-			"snippets", clientName, m.GetName(), "main.go.txt"), "main")
+			"snippets", clientName, m.GetName(), "main.go"), "main")
 		g.snippetMetadata.AddMethod(s.GetName(), m.GetName(), f.GetPackage(), methodServ.GetName(), lineCount-1)
 	}
 	return nil

--- a/internal/gengapic/snippets.go
+++ b/internal/gengapic/snippets.go
@@ -95,7 +95,7 @@ func (g *generator) genAndCommitSnippets(s *descriptor.ServiceDescriptorProto) e
 		// Get the original proto service for the method (different from `s` only for mixins).
 		methodServ := (g.descInfo.ParentElement[m]).(*descriptor.ServiceDescriptorProto)
 		lineCount := g.commit(filepath.Join(g.opts.outDir, "internal",
-			"snippets", clientName, m.GetName(), "main.go"), "main")
+			"snippets", clientName, m.GetName(), "main.go.txt"), "main")
 		g.snippetMetadata.AddMethod(s.GetName(), m.GetName(), f.GetPackage(), methodServ.GetName(), lineCount-1)
 	}
 	return nil

--- a/rules_go_gapic/go_gapic.bzl
+++ b/rules_go_gapic/go_gapic.bzl
@@ -36,8 +36,8 @@ def _go_gapic_postprocessed_srcjar_impl(ctx):
     cd {output_dir_path}
     zip -q -r {output_dir_name}-test.srcjar . -i ./*_test.go
     find . -name "*_test.go" -delete
-    zip -q -r {output_dir_name}-snippets.srcjar . -i ./*main.go.txt ./*snippet_metadata.*.json
-    find . -name "*main.go.txt" -delete
+    zip -q -r {output_dir_name}-snippets.srcjar . -i ./*main.go ./*snippet_metadata.*.json
+    find . -name "*main.go" -delete
     find . -name "*snippet_metadata.*.json" -delete
     zip -q -r {output_dir_name}.srcjar . -i ./*.go
     find . -name "*.go" -delete


### PR DESCRIPTION
* Rename snippet files to `*.go.txt` to avoid bazel compilation.
* Package snippets in `*_go_gapic_srcjar-snippets.srcjar` in `go_gapic.bzl`.