### PR TITLE
chore(internal): replace some usage of deprecated github.com/golang/protobuf/proto 

### DIFF
--- a/internal/gencli/BUILD.bazel
+++ b/internal/gencli/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@go_googleapis//google/api:annotations_go_proto",
         "@io_bazel_rules_go//proto/wkt:compiler_plugin_go_proto",
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
+        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/internal/gencli/gencli.go
+++ b/internal/gencli/gencli.go
@@ -24,13 +24,13 @@ import (
 	"github.com/jhump/protoreflect/desc"
 
 	longrunning "cloud.google.com/go/longrunning/autogen/longrunningpb"
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"github.com/googleapis/gapic-generator-go/internal/errors"
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"github.com/googleapis/gapic-generator-go/internal/printer"
 	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
 )
 
 const (
@@ -216,14 +216,7 @@ func (g *gcli) genCommands() {
 				cmd.IsLRO = true
 				cmd.OutputMessageType = out
 
-				operationInfo, err := proto.GetExtension(mthd.GetMethodOptions(), longrunning.E_OperationInfo)
-				if err == proto.ErrMissingExtension {
-					return
-				} else if err != nil {
-					errStr := fmt.Sprintf("Error parsing the %s operation_info: %v", mthd.GetName(), err)
-					g.response.Error = &errStr
-					return
-				}
+				operationInfo := proto.GetExtension(mthd.GetMethodOptions(), longrunning.E_OperationInfo)
 				opInfo := operationInfo.(*longrunning.OperationInfo)
 				cmd.IsLRORespEmpty = opInfo == nil || opInfo.GetResponseType() == emptyValue
 
@@ -621,17 +614,8 @@ func (g *gcli) getFieldBehavior(field *desc.FieldDescriptor) (output bool, requi
 		return
 	}
 
-	eBehav, err := proto.GetExtension(field.GetFieldOptions(), annotations.E_FieldBehavior)
-	if err == proto.ErrMissingExtension {
-		return
-	} else if err != nil {
-		errStr := fmt.Sprintf("Error parsing the %s field_behavior: %v", field.GetName(), err)
-		g.response.Error = &errStr
-		return
-	}
-
+	eBehav := proto.GetExtension(field.GetFieldOptions(), annotations.E_FieldBehavior)
 	behavior := eBehav.([]annotations.FieldBehavior)
-
 	for _, b := range behavior {
 		if b == annotations.FieldBehavior_REQUIRED {
 			required = true

--- a/internal/gengapic/custom_operation_test.go
+++ b/internal/gengapic/custom_operation_test.go
@@ -25,7 +25,8 @@ import (
 	"github.com/googleapis/gapic-generator-go/internal/txtdiff"
 	"google.golang.org/genproto/googleapis/cloud/extendedops"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/runtime/protoiface"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 func TestCustomOpProtoName(t *testing.T) {
@@ -40,7 +41,7 @@ func TestCustomOpProtoName(t *testing.T) {
 			},
 		},
 		descInfo: pbinfo.Info{
-			ParentFile: map[protoiface.MessageV1]*descriptor.FileDescriptorProto{
+			ParentFile: map[protoreflect.ProtoMessage]*descriptorpb.FileDescriptorProto{
 				op: {
 					Package: proto.String(pkg),
 				},
@@ -65,7 +66,7 @@ func TestCustomPointerTyp(t *testing.T) {
 			},
 		},
 		descInfo: pbinfo.Info{
-			ParentFile: map[protoiface.MessageV1]*descriptor.FileDescriptorProto{
+			ParentFile: map[protoreflect.ProtoMessage]*descriptorpb.FileDescriptorProto{
 				op: {
 					Package: proto.String("google.cloud.foo.v1"),
 					Options: &descriptor.FileOptions{
@@ -235,7 +236,7 @@ func TestCustomOperationType(t *testing.T) {
 			},
 		},
 		descInfo: pbinfo.Info{
-			ParentFile: map[protoiface.MessageV1]*descriptor.FileDescriptorProto{
+			ParentFile: map[protoreflect.ProtoMessage]*descriptorpb.FileDescriptorProto{
 				op:        f,
 				fooOpServ: f,
 				getInput:  f,

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -33,7 +33,9 @@ import (
 	metadatapb "google.golang.org/genproto/googleapis/gapic/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/runtime/protoiface"
+	"google.golang.org/protobuf/types/descriptorpb"
 	duration "google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/pluginpb"
 )
@@ -797,7 +799,7 @@ func TestIsLRO(t *testing.T) {
 	}
 
 	var g generator
-	g.descInfo.ParentFile = map[protoiface.MessageV1]*descriptor.FileDescriptorProto{
+	g.descInfo.ParentFile = map[protoreflect.ProtoMessage]*descriptorpb.FileDescriptorProto{
 		lroGetOp: {
 			Package: proto.String("google.longrunning"),
 		},
@@ -1181,7 +1183,7 @@ func TestReturnType(t *testing.T) {
 			diregapic: true,
 		},
 		descInfo: pbinfo.Info{
-			ParentFile: map[protoiface.MessageV1]*descriptor.FileDescriptorProto{
+			ParentFile: map[protoreflect.ProtoMessage]*descriptorpb.FileDescriptorProto{
 				op:  f,
 				foo: f,
 			},

--- a/internal/gengapic/genrest_test.go
+++ b/internal/gengapic/genrest_test.go
@@ -32,7 +32,8 @@ import (
 	"google.golang.org/genproto/googleapis/cloud/extendedops"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
-	"google.golang.org/protobuf/runtime/protoiface"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -696,7 +697,7 @@ func TestGenRestMethod(t *testing.T) {
 			s: opS,
 		},
 		descInfo: pbinfo.Info{
-			ParentFile: map[protoiface.MessageV1]*descriptor.FileDescriptorProto{
+			ParentFile: map[protoreflect.ProtoMessage]*descriptorpb.FileDescriptorProto{
 				op:           f,
 				opS:          f,
 				opRPC:        f,

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -22,7 +22,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/runtime/protoiface"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 // TODO(dovs): Augment with map iterator
@@ -44,7 +45,7 @@ func TestIterTypeOf(t *testing.T) {
 				mapEntry.GetName(): mapEntry,
 			},
 			ParentElement: map[pbinfo.ProtoType]pbinfo.ProtoType{},
-			ParentFile: map[protoiface.MessageV1]*descriptor.FileDescriptorProto{
+			ParentFile: map[protoreflect.ProtoMessage]*descriptorpb.FileDescriptorProto{
 				msgType: {
 					Options: &descriptor.FileOptions{
 						GoPackage: proto.String("path/to/foo;foo"),

--- a/internal/pbinfo/BUILD.bazel
+++ b/internal/pbinfo/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//internal/errors",
         "@com_github_golang_protobuf//proto:go_default_library",
         "@io_bazel_rules_go//proto/wkt:descriptor_go_proto",
+        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/internal/pbinfo/pbinfo.go
+++ b/internal/pbinfo/pbinfo.go
@@ -20,9 +20,9 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/gapic-generator-go/internal/errors"
+	"google.golang.org/protobuf/proto"
 )
 
 // ProtoType represents a type in protobuf descriptors.


### PR DESCRIPTION
Replace some usage of github.com/golang/protobuf/proto with google.golang.org/protobuf/proto. The [github.com/golang/protobuf](https://pkg.go.dev/github.com/golang/protobuf) module has been deprecated.

For #348