### PR TITLE
chore: make renovate config closer to other packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "extends": [
     "config:base",
     ":disableDependencyDashboard",
-    ":semanticCommitTypeAll(chore)"
+    ":semanticCommitTypeAll(chore)",
+    "schedule:weekly"
   ],
   "golang": {
     "ignoreDeps": [
@@ -10,16 +11,7 @@
     ],
     "postUpdateOptions": ["gomodTidy"]
   },
-  "reviewers": [
-    "noahdietz"
-  ],
   "rebaseWhen": "behind-base-branch",
   "labels": ["automerge"],
-  "packageRules": [
-    {
-      "packageNames": ["google.golang.org/genproto"],
-      "schedule": "after 12pm on monday"
-    }
-  ],
-  "timezone": "America/Los_Angeles"
+  "groupName": "deps"
 }


### PR DESCRIPTION
- don't assign reviewer, leave it to CO
- extend the base weekly strat
- group deps bumps together.

Let's try bundling dep updagrades so a single pr can do it all for this repo. It may be we want to explicitly package some seperatly, if so we can carve those out in a future pr.