### PR TITLE
chore(internal): run tests in parallel

### DIFF
--- a/internal/gencli/cmd_file_test.go
+++ b/internal/gencli/cmd_file_test.go
@@ -205,17 +205,19 @@ func TestCommandFile(t *testing.T) {
 			goldenPath: filepath.Join("testdata", "manage-todos.want"),
 		},
 	} {
-		tst.g.genCommandFile(tst.cmd)
-		if tst.g.response.GetError() != "" {
-			t.Errorf("Error generating the command file %s: %s", tst.name, tst.g.response.GetError())
-			return
-		}
+		t.Run(tst.name, func(t *testing.T) {
+			tst.g.genCommandFile(tst.cmd)
+			if tst.g.response.GetError() != "" {
+				t.Errorf("Error generating the command file %s: %s", tst.name, tst.g.response.GetError())
+				return
+			}
 
-		file := tst.g.response.File[0]
+			file := tst.g.response.File[0]
 
-		if file.GetName() != tst.name+".go" {
-			t.Errorf("(%+v).genCommands() = %s, want %s", tst.g, file.GetName(), tst.name+".go")
-		}
-		txtdiff.Diff(t, tst.name, file.GetContent(), tst.goldenPath)
+			if file.GetName() != tst.name+".go" {
+				t.Errorf("(%+v).genCommands() = %s, want %s", tst.g, file.GetName(), tst.name+".go")
+			}
+			txtdiff.Diff(t, file.GetContent(), tst.goldenPath)
+		})
 	}
 }

--- a/internal/gencli/completion_file_test.go
+++ b/internal/gencli/completion_file_test.go
@@ -44,5 +44,5 @@ func TestCompletionFile(t *testing.T) {
 	if file.GetName() != "completion.go" {
 		t.Errorf("(%s).genCompletionCmdFile() = %s, want %s", g.root, file.GetName(), "completion.go")
 	}
-	txtdiff.Diff(t, "completion_file", file.GetContent(), filepath.Join("testdata", "completion_file.want"))
+	txtdiff.Diff(t, file.GetContent(), filepath.Join("testdata", "completion_file.want"))
 }

--- a/internal/gencli/root_file_test.go
+++ b/internal/gencli/root_file_test.go
@@ -44,5 +44,5 @@ func TestRootFile(t *testing.T) {
 	if file.GetName() != "root.go" {
 		t.Errorf("(%s).genRootCmdFile() = %s, want %s", g.root, file.GetName(), "root.go")
 	}
-	txtdiff.Diff(t, "root_file", file.GetContent(), filepath.Join("testdata", "root_file.want"))
+	txtdiff.Diff(t, file.GetContent(), filepath.Join("testdata", "root_file.want"))
 }

--- a/internal/gencli/service_file_test.go
+++ b/internal/gencli/service_file_test.go
@@ -68,5 +68,5 @@ func TestServiceFile(t *testing.T) {
 	if file.GetName() != "todo_service.go" {
 		t.Errorf("(%+v).genServiceCmdFile(%+v) = %s, want %s", g, cmd, file.GetName(), "todo_service.go")
 	}
-	txtdiff.Diff(t, "service_file", file.GetContent(), filepath.Join("testdata", "service_file.want"))
+	txtdiff.Diff(t, file.GetContent(), filepath.Join("testdata", "service_file.want"))
 }

--- a/internal/gengapic/custom_operation_test.go
+++ b/internal/gengapic/custom_operation_test.go
@@ -117,7 +117,7 @@ func TestCustomOpInit(t *testing.T) {
 		opts: &options{pkgName: "bar"},
 	}
 	g.customOpInit("foo", "req", "op", req, opServ)
-	txtdiff.Diff(t, "custom_op_init_helper", g.pt.String(), filepath.Join("testdata", "custom_op_init_helper.want"))
+	txtdiff.Diff(t, g.pt.String(), filepath.Join("testdata", "custom_op_init_helper.want"))
 }
 
 func TestCustomOperationType(t *testing.T) {
@@ -266,16 +266,18 @@ func TestCustomOperationType(t *testing.T) {
 			errorField: true,
 		},
 	} {
-		op.Field = []*descriptor.FieldDescriptorProto{errorCodeField, errorMessageField, nameField, tst.st}
-		if tst.errorField {
-			op.Field = append(op.Field, errorField)
-		}
-		err := g.customOperationType()
-		if err != nil {
-			t.Fatal(err)
-		}
-		tn := "custom_op_type_" + tst.name
-		txtdiff.Diff(t, tn, g.pt.String(), filepath.Join("testdata", tn+".want"))
-		g.reset()
+		t.Run(tst.name, func(t *testing.T) {
+			op.Field = []*descriptor.FieldDescriptorProto{errorCodeField, errorMessageField, nameField, tst.st}
+			if tst.errorField {
+				op.Field = append(op.Field, errorField)
+			}
+			err := g.customOperationType()
+			if err != nil {
+				t.Fatal(err)
+			}
+			tn := "custom_op_type_" + tst.name
+			txtdiff.Diff(t, g.pt.String(), filepath.Join("testdata", tn+".want"))
+			g.reset()
+		})
 	}
 }

--- a/internal/gengapic/doc_file_test.go
+++ b/internal/gengapic/doc_file_test.go
@@ -15,7 +15,6 @@
 package gengapic
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -84,10 +83,12 @@ func TestDocFile(t *testing.T) {
 			want:   filepath.Join("testdata", "doc_file_beta.want"),
 		},
 	} {
-		g.opts.relLvl = tst.relLvl
-		g.genDocFile(42, []string{"https://foo.bar.com/auth", "https://zip.zap.com/auth"}, serv)
-		txtdiff.Diff(t, "doc_file", g.pt.String(), tst.want)
-		g.reset()
+		t.Run(tst.want, func(t *testing.T) {
+			g.opts.relLvl = tst.relLvl
+			g.genDocFile(42, []string{"https://foo.bar.com/auth", "https://zip.zap.com/auth"}, serv)
+			txtdiff.Diff(t, g.pt.String(), tst.want)
+			g.reset()
+		})
 	}
 }
 
@@ -146,10 +147,11 @@ func TestDocFileEmptyService(t *testing.T) {
 			want:   filepath.Join("testdata", "doc_file_deprecated_emptyservice.want"),
 		},
 	} {
-		g.opts.relLvl = tst.relLvl
-		g.genDocFile(43, []string{"https://foo.bar.com/auth", "https://zip.zap.com/auth"}, serv)
-		name := fmt.Sprintf("doc_file: %s", tst.want)
-		txtdiff.Diff(t, name, g.pt.String(), tst.want)
-		g.reset()
+		t.Run(tst.want, func(t *testing.T) {
+			g.opts.relLvl = tst.relLvl
+			g.genDocFile(43, []string{"https://foo.bar.com/auth", "https://zip.zap.com/auth"}, serv)
+			txtdiff.Diff(t, g.pt.String(), tst.want)
+			g.reset()
+		})
 	}
 }

--- a/internal/gengapic/example_test.go
+++ b/internal/gengapic/example_test.go
@@ -262,18 +262,20 @@ func TestExample(t *testing.T) {
 			op: &customOp{message: cop},
 		},
 	} {
-		g.reset()
-		g.opts = &tst.options
-		g.mixins = mix
-		if tst.options.diregapic {
-			g.mixins = nil
-		}
-		g.aux.customOp = tst.op
-		g.genExampleFile(serv)
-		if diff := cmp.Diff(g.imports, tst.imports); diff != "" {
-			t.Errorf("TestExample(%s): imports got(-),want(+):\n%s", tst.tstName, diff)
-		}
-		txtdiff.Diff(t, tst.tstName, g.pt.String(), filepath.Join("testdata", tst.tstName+".want"))
+		t.Run(tst.tstName, func(t *testing.T) {
+			g.reset()
+			g.opts = &tst.options
+			g.mixins = mix
+			if tst.options.diregapic {
+				g.mixins = nil
+			}
+			g.aux.customOp = tst.op
+			g.genExampleFile(serv)
+			if diff := cmp.Diff(g.imports, tst.imports); diff != "" {
+				t.Errorf("TestExample(%s): imports got(-),want(+):\n%s", tst.tstName, diff)
+			}
+			txtdiff.Diff(t, g.pt.String(), filepath.Join("testdata", tst.tstName+".want"))
+		})
 	}
 }
 
@@ -342,20 +344,22 @@ func TestGenSnippetFile(t *testing.T) {
 			},
 		},
 	} {
-		g.reset()
-		g.opts = &tst.options
-		defaultHost := "bigquerymigration.googleapis.com"
-		g.snippetMetadata.AddService(serv.GetName(), defaultHost)
-		err := g.genSnippetFile(serv, serv.Method[0])
-		if err != nil {
-			t.Fatal(err)
-		}
-		g.commit(filepath.Join("cloud.google.com/go", "internal", "generated", "snippets", "bigquery", "main.go"), "main")
-		if diff := cmp.Diff(g.imports, tst.imports); diff != "" {
-			t.Errorf("TestExample(%s): imports got(-),want(+):\n%s", tst.tstName, diff)
-		}
-		got := *g.resp.File[0].Content + *g.resp.File[1].Content
-		txtdiff.Diff(t, tst.tstName, got, filepath.Join("testdata", tst.tstName+".want"))
+		t.Run(tst.tstName, func(t *testing.T) {
+			g.reset()
+			g.opts = &tst.options
+			defaultHost := "bigquerymigration.googleapis.com"
+			g.snippetMetadata.AddService(serv.GetName(), defaultHost)
+			err := g.genSnippetFile(serv, serv.Method[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			g.commit(filepath.Join("cloud.google.com/go", "internal", "generated", "snippets", "bigquery", "main.go"), "main")
+			if diff := cmp.Diff(g.imports, tst.imports); diff != "" {
+				t.Errorf("TestExample(%s): imports got(-),want(+):\n%s", tst.tstName, diff)
+			}
+			got := *g.resp.File[0].Content + *g.resp.File[1].Content
+			txtdiff.Diff(t, got, filepath.Join("testdata", tst.tstName+".want"))
+		})
 	}
 }
 

--- a/internal/gengapic/metadata_test.go
+++ b/internal/gengapic/metadata_test.go
@@ -228,5 +228,5 @@ func TestGenGapicMetadataFile_standardized(t *testing.T) {
 	if err := g.genGapicMetadataFile(); err != nil {
 		t.Fatalf("got genGapicMetadataFile() = %v, want nil", err)
 	}
-	txtdiff.Diff(t, "genGapicMetadataFile", g.pt.String(), "testdata/metadata.want")
+	txtdiff.Diff(t, g.pt.String(), "testdata/metadata.want")
 }

--- a/internal/gengapic/snippets_test.go
+++ b/internal/gengapic/snippets_test.go
@@ -212,29 +212,30 @@ func TestGenAndCommitSnippets(t *testing.T) {
 			},
 		},
 	} {
-		g.reset()
-		g.descInfo.ParentElement[tst.m] = serv
-		serv.Method = []*descriptor.MethodDescriptorProto{
-			tst.m,
-		}
-		g.aux = &auxTypes{
-			iters: map[string]*iterType{},
-		}
-
-		if err := g.genAndCommitSnippets(serv); err != nil {
-			t.Error(err)
-			continue
-		}
-
-		if diff := cmp.Diff(g.imports, tst.imports); diff != "" {
-			t.Errorf("TestGenAndCommitSnippets(%s): imports got(-),want(+):\n%s", tst.m.GetName(), diff)
-		}
-		if !tst.wantNil {
-			wantRegionTag := fmt.Sprintf("// [START _pkg_generated_Foo_%s_sync]\n", tst.m.GetName())
-			if g.headerComments.String() != wantRegionTag {
-				t.Errorf("TestGenAndCommitSnippets(%s): got %s, want %s", tst.m.GetName(), g.headerComments.String(), wantRegionTag)
+		t.Run(tst.m.GetName(), func(t *testing.T) {
+			g.reset()
+			g.descInfo.ParentElement[tst.m] = serv
+			serv.Method = []*descriptor.MethodDescriptorProto{
+				tst.m,
 			}
-			txtdiff.Diff(t, tst.m.GetName(), g.pt.String(), filepath.Join("testdata", "snippet_"+tst.m.GetName()+".want"))
-		}
+			g.aux = &auxTypes{
+				iters: map[string]*iterType{},
+			}
+
+			if err := g.genAndCommitSnippets(serv); err != nil {
+				t.Fatal(err)
+			}
+
+			if diff := cmp.Diff(g.imports, tst.imports); diff != "" {
+				t.Errorf("TestGenAndCommitSnippets(%s): imports got(-),want(+):\n%s", tst.m.GetName(), diff)
+			}
+			if !tst.wantNil {
+				wantRegionTag := fmt.Sprintf("// [START _pkg_generated_Foo_%s_sync]\n", tst.m.GetName())
+				if g.headerComments.String() != wantRegionTag {
+					t.Errorf("TestGenAndCommitSnippets(%s): got %s, want %s", tst.m.GetName(), g.headerComments.String(), wantRegionTag)
+				}
+				txtdiff.Diff(t, g.pt.String(), filepath.Join("testdata", "snippet_"+tst.m.GetName()+".want"))
+			}
+		})
 	}
 }

--- a/internal/txtdiff/diff.go
+++ b/internal/txtdiff/diff.go
@@ -27,7 +27,7 @@ var updateGolden = flag.Bool("update_golden", false, "update golden files")
 
 // Diff is a test helper, testing got against contents of goldenFile. If they do not match,
 // Diff fails the test, reporting the diff.
-func Diff(t *testing.T, name, got, goldenFile string) {
+func Diff(t *testing.T, got, goldenFile string) {
 	t.Helper()
 
 	if *updateGolden {


### PR DESCRIPTION
Use `t.Run` to run tests in parallel where relevant. Additionally, remove the `name` argument `txtdiff.Diff` since it isn't being used.