### PR TITLE
harden(rest): escape REST path args in generated clients via url.PathEscape 

### DIFF
--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -522,7 +522,17 @@ func (g *generator) generateBaseURL(info *httpInfo, ret string) {
 		tokens = append(tokens, fmt.Sprintf("req%s", fieldGetter(path[1])))
 	}
 	g.imports[pbinfo.ImportSpec{Path: "fmt"}] = true
-	p("baseUrl.Path += fmt.Sprintf(%s)", strings.Join(tokens, ", "))
+// Emit: baseUrl.Path += fmt.Sprintf("<path format>", url.PathEscape(arg1), url.PathEscape(arg2), ...)
+// tokens[0] is the format string; tokens[1:] are the arguments to fmt.Sprintf.
+if len(tokens) > 1 {
+	for i := 1; i < len(tokens); i++ {
+		t := strings.TrimSpace(tokens[i])
+		if t != "" {
+			tokens[i] = fmt.Sprintf("url.PathEscape(%s)", tokens[i])
+		}
+	}
+}
+p("baseUrl.Path += fmt.Sprintf(%s)", strings.Join(tokens, ", "))
 	p("")
 }
 

--- a/internal/gengapic/testdata/rest_EmptyRPC.want
+++ b/internal/gengapic/testdata/rest_EmptyRPC.want
@@ -6,7 +6,7 @@ func (c *fooRESTClient) EmptyRPC(ctx context.Context, req *foopb.Foo, opts ...ga
 	if err != nil {
 		return err
 	}
-	baseUrl.Path += fmt.Sprintf("/v1/foo/%v", req.GetOther())
+	baseUrl.Path += fmt.Sprintf("/v1/foo/%v", url.PathEscape(req.GetOther()))
 
 	params := url.Values{}
 	if req != nil && req.RequestId != nil {


### PR DESCRIPTION
### Summary
Generated REST clients interpolate request fields into URL paths via `fmt.Sprintf("/.../%v", ...)` without escaping. This can yield ambiguous/malformed URLs when arguments contain `/`, `..`, or reserved characters.

### Fix
Generator now wraps each interpolated path argument with `url.PathEscape(...)`.

**Before**
```go
baseUrl.Path += fmt.Sprintf("/v1/foo/%v", req.GetOther())
**After**
baseUrl.Path += fmt.Sprintf("/v1/foo/%v", url.PathEscape(req.GetOther()))
```
**Impact**
Secure-by-default for generated clients; RFC 3986–compliant component encoding.
Minimal risk: only affects %v args; literals unchanged.
**Tests**
Updated golden: internal/gengapic/testdata/rest_EmptyRPC.want.
go test ./... passes locally.