### PR TITLE
fix(internal/gencli): revert broken migration to protobuf-go v2 in gencli

### DIFF
--- a/internal/gencli/gencli.go
+++ b/internal/gencli/gencli.go
@@ -191,7 +191,7 @@ func (g *gcli) genCommands() {
 				})
 
 				putImport(cmd.Imports, &pbinfo.ImportSpec{
-					Path: "google.golang.org/protobuf/jsonpb",
+					Path: "github.com/golang/protobuf/jsonpb",
 				})
 
 				if !cmd.ClientStreaming {

--- a/internal/gencli/root_file.go
+++ b/internal/gencli/root_file.go
@@ -31,9 +31,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/spf13/cobra"
-	"google.golang.org/protobuf/jsonpb"
-	"google.golang.org/protobuf/proto"
 )
 
 var Verbose, OutputJSON bool

--- a/internal/gencli/service_file_test.go
+++ b/internal/gencli/service_file_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
+
 	"github.com/googleapis/gapic-generator-go/internal/txtdiff"
 )
 
@@ -36,7 +37,7 @@ func TestServiceFile(t *testing.T) {
 		root:   "Root",
 		format: true,
 		imports: map[string]*pbinfo.ImportSpec{
-			"test": &pbinfo.ImportSpec{Name: "proto", Path: "google.golang.org/protobuf/proto"},
+			"test": &pbinfo.ImportSpec{Name: "proto", Path: "github.com/golang/protobuf/proto"},
 		},
 		subcommands: map[string][]*Command{
 			name: []*Command{

--- a/internal/gencli/testdata/root_file.want
+++ b/internal/gencli/testdata/root_file.want
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/golang/protobuf/jsonpb"
+	"github.com/golang/protobuf/proto"
 	"github.com/spf13/cobra"
-	"google.golang.org/protobuf/jsonpb"
-	"google.golang.org/protobuf/proto"
 )
 
 var Verbose, OutputJSON bool

--- a/internal/gencli/testdata/service_file.want
+++ b/internal/gencli/testdata/service_file.want
@@ -12,7 +12,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	proto "google.golang.org/protobuf/proto"
+	proto "github.com/golang/protobuf/proto"
 )
 
 var TodoConfig *viper.Viper


### PR DESCRIPTION
Reverts googleapis/gapic-generator-go#1555, which broke gencli generation. The dependency replacement for proto-JSON encoding actually requires an upgrade (it is not a compat api) and the `proto` lib change also requires changes to generated cli code.

Since the gencli isn't a production system and should probably be cleaned up entirely, I'm just reverting this change to unblock development on showcase. What is generated is currently broken.