### PR TITLE
fix(gengapic): remove quotes from query params for well known types

### DIFF
--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -419,7 +419,11 @@ func (g *generator) generateQueryString(m *descriptor.MethodDescriptorProto) {
 				b.WriteString("  return nil, err\n")
 			}
 			b.WriteString("}\n")
-			b.WriteString(fmt.Sprintf("params.Add(%q, string(%s))", key, field.GetJsonName()))
+			// Convert to string and remove surrounding quotes
+			b.WriteString(fmt.Sprintf("%sString := string(%s)\n", field.GetJsonName(), field.GetJsonName()))
+			b.WriteString(fmt.Sprintf("%sString = %sString[1:len(%sString)-1]\n", field.GetJsonName(), field.GetJsonName(), field.GetJsonName()))
+			// Add field to query parameters
+			b.WriteString(fmt.Sprintf("params.Add(%q, %sString)", key, field.GetJsonName()))
 			paramAdd = b.String()
 		} else {
 			paramAdd = fmt.Sprintf("params.Add(%q, fmt.Sprintf(%q, req%s))", key, "%v", accessor)

--- a/internal/gengapic/testdata/rest_UpdateRPC.want
+++ b/internal/gengapic/testdata/rest_UpdateRPC.want
@@ -24,7 +24,9 @@ func (c *fooRESTClient) UpdateRPC(ctx context.Context, req *foopb.UpdateRequest,
 		if err != nil {
 		  return nil, err
 		}
-		params.Add("updateMask", string(updateMask))
+		updateMaskString := string(updateMask)
+		updateMaskString = updateMaskString[1:len(updateMaskString)-1]
+		params.Add("updateMask", updateMaskString)
 	}
 
 	baseUrl.RawQuery = params.Encode()


### PR DESCRIPTION
Update rest calls have quotes around the updateMask query parameter that causes validation issues on the server side. 
Ex:
`updateMask=%22spec.ingressPolicies%2Cspec.egressPolicies%2Ctitle%2CuseExplicitDryRunSpec%22`