### PR TITLE
chore: refactor Gen error handling

### DIFF
--- a/cmd/protoc-gen-go_gapic/main.go
+++ b/cmd/protoc-gen-go_gapic/main.go
@@ -34,13 +34,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	genResp, err := gengapic.Gen(&genReq)
-	if err != nil {
-		genResp.Error = proto.String(err.Error())
-	}
-
-	genResp.SupportedFeatures = proto.Uint64(uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL))
-
+	genResp := gengapic.Gen(&genReq)
 	outBytes, err := proto.Marshal(genResp)
 	if err != nil {
 		log.Fatal(err)

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -52,14 +52,24 @@ const (
 var headerParamRegexp = regexp.MustCompile(`{([_.a-z0-9]+)`)
 
 // Gen is the entry point for GAPIC generation via the protoc pluginpb.
-func Gen(genReq *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorResponse, error) {
+func Gen(genReq *pluginpb.CodeGeneratorRequest) *pluginpb.CodeGeneratorResponse {
+	genResp, err := gen(genReq)
+	if err != nil {
+		genResp = &pluginpb.CodeGeneratorResponse{
+			Error: proto.String(err.Error()),
+		}
+	}
+	genResp.SupportedFeatures = proto.Uint64(uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL))
+	return genResp
+}
+
+func gen(genReq *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorResponse, error) {
 	g, err := newGenerator(genReq)
 	if err != nil {
-		return &g.resp, err
+		return nil, err
 	}
 
 	genServs := g.collectServices(genReq)
-
 	if len(genServs) == 0 {
 		return &g.resp, nil
 	}
@@ -112,7 +122,7 @@ func Gen(genReq *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorResponse
 			g.opts.transports = []transport{grpc}
 		}
 		if err := g.gen(s); err != nil {
-			return &g.resp, err
+			return nil, err
 		}
 		g.commit(outFile+"_client.go", g.opts.pkgName)
 
@@ -130,7 +140,7 @@ func Gen(genReq *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorResponse
 		}
 	}
 	if err := g.genAndCommitSnippetMetadata(protoPkg); err != nil {
-		return &g.resp, err
+		return nil, err
 	}
 	g.reset()
 	scopes := collectScopes(genServs)
@@ -154,14 +164,14 @@ func Gen(genReq *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorResponse
 	if g.aux.customOp != nil {
 		g.reset()
 		if err := g.customOperationType(); err != nil {
-			return &g.resp, err
+			return nil, err
 		}
 		g.commit(filepath.Join(g.opts.outDir, "operations.go"), g.opts.pkgName)
 	}
 
 	g.reset()
 	if err := g.genAuxFile(); err != nil {
-		return &g.resp, err
+		return nil, err
 	}
 
 	return &g.resp, nil


### PR DESCRIPTION
At the moment, Gen returns a non-nil value when the error is not nil, which is an unexpected Go pattern. Refactor Gen so that it only returns one value, and the Error field is set inside the function.