### PR TITLE
fix(bazel): add missing otel deps & resolve patches

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1206,11 +1206,29 @@ def com_googleapis_gapic_generator_go_repositories():
         name = "io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc",
         importpath = "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc",
         sum = "h1:P+/g8GpuJGYbOp2tAdKrIPUX9JO02q8Q0YNlHolpibA=",
+        build_directives = [
+            "gazelle:resolve go go.opentelemetry.io/otel @io_opentelemetry_go_otel//:go_default_library",
+            "gazelle:resolve go go.opentelemetry.io/otel/attribute @io_opentelemetry_go_otel//attribute",
+            "gazelle:resolve go go.opentelemetry.io/otel/codes @io_opentelemetry_go_otel//codes",
+            "gazelle:resolve go go.opentelemetry.io/otel/metric @io_opentelemetry_go_otel_metric//:go_default_library",
+            "gazelle:resolve go go.opentelemetry.io/otel/metric/noop @io_opentelemetry_go_otel_metric//noop:go_default_library",
+            "gazelle:resolve go go.opentelemetry.io/otel/propagation @io_opentelemetry_go_otel//propagation",
+            "gazelle:resolve go go.opentelemetry.io/otel/semconv/v1.17.0 @io_opentelemetry_go_otel//semconv/v1.17.0:v1_17_0",
+            "gazelle:resolve go go.opentelemetry.io/otel/trace @io_opentelemetry_go_otel_trace//:go_default_library",
+        ],
         version = "v0.48.0",
     )
     go_repository(
         name = "io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp",
         importpath = "go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp",
+        build_directives = [
+            "gazelle:resolve go go.opentelemetry.io/otel @io_opentelemetry_go_otel//:go_default_library",
+            "gazelle:resolve go go.opentelemetry.io/otel/attribute @io_opentelemetry_go_otel//attribute",
+            "gazelle:resolve go go.opentelemetry.io/otel/metric @io_opentelemetry_go_otel_metric//:go_default_library",
+            "gazelle:resolve go go.opentelemetry.io/otel/propagation @io_opentelemetry_go_otel//propagation",
+            "gazelle:resolve go go.opentelemetry.io/otel/semconv/v1.20.0 @io_opentelemetry_go_otel//semconv/v1.20.0:v1_20_0",
+            "gazelle:resolve go go.opentelemetry.io/otel/trace @io_opentelemetry_go_otel_trace//:go_default_library",
+        ],
         sum = "h1:doUP+ExOpH3spVTLS0FcWGLnQrPct/hD/bCPbDRUEAU=",
         version = "v0.48.0",
     )
@@ -1218,12 +1236,20 @@ def com_googleapis_gapic_generator_go_repositories():
         name = "io_opentelemetry_go_otel",
         importpath = "go.opentelemetry.io/otel",
         sum = "h1:Df0pqjqExIywbMCMTxkAwzjLZtRf+bBKLbUcpxO2C9E=",
+        build_directives = [
+            "gazelle:resolve go go.opentelemetry.io/otel/trace @io_opentelemetry_go_otel_trace//:go_default_library",
+            "gazelle:resolve go go.opentelemetry.io/otel/metric @io_opentelemetry_go_otel_metric//:go_default_library",
+            "gazelle:resolve go go.opentelemetry.io/otel/metric/embedded @io_opentelemetry_go_otel_metric//embedded:go_default_library",
+        ],
         version = "v1.23.0",
     )
     go_repository(
         name = "io_opentelemetry_go_otel_metric",
         importpath = "go.opentelemetry.io/otel/metric",
         sum = "h1:pazkx7ss4LFVVYSxYew7L5I6qvLXHA0Ap2pwV+9Cnpo=",
+        build_directives = [
+            "gazelle:resolve go go.opentelemetry.io/otel/attribute @io_opentelemetry_go_otel//attribute:go_default_library",
+        ],
         version = "v1.23.0",
     )
     go_repository(
@@ -1237,6 +1263,9 @@ def com_googleapis_gapic_generator_go_repositories():
         importpath = "go.opentelemetry.io/otel/trace",
         sum = "h1:37Ik5Ib7xfYVb4V1UtnT97T1jI+AoIYkJyPkuL4iJgI=",
         version = "v1.23.0",
+        build_directives = [
+            "gazelle:resolve go go.opentelemetry.io/otel/attribute @io_opentelemetry_go_otel//attribute:go_default_library",
+        ],
     )
 
     go_repository(
@@ -1244,6 +1273,10 @@ def com_googleapis_gapic_generator_go_repositories():
         importpath = "google.golang.org/api",
         sum = "h1:CKHrQD1BLRii6xdkatBDXyKzM0mkawt2QP+H3LtPmSE=",
         version = "v0.167.0",
+        build_directives = [
+            "gazelle:resolve go go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp @io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:go_default_library",
+            "gazelle:resolve go go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc @io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc//:go_default_library",
+        ],
     )
 
     go_repository(
@@ -1400,7 +1433,7 @@ def _maybe(repo_rule, name, strip_repo_prefix = "", **kwargs):
 # targets. This way we get both the _maybe functionality and still use
 # gazelle update-repos. The real go_repository rule is loaded with an alias:
 # gazelle_go_repository.
-def go_repository(name, importpath, sum, version, build_file_proto_mode = "", build_extra_args = []):
+def go_repository(name, importpath, sum, version, build_file_proto_mode = "", build_extra_args = [], build_directives = []):
     _maybe(
         gazelle_go_repository,
         name = name,
@@ -1409,4 +1442,5 @@ def go_repository(name, importpath, sum, version, build_file_proto_mode = "", bu
         version = version,
         build_file_proto_mode = build_file_proto_mode,
         build_extra_args = build_extra_args,
+        build_directives = build_directives,
     )

--- a/rules_go_gapic/go_gapic.bzl
+++ b/rules_go_gapic/go_gapic.bzl
@@ -157,6 +157,8 @@ def go_gapic_library(
     "@com_github_google_uuid//:go_default_library",
     "@com_github_googleapis_gax_go_v2//:go_default_library",
     "@com_github_googleapis_gax_go_v2//apierror:go_default_library",
+    "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:go_default_library",
+    "@io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc//:go_default_library",
     "@org_golang_google_api//googleapi:go_default_library",
     "@org_golang_google_api//option:go_default_library",
     "@org_golang_google_api//option/internaloption:go_default_library",


### PR DESCRIPTION
Adds missing otel grpc/http helpers necessary for grpc & http transport wrapper functionality.

Also adds a bunch of `gazelle` `resolve` directives to help fix resolution issues that gazelle has with `otel` modules. According to https://github.com/open-telemetry/opentelemetry-go-contrib/issues/872, there are some weird issues with resolving otel packages between the separate modules and we must explicitly state the resolution mapping in order to actually have the dependency provided to the `gazelle` generated `go_library` targets.

Addresses b/333129802