### PR TITLE
fix(internal/gengapic): add iter response access example

### DIFF
--- a/internal/gengapic/example.go
+++ b/internal/gengapic/example.go
@@ -238,9 +238,10 @@ func (g *generator) examplePagingCall(m *descriptor.MethodDescriptorProto) error
 	p("  // TODO: Use resp.")
 	p("  _ = resp")
 	p("")
-	p("  // TODO: Use the underlying response message.")
-	p("  // Only populated after first call to Next().")
-	p("  // Not safe for concurrent access.")
+	p("  // If you need to access the underlying RPC response,")
+	p("  // you can do so by casting the `Response` as below.")
+	p("  // Otherwise, remove this line. Only populated after")
+	p("  // first call to Next(). Not safe for concurrent access.")
 	p("  _ = it.Response.(*%s.%s)", outSpec.Name, outType.GetName())
 	p("}")
 

--- a/internal/gengapic/testdata/custom_op_example.want
+++ b/internal/gengapic/testdata/custom_op_example.want
@@ -122,9 +122,10 @@ func ExampleFooClient_GetManyThings() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }

--- a/internal/gengapic/testdata/custom_op_example.want
+++ b/internal/gengapic/testdata/custom_op_example.want
@@ -121,6 +121,11 @@ func ExampleFooClient_GetManyThings() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }
 

--- a/internal/gengapic/testdata/empty_example.want
+++ b/internal/gengapic/testdata/empty_example.want
@@ -139,9 +139,10 @@ func ExampleClient_GetManyThings() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }
@@ -298,9 +299,10 @@ func ExampleClient_ListLocations() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*locationpb.ListLocationsResponse)
 	}
 }
@@ -434,9 +436,10 @@ func ExampleClient_ListOperations() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*longrunningpb.ListOperationsResponse)
 	}
 }

--- a/internal/gengapic/testdata/empty_example.want
+++ b/internal/gengapic/testdata/empty_example.want
@@ -138,6 +138,11 @@ func ExampleClient_GetManyThings() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }
 
@@ -292,6 +297,11 @@ func ExampleClient_ListLocations() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*locationpb.ListLocationsResponse)
 	}
 }
 
@@ -423,6 +433,11 @@ func ExampleClient_ListOperations() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*longrunningpb.ListOperationsResponse)
 	}
 }
 

--- a/internal/gengapic/testdata/empty_example_grpc.want
+++ b/internal/gengapic/testdata/empty_example_grpc.want
@@ -122,9 +122,10 @@ func ExampleClient_GetManyThings() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }
@@ -281,9 +282,10 @@ func ExampleClient_ListLocations() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*locationpb.ListLocationsResponse)
 	}
 }
@@ -417,9 +419,10 @@ func ExampleClient_ListOperations() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*longrunningpb.ListOperationsResponse)
 	}
 }

--- a/internal/gengapic/testdata/empty_example_grpc.want
+++ b/internal/gengapic/testdata/empty_example_grpc.want
@@ -121,6 +121,11 @@ func ExampleClient_GetManyThings() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }
 
@@ -275,6 +280,11 @@ func ExampleClient_ListLocations() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*locationpb.ListLocationsResponse)
 	}
 }
 
@@ -406,6 +416,11 @@ func ExampleClient_ListOperations() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*longrunningpb.ListOperationsResponse)
 	}
 }
 

--- a/internal/gengapic/testdata/foo_example.want
+++ b/internal/gengapic/testdata/foo_example.want
@@ -139,9 +139,10 @@ func ExampleFooClient_GetManyThings() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }
@@ -298,9 +299,10 @@ func ExampleFooClient_ListLocations() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*locationpb.ListLocationsResponse)
 	}
 }
@@ -434,9 +436,10 @@ func ExampleFooClient_ListOperations() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*longrunningpb.ListOperationsResponse)
 	}
 }

--- a/internal/gengapic/testdata/foo_example.want
+++ b/internal/gengapic/testdata/foo_example.want
@@ -138,6 +138,11 @@ func ExampleFooClient_GetManyThings() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }
 
@@ -292,6 +297,11 @@ func ExampleFooClient_ListLocations() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*locationpb.ListLocationsResponse)
 	}
 }
 
@@ -423,6 +433,11 @@ func ExampleFooClient_ListOperations() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*longrunningpb.ListOperationsResponse)
 	}
 }
 

--- a/internal/gengapic/testdata/foo_example_rest.want
+++ b/internal/gengapic/testdata/foo_example_rest.want
@@ -121,6 +121,11 @@ func ExampleFooClient_GetManyThings() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }
 
@@ -275,6 +280,11 @@ func ExampleFooClient_ListLocations() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*locationpb.ListLocationsResponse)
 	}
 }
 
@@ -406,6 +416,11 @@ func ExampleFooClient_ListOperations() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*longrunningpb.ListOperationsResponse)
 	}
 }
 

--- a/internal/gengapic/testdata/foo_example_rest.want
+++ b/internal/gengapic/testdata/foo_example_rest.want
@@ -122,9 +122,10 @@ func ExampleFooClient_GetManyThings() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }
@@ -281,9 +282,10 @@ func ExampleFooClient_ListLocations() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*locationpb.ListLocationsResponse)
 	}
 }
@@ -417,9 +419,10 @@ func ExampleFooClient_ListOperations() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*longrunningpb.ListOperationsResponse)
 	}
 }

--- a/internal/gengapic/testdata/snippet_GetManyThings.want
+++ b/internal/gengapic/testdata/snippet_GetManyThings.want
@@ -26,6 +26,11 @@ func main() {
 		}
 		// TODO: Use resp.
 		_ = resp
+
+		// TODO: Use the underlying response message.
+		// Only populated after first call to Next().
+		// Not safe for concurrent access.
+		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }
 

--- a/internal/gengapic/testdata/snippet_GetManyThings.want
+++ b/internal/gengapic/testdata/snippet_GetManyThings.want
@@ -27,9 +27,10 @@ func main() {
 		// TODO: Use resp.
 		_ = resp
 
-		// TODO: Use the underlying response message.
-		// Only populated after first call to Next().
-		// Not safe for concurrent access.
+		// If you need to access the underlying RPC response,
+		// you can do so by casting the `Response` as below.
+		// Otherwise, remove this line. Only populated after
+		// first call to Next(). Not safe for concurrent access.
 		_ = it.Response.(*mypackagepb.PageOutputType)
 	}
 }


### PR DESCRIPTION
Adds some code to the paging call example that demonstrates accessing the Iterator's underlying RPC specific response type for a page. Since Iterators are generated per-resource, rather than per RPC, the `Response` field has to be generic, but this makes it harder for users to get at the underlying response message if there are other interesting fields.

Fixes #1467 