### PR TITLE
fix(internal/gengapic): include status_go_proto gapic dependency

### DIFF
--- a/rules_go_gapic/go_gapic.bzl
+++ b/rules_go_gapic/go_gapic.bzl
@@ -157,6 +157,7 @@ def go_gapic_library(
     "@com_github_google_uuid//:go_default_library",
     "@com_github_googleapis_gax_go_v2//:go_default_library",
     "@com_github_googleapis_gax_go_v2//apierror:go_default_library",
+    "@com_google_googleapis//google/rpc:status_go_proto",
     "@io_opentelemetry_go_contrib_instrumentation_net_http_otelhttp//:go_default_library",
     "@io_opentelemetry_go_contrib_instrumentation_google_golang_org_grpc_otelgrpc//:go_default_library",
     "@org_golang_google_api//googleapi:go_default_library",


### PR DESCRIPTION
If `google.rpc.Status` is actually referenced in the GAPIC code such that an Go import is necessary, we need to provide the dependency. For example, if a paginated RPC paged over `google.rpc.Status` messages as "errors" stored in a system (see internal link http://yaqs/4633584991517802496).

It is easier to add this here than it is to have the BUILD.bazel generator understand which deps are necessary, and when, to each generator - though we may opt for a more holistic dependency generation approach there in the future, making this unnecessary. Adding it there would result in many many `go_gapic_library` targets getting a new dep that isn't actually necessary to compile the GAPIC code.