### PR TITLE
chore(internal/gengapic): use raw string with regexp.MustCompile

### DIFF
--- a/internal/gengapic/helpers.go
+++ b/internal/gengapic/helpers.go
@@ -228,7 +228,7 @@ func convertPathTemplateToRegex(pattern string) string {
 
 // This intakes a path template and returns the name of the header to be returned.
 func getHeaderName(pattern string) string {
-	curlyBraceRegex := regexp.MustCompile("\\{([^}]+)\\}")
+	curlyBraceRegex := regexp.MustCompile(`{([^}]+)\}`)
 	// Path template should only contain one name (e.g. at most one `=`) or
 	// a collectionId, and should be contained within curly braces.
 	if strings.Count(pattern, "=") > 1 || !curlyBraceRegex.MatchString(pattern) {


### PR DESCRIPTION
Fix staticcheck error:

internal/gengapic/helpers.go:231:21: should use raw string (`...`) with regexp.MustCompile to avoid having to escape twice (S1007)