### PR TITLE
chore(ci): use bazelisk

### DIFF
--- a/.bazeliskrc
+++ b/.bazeliskrc
@@ -1,0 +1,3 @@
+# See https://github.com/bazelbuild/bazelisk
+# Should match https://github.com/googleapis/googleapis/blob/master/.bazeliskrc
+USE_BAZEL_VERSION=6.3.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,13 +87,14 @@ jobs:
         apidiff -incompatible pkg.latest github.com/googleapis/gapic-showcase/client > diff.txt && cat diff.txt && ! [ -s diff.txt ]
   bazel-build:
     runs-on: ubuntu-latest
-    env:
-      USE_BAZEL_VERSION: 6.0.0
-    container: gcr.io/gapic-images/googleapis:latest
-    # Dockerfile for this image: https://github.com/googleapis/googleapis-discovery/blob/master/Dockerfile
     steps:
     - uses: actions/checkout@v4
-    - name: Run bazel build
-      run: bazelisk build '//...'
-    - name: Run bazel test
-      run: bazelisk test '//...'
+    - uses: bazel-contrib/setup-bazel@0.8.1
+      with:
+        # Avoid downloading Bazel every time.
+        bazelisk-cache: true
+        # Store build cache per workflow.
+        disk-cache: ${{ github.workflow }}
+        # Share repository cache between workflows.
+        repository-cache: true
+    - run: bazelisk test '//...'

--- a/.github/workflows/deps.yaml
+++ b/.github/workflows/deps.yaml
@@ -14,12 +14,16 @@ jobs:
     outputs:
       changed: ${{ steps.update.outputs.changed }}
     runs-on: ubuntu-latest
-    env:
-      USE_BAZEL_VERSION: 6.0.0
-    container: gcr.io/gapic-images/googleapis:latest
-    # Dockerfile for this image: https://github.com/googleapis/googleapis-discovery/blob/master/Dockerfile
     steps:
     - uses: actions/checkout@v4
+    - uses: bazel-contrib/setup-bazel@0.8.1
+      with:
+        # Avoid downloading Bazel every time.
+        bazelisk-cache: true
+        # Store build cache per workflow.
+        disk-cache: ${{ github.workflow }}
+        # Share repository cache between workflows.
+        repository-cache: true
     - name: Run gazelle update-repos
       id: update
       run: |

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,13 @@ install:
 	go install ./cmd/protoc-gen-go_cli
 
 update-bazel-repos:
-	bazel run //:gazelle -- update-repos -from_file=go.mod -prune -to_macro=repositories.bzl%com_googleapis_gapic_generator_go_repositories
+	bazelisk run //:gazelle -- update-repos -from_file=go.mod -prune -to_macro=repositories.bzl%com_googleapis_gapic_generator_go_repositories
 	sed -i ''  "s/    \"go_repository\",//g" repositories.bzl
-	bazel run //:gazelle -- update-repos -from_file=showcase/go.mod -to_macro=repositories.bzl%com_googleapis_gapic_generator_go_repositories
+	bazelisk run //:gazelle -- update-repos -from_file=showcase/go.mod -to_macro=repositories.bzl%com_googleapis_gapic_generator_go_repositories
 	sed -i ''  "s/    \"go_repository\",//g" repositories.bzl
 
 gazelle:
-	bazel run //:gazelle
+	bazelisk run //:gazelle
 	sed -i '' "s/extendedops_go_proto/extended_operations_go_proto/g" internal/gengapic/BUILD.bazel
 	sed -i '' "s/@com_github_golang_protobuf\/\/protoc-gen-go\/plugin/@io_bazel_rules_go\/\/proto\/wkt:compiler_plugin_go_proto/g" cmd/protoc-gen-go_gapic/BUILD
 	sed -i '' "s/@com_github_golang_protobuf\/\/protoc-gen-go\/plugin/@io_bazel_rules_go\/\/proto\/wkt:compiler_plugin_go_proto/g" cmd/protoc-gen-go_cli/BUILD.bazel


### PR DESCRIPTION
Bazelisk is the preferred "runner" of bazel and more closely aligns with tools we use in googleapis. 