### PR TITLE
feat: support service renaming for snippets

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -245,7 +245,9 @@ func (g *generator) clientInit(serv *descriptorpb.ServiceDescriptorProto, servNa
 func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto, serv *descriptorpb.ServiceDescriptorProto, servName string) error {
 	p := g.printf
 
-	snippetServiceName := servName
+	// This cannot be servName since that is a shortened version and the
+	// addSnippetsMetadataResult function expects the full service name.
+	snippetServiceName := serv.GetName()
 	if override := g.getServiceNameOverride(serv); override != "" {
 		snippetServiceName = override
 	}

--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -160,16 +160,21 @@ func (g *generator) serviceDoc(serv *descriptorpb.ServiceDescriptorProto) {
 		return
 	}
 
+	servName := serv.GetName()
+	if override := g.getServiceNameOverride(serv); override != "" {
+		servName = override
+	}
+
 	// If the service is marked as deprecated and there is no comment, then add default deprecation comment.
 	// If the service has a comment but it does not include a deprecation notice, then append a default deprecation notice.
 	// If the service includes a deprecation notice at the beginning of the comment, prepend a comment stating the service is deprecated and use the included deprecation notice.
 	if serv.GetOptions().GetDeprecated() {
 		if com == "" {
-			com = fmt.Sprintf("\n%s is deprecated.\n\nDeprecated: %[1]s may be removed in a future version.", serv.GetName())
+			com = fmt.Sprintf("\n%s is deprecated.\n\nDeprecated: %[1]s may be removed in a future version.", servName)
 		} else if strings.HasPrefix(com, "Deprecated:") {
-			com = fmt.Sprintf("\n%s is deprecated.\n\n%s", serv.GetName(), com)
+			com = fmt.Sprintf("\n%s is deprecated.\n\n%s", servName, com)
 		} else if !containsDeprecated(com) {
-			com = fmt.Sprintf("%s\n\nDeprecated: %s may be removed in a future version.", com, serv.GetName())
+			com = fmt.Sprintf("%s\n\nDeprecated: %s may be removed in a future version.", com, servName)
 		}
 	}
 	com = strings.TrimSpace(com)
@@ -240,6 +245,10 @@ func (g *generator) clientInit(serv *descriptorpb.ServiceDescriptorProto, servNa
 func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto, serv *descriptorpb.ServiceDescriptorProto, servName string) error {
 	p := g.printf
 
+	snippetServiceName := servName
+	if override := g.getServiceNameOverride(serv); override != "" {
+		snippetServiceName = override
+	}
 	clientTypeName := fmt.Sprintf("%sClient", servName)
 	inType := g.descInfo.Type[m.GetInputType()]
 	inSpec, err := g.descInfo.ImportSpec(inType)
@@ -258,7 +267,7 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 		p("}")
 		p("")
 
-		g.addSnippetsMetadataParams(m, serv.GetName(), reqTyp)
+		g.addSnippetsMetadataParams(m, snippetServiceName, reqTyp)
 		return nil
 	}
 
@@ -277,8 +286,8 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 		p("}")
 		p("")
 
-		g.addSnippetsMetadataParams(m, serv.GetName(), reqTyp)
-		g.addSnippetsMetadataResult(m, serv.GetName(), lroType)
+		g.addSnippetsMetadataParams(m, snippetServiceName, reqTyp)
+		g.addSnippetsMetadataResult(m, snippetServiceName, lroType)
 		return nil
 	}
 
@@ -296,8 +305,8 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 		p("}")
 		p("")
 
-		g.addSnippetsMetadataParams(m, serv.GetName(), reqTyp)
-		g.addSnippetsMetadataResult(m, serv.GetName(), iter.iterTypeName)
+		g.addSnippetsMetadataParams(m, snippetServiceName, reqTyp)
+		g.addSnippetsMetadataResult(m, snippetServiceName, iter.iterTypeName)
 		return nil
 	}
 
@@ -315,8 +324,8 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 		p("}")
 		p("")
 
-		g.addSnippetsMetadataParams(m, serv.GetName(), "")
-		g.addSnippetsMetadataResult(m, serv.GetName(), retTyp)
+		g.addSnippetsMetadataParams(m, snippetServiceName, "")
+		g.addSnippetsMetadataResult(m, snippetServiceName, retTyp)
 		return nil
 	case m.GetServerStreaming():
 		servSpec, err := g.descInfo.ImportSpec(serv)
@@ -332,8 +341,8 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 		p("}")
 		p("")
 
-		g.addSnippetsMetadataParams(m, serv.GetName(), reqTyp)
-		g.addSnippetsMetadataResult(m, serv.GetName(), retTyp)
+		g.addSnippetsMetadataParams(m, snippetServiceName, reqTyp)
+		g.addSnippetsMetadataResult(m, snippetServiceName, retTyp)
 		return nil
 	default:
 		reqTyp := fmt.Sprintf("%s.%s", inSpec.Name, inType.GetName())
@@ -348,8 +357,8 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 		p("}")
 		p("")
 
-		g.addSnippetsMetadataParams(m, serv.GetName(), reqTyp)
-		g.addSnippetsMetadataResult(m, serv.GetName(), retTyp)
+		g.addSnippetsMetadataParams(m, snippetServiceName, reqTyp)
+		g.addSnippetsMetadataResult(m, snippetServiceName, retTyp)
 		return nil
 	}
 

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -652,7 +652,11 @@ func (g *generator) methodDoc(m *descriptorpb.MethodDescriptorProto, serv *descr
 
 	// Prepend the method name to all non-empty comments.
 	com = m.GetName() + " " + lowerFirst(com)
-	g.addSnippetsMetadataDoc(m, serv.GetName(), com)
+	servName := serv.GetName()
+	if override := g.getServiceNameOverride(serv); override != "" {
+		servName = override
+	}
+	g.addSnippetsMetadataDoc(m, servName, com)
 	g.comment(com)
 }
 

--- a/internal/snippets/snippets.go
+++ b/internal/snippets/snippets.go
@@ -18,6 +18,7 @@ package snippets
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"sort"
 	"strings"
@@ -129,6 +130,11 @@ func (sm *SnippetMetadata) UpdateMethodResult(servName, methodName, result strin
 // ctx and opts params are hardcoded since these are currently the same in all client wrapper methods.
 // The req param will be omitted if empty requestType is given.
 func (sm *SnippetMetadata) AddParams(servName, methodName, requestType string) {
+	log.Printf("AddParams: %v %v", servName, methodName)
+	log.Printf("expected SchemaService")
+	for key, value := range sm.protoServices {
+		log.Printf("key[%s] value[%v]", key, value)
+	}
 	m := sm.protoServices[servName].methods[methodName]
 	m.params = []*param{ctxParam}
 	if requestType != "" {

--- a/internal/snippets/snippets.go
+++ b/internal/snippets/snippets.go
@@ -18,7 +18,6 @@ package snippets
 
 import (
 	"fmt"
-	"log"
 	"regexp"
 	"sort"
 	"strings"
@@ -130,11 +129,6 @@ func (sm *SnippetMetadata) UpdateMethodResult(servName, methodName, result strin
 // ctx and opts params are hardcoded since these are currently the same in all client wrapper methods.
 // The req param will be omitted if empty requestType is given.
 func (sm *SnippetMetadata) AddParams(servName, methodName, requestType string) {
-	log.Printf("AddParams: %v %v", servName, methodName)
-	log.Printf("expected SchemaService")
-	for key, value := range sm.protoServices {
-		log.Printf("key[%s] value[%v]", key, value)
-	}
 	m := sm.protoServices[servName].methods[methodName]
 	m.params = []*param{ctxParam}
 	if requestType != "" {


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-go/issues/12063

Verified that this generates the Pub/Sub snippets correctly running on local copy of googleapis/googleapis