### PR TITLE
test: add the use_generic_streams_experimental=false to showcase builds

### DIFF
--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -47,6 +47,7 @@ protoc \
 	--experimental_allow_proto3_optional \
 	--go_out ./gen \
 	--go-grpc_out ./gen \
+	--go-grpc_opt=require_unimplemented_servers=false \
 	--go_gapic_out ./gen \
 	--go_gapic_opt 'transport=rest+grpc' \
 	--go_gapic_opt 'rest-numeric-enums' \

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -47,7 +47,7 @@ protoc \
 	--experimental_allow_proto3_optional \
 	--go_out ./gen \
 	--go-grpc_out ./gen \
-	--go_grpc_opt=use_generic_streams_experimental=false \
+	--go-grpc_opt=use_generic_streams_experimental=false \
 	--go_gapic_out ./gen \
 	--go_gapic_opt 'transport=rest+grpc' \
 	--go_gapic_opt 'rest-numeric-enums' \

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -47,7 +47,7 @@ protoc \
 	--experimental_allow_proto3_optional \
 	--go_out ./gen \
 	--go-grpc_out ./gen \
-	--go-grpc_opt=require_unimplemented_servers=false \
+	--go_grpc_opt=use_generic_streams_experimental=false \
 	--go_gapic_out ./gen \
 	--go_gapic_opt 'transport=rest+grpc' \
 	--go_gapic_opt 'rest-numeric-enums' \


### PR DESCRIPTION
This PR adds an experimental grpc plugin option to the showcase test script, to ensure we get consistent generation when doing A/B apidiff tests.

Related: https://github.com/googleapis/gapic-generator-go/issues/1554