### PR TITLE
chore(internal/gencli): replace strings.Title with golang.org/x/text/cases

### DIFF
--- a/internal/gencli/flag.go
+++ b/internal/gencli/flag.go
@@ -23,6 +23,8 @@ import (
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"github.com/jhump/protoreflect/desc"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 // Flag is used to represent fields as flags
@@ -58,7 +60,8 @@ func (f *Flag) GenFlag() string {
 	if f.IsEnum() {
 		tStr = "string"
 	}
-	fType := strings.Title(tStr)
+	caser := cases.Title(language.English)
+	fType := caser.String(tStr)
 
 	if f.Repeated {
 		if f.Type == descriptor.FieldDescriptorProto_TYPE_MESSAGE {

--- a/internal/gencli/util.go
+++ b/internal/gencli/util.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"github.com/jhump/protoreflect/desc"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 const (
@@ -73,7 +75,8 @@ func putImport(imports map[string]*pbinfo.ImportSpec, pkg *pbinfo.ImportSpec) {
 func title(name string) string {
 	split := strings.Split(name, "_")
 	for i, s := range split {
-		split[i] = strings.Title(s)
+		caser := cases.Title(language.English)
+		split[i] = caser.String(s)
 	}
 
 	return strings.Join(split, "")
@@ -82,7 +85,8 @@ func title(name string) string {
 // does not remove underscores
 func dotToCamel(name string) (s string) {
 	for _, tkn := range strings.Split(name, ".") {
-		s += strings.Title(tkn)
+		caser := cases.Title(language.English)
+		s += caser.String(tkn)
 	}
 
 	return


### PR DESCRIPTION
Fix staticcheck error: SA1019

strings.Title has been deprecated since Go 1.18.

The rule Title uses for word boundaries does not handle Unicode punctuation properly.

Use golang.org/x/text/cases instead.