### PR TITLE
fix: improve imports behavior for helpers.go

### DIFF
--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -230,12 +230,8 @@ func (g *generator) collectServicesAndScopes(genReq *pluginpb.CodeGeneratorReque
 func (g *generator) genAndCommitHelpers(scopes []string) error {
 	p := g.printf
 	g.reset()
-	p("import (")
-	p("%s%q", "\t", "context")
-	p("")
-	p("%s%q", "\t", "google.golang.org/api/option")
-	p(")")
-	p("")
+	g.imports[pbinfo.ImportSpec{Path: "context"}] = true
+	g.imports[pbinfo.ImportSpec{Path: "google.golang.org/api/option"}] = true
 
 	p("// For more information on implementing a client constructor hook, see")
 	p("// https://github.com/googleapis/google-cloud-go/wiki/Customizing-constructors.")

--- a/internal/gengapic/testdata/helpers_default_scope.want
+++ b/internal/gengapic/testdata/helpers_default_scope.want
@@ -1,9 +1,3 @@
-import (
-	"context"
-
-	"google.golang.org/api/option"
-)
-
 // For more information on implementing a client constructor hook, see
 // https://github.com/googleapis/google-cloud-go/wiki/Customizing-constructors.
 type clientHookParams struct{}

--- a/internal/gengapic/testdata/helpers_multiple_scopes.want
+++ b/internal/gengapic/testdata/helpers_multiple_scopes.want
@@ -1,9 +1,3 @@
-import (
-	"context"
-
-	"google.golang.org/api/option"
-)
-
 // For more information on implementing a client constructor hook, see
 // https://github.com/googleapis/google-cloud-go/wiki/Customizing-constructors.
 type clientHookParams struct{}

--- a/internal/gengapic/testdata/helpers_no_scopes.want
+++ b/internal/gengapic/testdata/helpers_no_scopes.want
@@ -1,9 +1,3 @@
-import (
-	"context"
-
-	"google.golang.org/api/option"
-)
-
 // For more information on implementing a client constructor hook, see
 // https://github.com/googleapis/google-cloud-go/wiki/Customizing-constructors.
 type clientHookParams struct{}


### PR DESCRIPTION
The refactor of helper methods from docs.go to helpers.go yielded a double-import, as the previous code yielded the full doc.go directly without leveraging the import management via gengapic's commit mechanism.

This PR removes the static import templating, and transitions to using the import templating available as part of the commit mechanism.