### PR TITLE
fix(gencli): title case dot delimited segments

### DIFF
--- a/internal/gencli/BUILD.bazel
+++ b/internal/gencli/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "flag_test.go",
         "root_file_test.go",
         "service_file_test.go",
+        "util_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":gencli"],

--- a/internal/gencli/util.go
+++ b/internal/gencli/util.go
@@ -71,11 +71,16 @@ func putImport(imports map[string]*pbinfo.ImportSpec, pkg *pbinfo.ImportSpec) {
 	imports[key] = pkg
 }
 
-// does not remove dot
+// does not remove dot, but does split on it,
+// title-casing each segment before rejoining.
 func title(name string) string {
 	split := strings.Split(name, "_")
 	for i, s := range split {
-		split[i] = toTitle(s)
+		dotSplit := strings.Split(s, ".")
+		for j, ds := range dotSplit {
+			dotSplit[j] = toTitle(ds)
+		}
+		split[i] = strings.Join(dotSplit, ".")
 	}
 
 	return strings.Join(split, "")

--- a/internal/gencli/util_test.go
+++ b/internal/gencli/util_test.go
@@ -1,0 +1,37 @@
+package gencli
+
+import "testing"
+
+func TestTitle(t *testing.T) {
+	testCases := []struct {
+		name, input, want string
+	}{
+		{
+			name:  "simple",
+			input: "title",
+			want:  "Title",
+		},
+		{
+			name:  "underscores",
+			input: "title_with_underscores",
+			want:  "TitleWithUnderscores",
+		},
+		{
+			name:  "dots",
+			input: "title.with.dots",
+			want:  "Title.With.Dots",
+		},
+		{
+			name:  "dots and underscores",
+			input: "title.with_dots.and_underscores",
+			want:  "Title.WithDots.AndUnderscores",
+		},
+	}
+	for _, tst := range testCases {
+		t.Run(tst.name, func(t *testing.T) {
+			if got := title(tst.input); got != tst.want {
+				t.Errorf("title(%s): got %s, want %s", tst.input, got, tst.want)
+			}
+		})
+	}
+}

--- a/internal/gencli/util_test.go
+++ b/internal/gencli/util_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package gencli
 
 import "testing"


### PR DESCRIPTION
#1420 broke flag generation because `strings.Title` would title-case each segment of a dot-delimited string, where as `cases.Title` does not ([example](https://go.dev/play/p/vMpS1NmChgd)).

Simple fix to ensure each segment, even if dot-delimited, gets title-cased.