### PR TITLE
docs: add link to error handling docs in root mod

### DIFF
--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -101,6 +101,12 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 		g.codesnippet(snipMethod)
 	}
 
+	p("// Inspecting errors")
+	p("//")
+	p("// To see examples of how to inspect errors returned by this package please reference")
+	p("// [Inspecting errors](https://pkg.go.dev/cloud.google.com/go#hdr-Inspecting_errors).")
+	p("//")
+
 	p("// Use of Context")
 	p("//")
 	p("// The ctx passed to New%sClient is used for authentication requests and", servName)

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -72,6 +72,11 @@
 //  // TODO: Use resp.
 //  _ = resp
 //
+// Inspecting errors
+//
+// To see examples of how to inspect errors returned by this package please reference
+// [Inspecting errors](https://pkg.go.dev/cloud.google.com/go#hdr-Inspecting_errors).
+//
 // Use of Context
 //
 // The ctx passed to NewFooClient is used for authentication requests and

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -74,6 +74,11 @@
 //  // TODO: Use resp.
 //  _ = resp
 //
+// Inspecting errors
+//
+// To see examples of how to inspect errors returned by this package please reference
+// [Inspecting errors](https://pkg.go.dev/cloud.google.com/go#hdr-Inspecting_errors).
+//
 // Use of Context
 //
 // The ctx passed to NewFooClient is used for authentication requests and

--- a/internal/gengapic/testdata/doc_file_alpha_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_alpha_emptyservice.want
@@ -47,6 +47,11 @@
 // The methods of Client are safe for concurrent use by multiple goroutines.
 // The returned client must be Closed when it is done being used.
 //
+// Inspecting errors
+//
+// To see examples of how to inspect errors returned by this package please reference
+// [Inspecting errors](https://pkg.go.dev/cloud.google.com/go#hdr-Inspecting_errors).
+//
 // Use of Context
 //
 // The ctx passed to NewFooClient is used for authentication requests and

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -74,6 +74,11 @@
 //  // TODO: Use resp.
 //  _ = resp
 //
+// Inspecting errors
+//
+// To see examples of how to inspect errors returned by this package please reference
+// [Inspecting errors](https://pkg.go.dev/cloud.google.com/go#hdr-Inspecting_errors).
+//
 // Use of Context
 //
 // The ctx passed to NewFooClient is used for authentication requests and

--- a/internal/gengapic/testdata/doc_file_beta_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_beta_emptyservice.want
@@ -47,6 +47,11 @@
 // The methods of Client are safe for concurrent use by multiple goroutines.
 // The returned client must be Closed when it is done being used.
 //
+// Inspecting errors
+//
+// To see examples of how to inspect errors returned by this package please reference
+// [Inspecting errors](https://pkg.go.dev/cloud.google.com/go#hdr-Inspecting_errors).
+//
 // Use of Context
 //
 // The ctx passed to NewFooClient is used for authentication requests and

--- a/internal/gengapic/testdata/doc_file_emptyservice.want
+++ b/internal/gengapic/testdata/doc_file_emptyservice.want
@@ -45,6 +45,11 @@
 // The methods of Client are safe for concurrent use by multiple goroutines.
 // The returned client must be Closed when it is done being used.
 //
+// Inspecting errors
+//
+// To see examples of how to inspect errors returned by this package please reference
+// [Inspecting errors](https://pkg.go.dev/cloud.google.com/go#hdr-Inspecting_errors).
+//
 // Use of Context
 //
 // The ctx passed to NewFooClient is used for authentication requests and


### PR DESCRIPTION
Fixes: https://github.com/googleapis/gax-go/issues/228