### PR TITLE
fix(gengapic): remove unneeded internaloption.WithDefaultUniverseDomain

### DIFF
--- a/internal/gengapic/gengrpc.go
+++ b/internal/gengapic/gengrpc.go
@@ -181,7 +181,6 @@ func (g *generator) grpcClientOptions(serv *descriptor.ServiceDescriptorProto, s
 	p("    internaloption.WithDefaultEndpoint(%q),", host)
 	p("    internaloption.WithDefaultEndpointTemplate(%q),", generateDefaultEndpointTemplate(host))
 	p("    internaloption.WithDefaultMTLSEndpoint(%q),", generateDefaultMTLSEndpoint(host))
-	p("    internaloption.WithDefaultUniverseDomain(%q),", googleDefaultUniverse)
 	p("    internaloption.WithDefaultAudience(%q),", generateDefaultAudience(host))
 	p("    internaloption.WithDefaultScopes(DefaultAuthScopes()...),")
 	p("    internaloption.EnableJwtWithScope(),")

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -134,7 +134,6 @@ func (g *generator) restClientOptions(serv *descriptor.ServiceDescriptorProto, s
 	p("    internaloption.WithDefaultEndpoint(%q),", host)
 	p("    internaloption.WithDefaultEndpointTemplate(%q),", generateDefaultEndpointTemplate(host))
 	p("    internaloption.WithDefaultMTLSEndpoint(%q),", generateDefaultMTLSEndpoint(host))
-	p("    internaloption.WithDefaultUniverseDomain(%q),", googleDefaultUniverse)
 	p("    internaloption.WithDefaultAudience(%q),", generateDefaultAudience(host))
 	p("    internaloption.WithDefaultScopes(DefaultAuthScopes()...),")
 	p("  }")

--- a/internal/gengapic/testdata/empty_opt.want
+++ b/internal/gengapic/testdata/empty_opt.want
@@ -20,7 +20,6 @@ func defaultGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultEndpoint("foo.googleapis.com:443"),
 		internaloption.WithDefaultEndpointTemplate("foo.UNIVERSE_DOMAIN:443"),
 		internaloption.WithDefaultMTLSEndpoint("foo.mtls.googleapis.com:443"),
-		internaloption.WithDefaultUniverseDomain("googleapis.com"),
 		internaloption.WithDefaultAudience("https://foo.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),

--- a/internal/gengapic/testdata/foo_opt.want
+++ b/internal/gengapic/testdata/foo_opt.want
@@ -20,7 +20,6 @@ func defaultFooGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultEndpoint("foo.googleapis.com:443"),
 		internaloption.WithDefaultEndpointTemplate("foo.UNIVERSE_DOMAIN:443"),
 		internaloption.WithDefaultMTLSEndpoint("foo.mtls.googleapis.com:443"),
-		internaloption.WithDefaultUniverseDomain("googleapis.com"),
 		internaloption.WithDefaultAudience("https://foo.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),

--- a/internal/gengapic/testdata/host_port_opt.want
+++ b/internal/gengapic/testdata/host_port_opt.want
@@ -18,7 +18,6 @@ func defaultBarGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultEndpoint("foo.googleapis.com:1234"),
 		internaloption.WithDefaultEndpointTemplate("foo.UNIVERSE_DOMAIN:1234"),
 		internaloption.WithDefaultMTLSEndpoint("foo.mtls.googleapis.com:1234"),
-		internaloption.WithDefaultUniverseDomain("googleapis.com"),
 		internaloption.WithDefaultAudience("https://foo.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),

--- a/internal/gengapic/testdata/iam_override_opt.want
+++ b/internal/gengapic/testdata/iam_override_opt.want
@@ -17,7 +17,6 @@ func defaultBazGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultEndpoint("foo.googleapis.com:1234"),
 		internaloption.WithDefaultEndpointTemplate("foo.UNIVERSE_DOMAIN:1234"),
 		internaloption.WithDefaultMTLSEndpoint("foo.mtls.googleapis.com:1234"),
-		internaloption.WithDefaultUniverseDomain("googleapis.com"),
 		internaloption.WithDefaultAudience("https://foo.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
 		internaloption.EnableJwtWithScope(),


### PR DESCRIPTION
refs: #1452
refs: https://github.com/googleapis/google-cloud-go/pull/9663/commits/dbb73d85295ce84eb4eb2ce45a827ea1bcd6e214