### PR TITLE
chore: don't update bazel deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,21 +5,24 @@
     ":semanticCommitTypeAll(chore)",
     "schedule:weekly"
   ],
+  "ignoreDeps": [
+    "bazel_gazelle",
+    "com_google_protobuf",
+    "io_bazel_rules_go"
+  ],
   "golang": {
     "ignoreDeps": [
       "github.com/russross/blackfriday"
     ],
-    "postUpdateOptions": ["gomodTidy"]
+    "postUpdateOptions": [
+      "gomodTidy"
+    ]
   },
   "rebaseWhen": "behind-base-branch",
-  "labels": ["automerge"],
-  "groupName": "deps",
-  "packageRules": [
-    {
-      "matchPackagePatterns": ["io_bazel_rules_go", "bazel_gazelle"],
-      "groupName": "bazel-go"
-    }
+  "labels": [
+    "automerge"
   ],
+  "groupName": "deps",
   "force": {
     "constraints": {
       "go": "1.21"


### PR DESCRIPTION
All of these deps added to the ignoreDeps need to be manually tested in googleapis before bumping. We need to do this intentionally and likely separate from other Go deps.

Also it seems like the grouping was not working, so I removed it for the time being.