### PR TITLE
feat(gengapic): enable cloud.google.com/go/auth for most clients

### DIFF
--- a/internal/gengapic/generator.go
+++ b/internal/gengapic/generator.go
@@ -36,10 +36,28 @@ import (
 	"google.golang.org/protobuf/types/pluginpb"
 )
 
-var enableNewAuthLibrary = map[string]bool{
-	"cloudkms.googleapis.com":      true,
-	"secretmanager.googleapis.com": true,
-	"showcase.googleapis.com":      true,
+var enableNewAuthLibraryBlocklist = map[string]bool{
+	"generativelanguage.googleapis.com":   true,
+	"aiplatform.googleapis.com":           true,
+	"analyticshub.googleapis.com":         true,
+	"biglake.googleapis.com":              true,
+	"bigqueryconnection.googleapis.com":   true,
+	"bigquerydatapolicy.googleapis.com":   true,
+	"bigquerydatatransfer.googleapis.com": true,
+	"bigquerymigration.googleapis.com":    true,
+	"bigqueryreservation.googleapis.com":  true,
+	"bigquerystorage.googleapis.com":      true,
+	"bigtableadmin.googleapis.com":        true,
+	"bigtable.googleapis.com":             true,
+	"datastore.googleapis.com":            true,
+	"clouderrorreporting.googleapis.com":  true,
+	"firestore.googleapis.com":            true,
+	"logging.googleapis.com":              true,
+	"cloudprofiler.googleapis.com":        true,
+	"pubsub.googleapis.com":               true,
+	"pubsublite.googleapis.com":           true,
+	"spanner.googleapis.com":              true,
+	"storage.googleapis.com":              true,
 }
 
 type generator struct {

--- a/internal/gengapic/gengrpc.go
+++ b/internal/gengapic/gengrpc.go
@@ -185,7 +185,7 @@ func (g *generator) grpcClientOptions(serv *descriptorpb.ServiceDescriptorProto,
 	p("    internaloption.WithDefaultAudience(%q),", generateDefaultAudience(host))
 	p("    internaloption.WithDefaultScopes(DefaultAuthScopes()...),")
 	p("    internaloption.EnableJwtWithScope(),")
-	if _, ok := enableNewAuthLibrary[g.serviceConfig.GetName()]; ok {
+	if _, ok := enableNewAuthLibraryBlocklist[g.serviceConfig.GetName()]; !ok {
 		p("internaloption.EnableNewAuthLibrary(),")
 	}
 	p("    option.WithGRPCDialOption(grpc.WithDefaultCallOptions(")

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -137,7 +137,7 @@ func (g *generator) restClientOptions(serv *descriptorpb.ServiceDescriptorProto,
 	p("    internaloption.WithDefaultUniverseDomain(%q),", googleDefaultUniverse)
 	p("    internaloption.WithDefaultAudience(%q),", generateDefaultAudience(host))
 	p("    internaloption.WithDefaultScopes(DefaultAuthScopes()...),")
-	if _, ok := enableNewAuthLibrary[g.serviceConfig.GetName()]; ok {
+	if _, ok := enableNewAuthLibraryBlocklist[g.serviceConfig.GetName()]; !ok {
 		p("internaloption.EnableNewAuthLibrary(),")
 	}
 	p("  }")


### PR DESCRIPTION
* Convert allowlist to blocklist.
* Block ai, aiplatform, bigquery, bigtable, datastore, errorreporting, firestore, logging, profiler, pubsub, pubsublite, spanner, storage.