### PR TITLE
chore(internal/gengapic): refactor g.init to newGenerator

### DIFF
--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -552,7 +552,6 @@ func TestClientInit(t *testing.T) {
 				t.Fatal(err)
 			}
 			g.apiName = "Awesome Foo API"
-			g.imports = map[pbinfo.ImportSpec]bool{}
 			g.comments = map[protoiface.MessageV1]string{
 				tst.serv:                "Foo service does stuff.",
 				tst.serv.GetMethod()[0]: "Does some stuff.",

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -313,9 +313,6 @@ func TestServiceDoc(t *testing.T) {
 }
 
 func TestClientInit(t *testing.T) {
-	var g generator
-	g.apiName = "Awesome Foo API"
-	g.imports = map[pbinfo.ImportSpec]bool{}
 
 	cop := &descriptorpb.DescriptorProto{
 		Name: proto.String("Operation"),
@@ -550,7 +547,12 @@ func TestClientInit(t *testing.T) {
 				Parameter: tst.parameter,
 				ProtoFile: fds,
 			}
-			g.init(&request)
+			g, err := newGenerator(&request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			g.apiName = "Awesome Foo API"
+			g.imports = map[pbinfo.ImportSpec]bool{}
 			g.comments = map[protoiface.MessageV1]string{
 				tst.serv:                "Foo service does stuff.",
 				tst.serv.GetMethod()[0]: "Does some stuff.",

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -53,8 +53,8 @@ var headerParamRegexp = regexp.MustCompile(`{([_.a-z0-9]+)`)
 
 // Gen is the entry point for GAPIC generation via the protoc pluginpb.
 func Gen(genReq *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorResponse, error) {
-	var g generator
-	if err := g.init(genReq); err != nil {
+	g, err := newGenerator(genReq)
+	if err != nil {
 		return &g.resp, err
 	}
 
@@ -127,8 +127,7 @@ func Gen(genReq *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorResponse
 			g.opts.transports = transports
 		}
 	}
-	err := g.genAndCommitSnippetMetadata(protoPkg)
-	if err != nil {
+	if err := g.genAndCommitSnippetMetadata(protoPkg); err != nil {
 		return &g.resp, err
 	}
 	g.reset()

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -1113,8 +1113,7 @@ func TestGRPCStubCall(t *testing.T) {
 			},
 		},
 	}
-	var g generator
-	err := g.init(&pluginpb.CodeGeneratorRequest{
+	g, err := newGenerator(&pluginpb.CodeGeneratorRequest{
 		ProtoFile: []*descriptorpb.FileDescriptorProto{foo},
 		Parameter: proto.String("go-gapic-package=cloud.google.com/go/foo/apiv1;foo"),
 	})
@@ -1137,6 +1136,9 @@ func TestGRPCStubCall(t *testing.T) {
 			in:   getBar,
 		},
 	} {
+		if err != nil {
+			t.Fatal(err)
+		}
 		got := g.grpcStubCall(tst.in)
 		if diff := cmp.Diff(got, tst.want); diff != "" {
 			t.Errorf("TestGRPCStubCall(%s) got(-),want(+):\n%s", tst.name, diff)

--- a/internal/gengapic/genrest_test.go
+++ b/internal/gengapic/genrest_test.go
@@ -161,9 +161,6 @@ func TestPathParams(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		g.apiName = "Awesome Mollusc API"
-		g.imports = map[pbinfo.ImportSpec]bool{}
-		g.opts = &options{transports: []transport{rest}}
 		if err != nil {
 			t.Errorf("test %s setup got error: %s", tst.name, err.Error())
 		}
@@ -176,10 +173,6 @@ func TestPathParams(t *testing.T) {
 }
 
 func TestQueryParams(t *testing.T) {
-	var g generator
-	g.apiName = "Awesome Mollusc API"
-	g.imports = map[pbinfo.ImportSpec]bool{}
-	g.opts = &options{transports: []transport{rest}}
 	for _, tst := range []struct {
 		name     string
 		body     string
@@ -368,14 +361,10 @@ func TestLeafFields(t *testing.T) {
 		Parameter: proto.String("go-gapic-package=path;mypackage,transport=rest"),
 		ProtoFile: []*descriptorpb.FileDescriptorProto{file},
 	}
-
 	g, err := newGenerator(&req)
 	if err != nil {
 		t.Fatal(err)
 	}
-	g.apiName = "Awesome Mollusc API"
-	g.imports = map[pbinfo.ImportSpec]bool{}
-	g.opts = &options{transports: []transport{rest}}
 
 	for _, tst := range []struct {
 		name           string

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -410,8 +410,6 @@ func TestPagingField(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	g.apiName = "Awesome API"
-	g.imports = map[pbinfo.ImportSpec]bool{}
 	g.opts = &options{transports: []transport{rest}}
 
 	for _, tst := range []struct {

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -118,12 +118,6 @@ func TestIterTypeOf(t *testing.T) {
 }
 
 func TestPagingField(t *testing.T) {
-	g := generator{
-		apiName: "Awesome API",
-		imports: map[pbinfo.ImportSpec]bool{},
-		opts:    &options{transports: []transport{rest}},
-	}
-
 	// The predicate is simple:
 	// * No streaming in the method
 	// * Request has a int32 page_size field XOR a int32 max_results field
@@ -412,7 +406,13 @@ func TestPagingField(t *testing.T) {
 		Parameter: proto.String("go-gapic-package=path;mypackage,transport=rest"),
 		ProtoFile: []*descriptorpb.FileDescriptorProto{file},
 	}
-	g.init(&req)
+	g, err := newGenerator(&req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g.apiName = "Awesome API"
+	g.imports = map[pbinfo.ImportSpec]bool{}
+	g.opts = &options{transports: []transport{rest}}
 
 	for _, tst := range []struct {
 		mthd      *descriptorpb.MethodDescriptorProto

--- a/internal/testing/sample/sample.go
+++ b/internal/testing/sample/sample.go
@@ -102,6 +102,34 @@ const (
 	// https://github.com/googleapis/googleapis/blob/f7df662a24c56ecaab79cb7d808fed4d2bb4981d/google/cloud/secretmanager/v1/resources.proto#L40
 	Resource = "Secret"
 
+	// ListMethod is the name of the method for listing resources.
+	//
+	// Example:
+	// https://pkg.go.dev/cloud.google.com/go/secretmanager/apiv1/secretmanagerpb#ListSecrets
+	// https://github.com/googleapis/googleapis/blob/f7df662a24c56ecaab79cb7d808fed4d2bb4981d/google/cloud/secretmanager/v1/service.proto#L52
+	ListMethod = "ListSecrets"
+
+	// ListRequest is the name of the request for listing resources.
+	//
+	// A ListRequest often contains `page_size` and `page_token` fields (see
+	// https://aip.dev/158).
+	//
+	// Example:
+	// https://pkg.go.dev/cloud.google.com/go/secretmanager/apiv1/secretmanagerpb#ListSecretsRequest
+	// https://github.com/googleapis/googleapis/blob/f7df662a24c56ecaab79cb7d808fed4d2bb4981d/google/cloud/secretmanager/v1/service.proto#L274
+	ListRequest = "ListSecretsRequest"
+
+	// ListResponse is the name of the resource returned by a List request.
+	//
+	// A ListResponse message often contains the Resource, a `next_page_token`
+	// and sometimes a `total_size` field (https://aip.dev/158).
+	// type and pattern (see https://aip.dev/4231#resource-messages).
+	//
+	// Example:
+	// https://pkg.go.dev/cloud.google.com/go/secretmanager/apiv1/secretmanagerpb#ListSecretsResponse
+	// https://github.com/googleapis/googleapis/blob/f7df662a24c56ecaab79cb7d808fed4d2bb4981d/google/cloud/secretmanager/v1/service.proto#L304
+	ListResponse = "ListSecretsResponse"
+
 	// CreateMethodWithSettings is a fake method for the purpose of testing
 	// the method_settings functionality in the publishing YAML.
 	//
@@ -191,6 +219,11 @@ func Service() *descriptorpb.ServiceDescriptorProto {
 				Name:       proto.String(GetMethod),
 				InputType:  proto.String(DescriptorInfoTypeName(GetRequest)),
 				OutputType: proto.String(DescriptorInfoTypeName(Resource)),
+			},
+			{
+				Name:       proto.String(ListMethod),
+				InputType:  proto.String(DescriptorInfoTypeName(ListRequest)),
+				OutputType: proto.String(DescriptorInfoTypeName(ListResponse)),
 			},
 		},
 	}


### PR DESCRIPTION
At the moment, the `g.init` modifies a type `generator`. In many cases, `g` is empty and populated by `g.init`. It is generally more idiomatic to use a `new<thing>` function to construct a new instance of a type, so g.init is replaced with a `newGenerator` function to follow that pattern.

Additionally, errors were not captured in tests for some calls to `g.init`, which are now handled.