### PR TITLE
chore: update showcase to go 1.23

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,7 +89,7 @@ com_googleapis_gapic_generator_go_repositories()
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
-go_register_toolchains(version = "1.22.11")
+go_register_toolchains(version = "1.23.9")
 
 go_rules_dependencies()
 

--- a/showcase/go.mod
+++ b/showcase/go.mod
@@ -1,6 +1,6 @@
 module showcase
 
-go 1.22.7
+go 1.23.0
 
 require (
 	cloud.google.com/go v0.118.2


### PR DESCRIPTION
Needed for some deps. Also updated bazel workspaces Go version as this will be needed for building the code.