### PR TITLE
fix(gengapic): remove unknown enum error helper

### DIFF
--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -120,7 +120,6 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	p("import (")
 	p("%s%q", "\t", "context")
 	if hasREST {
-		p("%s%q", "\t", "fmt")
 		p("%s%q", "\t", "net/http")
 	}
 	p("%s%q", "\t", "runtime")
@@ -212,17 +211,6 @@ func (g *generator) genDocFile(year int, scopes []string, serv *descriptor.Servi
 	}
 
 	if hasREST {
-		// UnknownEnum error check helper.
-		p("// maybeUnknownEnum wraps the given proto-JSON parsing error if it is the result")
-		p("// of receiving an unknown enum value.")
-		p("func maybeUnknownEnum(err error) error {")
-		p(`  if strings.Contains(err.Error(), "invalid value for enum type") {`)
-		p(`    err = fmt.Errorf("received an unknown enum value; a later version of the library may support it: %%w", err)`)
-		p("  }")
-		p("  return err")
-		p("}")
-		p("")
-
 		// buildHeaders from context and other metadata helper.
 		p("// buildHeaders extracts metadata from the outgoing context, joins it with any other")
 		p("// given metadata, and converts them into a http.Header. ")

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -848,7 +848,7 @@ func (g *generator) pagingRESTCall(servName string, m *descriptor.MethodDescript
 	p("    }")
 	p("")
 	p("    if err := unm.Unmarshal(buf, resp); err != nil {")
-	p("      return maybeUnknownEnum(err)")
+	p("      return err")
 	p("    }")
 	p("")
 	p("    return nil")
@@ -970,7 +970,7 @@ func (g *generator) lroRESTCall(servName string, m *descriptor.MethodDescriptorP
 	p("  }")
 	p("")
 	p("  if err := unm.Unmarshal(buf, resp); err != nil {")
-	p("    return maybeUnknownEnum(err)")
+	p("    return err")
 	p("  }")
 	p("")
 	p("  return nil")
@@ -1184,7 +1184,7 @@ func (g *generator) unaryRESTCall(servName string, m *descriptor.MethodDescripto
 		p("}")
 	} else {
 		p("if err := unm.Unmarshal(buf, resp); err != nil {")
-		p("  return maybeUnknownEnum(err)")
+		p("  return err")
 		p("}")
 	}
 

--- a/internal/gengapic/testdata/doc_file.want
+++ b/internal/gengapic/testdata/doc_file.want
@@ -88,7 +88,6 @@ package awesome // import "path/to/awesome"
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"runtime"
 	"strings"
@@ -166,15 +165,6 @@ func versionGo() string {
 		return s
 	}
 	return "UNKNOWN"
-}
-
-// maybeUnknownEnum wraps the given proto-JSON parsing error if it is the result
-// of receiving an unknown enum value.
-func maybeUnknownEnum(err error) error {
-	if strings.Contains(err.Error(), "invalid value for enum type") {
-		err = fmt.Errorf("received an unknown enum value; a later version of the library may support it: %w", err)
-	}
-	return err
 }
 
 // buildHeaders extracts metadata from the outgoing context, joins it with any other

--- a/internal/gengapic/testdata/doc_file_alpha.want
+++ b/internal/gengapic/testdata/doc_file_alpha.want
@@ -90,7 +90,6 @@ package awesome // import "path/to/awesome"
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"runtime"
 	"strings"
@@ -168,15 +167,6 @@ func versionGo() string {
 		return s
 	}
 	return "UNKNOWN"
-}
-
-// maybeUnknownEnum wraps the given proto-JSON parsing error if it is the result
-// of receiving an unknown enum value.
-func maybeUnknownEnum(err error) error {
-	if strings.Contains(err.Error(), "invalid value for enum type") {
-		err = fmt.Errorf("received an unknown enum value; a later version of the library may support it: %w", err)
-	}
-	return err
 }
 
 // buildHeaders extracts metadata from the outgoing context, joins it with any other

--- a/internal/gengapic/testdata/doc_file_beta.want
+++ b/internal/gengapic/testdata/doc_file_beta.want
@@ -90,7 +90,6 @@ package awesome // import "path/to/awesome"
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"runtime"
 	"strings"
@@ -168,15 +167,6 @@ func versionGo() string {
 		return s
 	}
 	return "UNKNOWN"
-}
-
-// maybeUnknownEnum wraps the given proto-JSON parsing error if it is the result
-// of receiving an unknown enum value.
-func maybeUnknownEnum(err error) error {
-	if strings.Contains(err.Error(), "invalid value for enum type") {
-		err = fmt.Errorf("received an unknown enum value; a later version of the library may support it: %w", err)
-	}
-	return err
 }
 
 // buildHeaders extracts metadata from the outgoing context, joins it with any other

--- a/internal/gengapic/testdata/rest_CustomOp.want
+++ b/internal/gengapic/testdata/rest_CustomOp.want
@@ -45,7 +45,7 @@ func (c *fooRESTClient) CustomOp(ctx context.Context, req *foopb.Foo, opts ...ga
 		}
 
 		if err := unm.Unmarshal(buf, resp); err != nil {
-			return maybeUnknownEnum(err)
+			return err
 		}
 
 		return nil

--- a/internal/gengapic/testdata/rest_LongrunningRPC.want
+++ b/internal/gengapic/testdata/rest_LongrunningRPC.want
@@ -42,7 +42,7 @@ func (c *fooRESTClient) LongrunningRPC(ctx context.Context, req *foopb.Foo, opts
 		}
 
 		if err := unm.Unmarshal(buf, resp); err != nil {
-			return maybeUnknownEnum(err)
+			return err
 		}
 
 		return nil

--- a/internal/gengapic/testdata/rest_PagingRPC.want
+++ b/internal/gengapic/testdata/rest_PagingRPC.want
@@ -56,7 +56,7 @@ func (c *fooRESTClient) PagingRPC(ctx context.Context, req *foopb.PagedFooReques
 			}
 
 			if err := unm.Unmarshal(buf, resp); err != nil {
-				return maybeUnknownEnum(err)
+				return err
 			}
 
 			return nil

--- a/internal/gengapic/testdata/rest_UnaryRPC.want
+++ b/internal/gengapic/testdata/rest_UnaryRPC.want
@@ -59,7 +59,7 @@ func (c *fooRESTClient) UnaryRPC(ctx context.Context, req *foopb.Foo, opts ...ga
 		}
 
 		if err := unm.Unmarshal(buf, resp); err != nil {
-			return maybeUnknownEnum(err)
+			return err
 		}
 
 		return nil

--- a/internal/gengapic/testdata/rest_UpdateRPC.want
+++ b/internal/gengapic/testdata/rest_UpdateRPC.want
@@ -61,7 +61,7 @@ func (c *fooRESTClient) UpdateRPC(ctx context.Context, req *foopb.UpdateRequest,
 		}
 
 		if err := unm.Unmarshal(buf, resp); err != nil {
-			return maybeUnknownEnum(err)
+			return err
 		}
 
 		return nil


### PR DESCRIPTION
Most if not all REGAPIC clients use numeric enum value serialization now, all new APIs will, and we haven't had an unknown enum value issue reported to date. It is likely safe to remove the error parsing at this point. 

Fixes #1302