### PR TITLE
chore: release v0.54.0

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,11 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
 libraries:
   - id: generator
-    version: 0.53.1
+    version: 0.54.0
+    last_generated_commit: ""
+    apis: []
     source_roots:
       - .
-    tag_format: 'v{version}'
+    preserve_regex: []
+    remove_regex: []
+    tag_format: v{version}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Changes
 
+## [0.54.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.54.0) (2025-10-07)
+
+
+### Features
+
+* Conditionally enable directpath for storagecontrol.googleapis.com ([1e451fa](https://github.com/googleapis/gapic-generator-go/commit/1e451faec522cd81ea911853bc4a53315766c2fd))
+* Conditionally enable AllowHardBoundTokens in gengrpc ([0edb451](https://github.com/googleapis/gapic-generator-go/commit/0edb4512ee7e4541592d669e270543f3fc856976))
+
 ## [0.53.1](https://github.com/googleapis/gapic-generator-go/compare/v0.53.0...v0.53.1) (2025-05-30)
 
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.53.1"
+const Version = "0.54.0"


### PR DESCRIPTION
Librarian Version: v0.3.1-0.20251006193731-31a496db4d50&#43;dirty
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go:latest
<details><summary>generator: 0.54.0</summary>

## [0.54.0](https://github.com/quartzmo/gapic-generator-go/compare/v0.53.1...v0.54.0) (2025-10-07)

### Features

* Conditionally enable directpath for storagecontrol.googleapis.com ([1e451fa](https://github.com/googleapis/gapic-generator-go/commit/1e451faec522cd81ea911853bc4a53315766c2fd))
* Conditionally enable AllowHardBoundTokens in gengrpc ([0edb451](https://github.com/googleapis/gapic-generator-go/commit/0edb4512ee7e4541592d669e270543f3fc856976))
</details>