### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-* @googleapis/actools-go @googleapis/yoshi-go
+* @googleapis/cloud-sdk-go-eng


### PR DESCRIPTION
makes cloud-sdk-go-eng the CODEOWNER, removes legacy ownerships