### PR TITLE
feat(gengapic): conditionally enable directpath for storagecontrol

### DIFF
--- a/internal/gengapic/generator.go
+++ b/internal/gengapic/generator.go
@@ -41,6 +41,13 @@ var enableWrapperTypesForPageSize = map[string]bool{
 	"google.cloud.bigquery.v2": true,
 }
 
+// keyed by the API + service name joined by "/", e.g. "storage.googleapis.com/StorageControl".
+var enableDirectPath = map[string]bool{
+	"storage.googleapis.com/StorageControl": true,
+	// for test purposes.
+	"showcase.googleapis.com/Foo": true,
+}
+
 type generator struct {
 	pt printer.P
 

--- a/internal/gengapic/gengrpc.go
+++ b/internal/gengapic/gengrpc.go
@@ -185,6 +185,10 @@ func (g *generator) grpcClientOptions(serv *descriptorpb.ServiceDescriptorProto,
 	p("    internaloption.WithDefaultUniverseDomain(%q),", googleDefaultUniverse)
 	p("    internaloption.WithDefaultAudience(%q),", generateDefaultAudience(host))
 	p("    internaloption.WithDefaultScopes(DefaultAuthScopes()...),")
+	if _, ok := enableDirectPath[fmt.Sprintf("%s/%s", g.serviceConfig.GetName(), servName)]; ok {
+		p("    internaloption.EnableDirectPath(true),")
+		p("    internaloption.EnableDirectPathXds(),")
+	}
 	p("    internaloption.EnableJwtWithScope(),")
 	p("    internaloption.EnableNewAuthLibrary(),")
 	p("    option.WithGRPCDialOption(grpc.WithDefaultCallOptions(")

--- a/internal/gengapic/testdata/foo_opt.want
+++ b/internal/gengapic/testdata/foo_opt.want
@@ -23,6 +23,8 @@ func defaultFooGRPCClientOptions() []option.ClientOption {
 		internaloption.WithDefaultUniverseDomain("googleapis.com"),
 		internaloption.WithDefaultAudience("https://foo.googleapis.com/"),
 		internaloption.WithDefaultScopes(DefaultAuthScopes()...),
+		internaloption.EnableDirectPath(true),
+		internaloption.EnableDirectPathXds(),
 		internaloption.EnableJwtWithScope(),
 		internaloption.EnableNewAuthLibrary(),
 		option.WithGRPCDialOption(grpc.WithDefaultCallOptions(


### PR DESCRIPTION
Given storagecontrol being the only use case we know, hard-coding it in the generator seems the most convenient approach.

To uniquely identity the service, it uses the API and service name joined by "/".