### PR TITLE
feat(gengapic): implement selective gapic generation

### DIFF
--- a/internal/gengapic/client_init.go
+++ b/internal/gengapic/client_init.go
@@ -46,7 +46,7 @@ func (g *generator) clientOptions(serv *descriptorpb.ServiceDescriptorProto, ser
 		p("// %[1]sCallOptions contains the retry settings for each method of %[1]sClient.", servName)
 		p("type %sCallOptions struct {", servName)
 		for _, m := range methods {
-			p("%s []gax.CallOption", m.GetName())
+			p("%s []gax.CallOption", g.methodName(m))
 		}
 		p("}")
 		p("")
@@ -99,7 +99,7 @@ func (g *generator) internalClientIntfInit(serv *descriptorpb.ServiceDescriptorP
 		g.imports[inSpec] = true
 		if m.GetOutputType() == emptyType {
 			p("%s(context.Context, *%s.%s, ...gax.CallOption) error",
-				m.GetName(),
+				g.methodName(m),
 				inSpec.Name,
 				inType.GetName())
 			continue
@@ -113,7 +113,7 @@ func (g *generator) internalClientIntfInit(serv *descriptorpb.ServiceDescriptorP
 				return err
 			}
 			p("%s(context.Context, *%s.%s, ...gax.CallOption) *%s",
-				m.GetName(),
+				g.methodName(m),
 				inSpec.Name,
 				inType.GetName(),
 				iter.iterTypeName)
@@ -126,17 +126,17 @@ func (g *generator) internalClientIntfInit(serv *descriptorpb.ServiceDescriptorP
 			// longrunning.Operation and more precise types
 			lroType := lroTypeName(m)
 			p("%s(context.Context, *%s.%s, ...gax.CallOption) (*%s, error)",
-				m.GetName(), inSpec.Name, inType.GetName(), lroType)
+				g.methodName(m), inSpec.Name, inType.GetName(), lroType)
 			p("%[1]s(name string) *%[1]s", lroType)
 
 		case m.GetClientStreaming():
 			// Handles both client-streaming and bidi-streaming
 			p("%s(context.Context, ...gax.CallOption) (%s.%s_%sClient, error)",
-				m.GetName(), inSpec.Name, serv.GetName(), m.GetName())
+				g.methodName(m), inSpec.Name, serv.GetName(), m.GetName())
 		case m.GetServerStreaming():
 			// Handles _just_ server streaming
 			p("%s(context.Context, *%s.%s, ...gax.CallOption) (%s.%s_%sClient, error)",
-				m.GetName(), inSpec.Name, inType.GetName(), inSpec.Name, serv.GetName(), m.GetName())
+				g.methodName(m), inSpec.Name, inType.GetName(), inSpec.Name, serv.GetName(), m.GetName())
 		default:
 			retTyp, err := g.returnType(m)
 			if err != nil {
@@ -144,7 +144,7 @@ func (g *generator) internalClientIntfInit(serv *descriptorpb.ServiceDescriptorP
 			}
 
 			p("%s(context.Context, *%s.%s, ...gax.CallOption) (%s, error)",
-				m.GetName(), inSpec.Name, inType.GetName(), retTyp)
+				g.methodName(m), inSpec.Name, inType.GetName(), retTyp)
 		}
 	}
 	p("}")
@@ -272,8 +272,8 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 	if m.GetOutputType() == emptyType {
 		reqTyp := fmt.Sprintf("%s.%s", inSpec.Name, inType.GetName())
 		p("func (c *%s) %s(ctx context.Context, req *%s, opts ...gax.CallOption) error {",
-			clientTypeName, m.GetName(), reqTyp)
-		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
+			clientTypeName, g.methodName(m), reqTyp)
+		p("    return c.internalClient.%s(ctx, req, opts...)", g.methodName(m))
 		p("}")
 		p("")
 
@@ -285,8 +285,8 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 		reqTyp := fmt.Sprintf("%s.%s", inSpec.Name, inType.GetName())
 		lroType := lroTypeName(m)
 		p("func (c *%s) %s(ctx context.Context, req *%s, opts ...gax.CallOption) (*%s, error) {",
-			clientTypeName, m.GetName(), reqTyp, lroType)
-		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
+			clientTypeName, g.methodName(m), reqTyp, lroType)
+		p("    return c.internalClient.%s(ctx, req, opts...)", g.methodName(m))
 		p("}")
 		p("")
 		p("// %s returns a new %[1]s from a given name.", lroType)
@@ -310,8 +310,8 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 			return err
 		}
 		p("func (c *%s) %s(ctx context.Context, req *%s, opts ...gax.CallOption) *%s {",
-			clientTypeName, m.GetName(), reqTyp, iter.iterTypeName)
-		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
+			clientTypeName, g.methodName(m), reqTyp, iter.iterTypeName)
+		p("    return c.internalClient.%s(ctx, req, opts...)", g.methodName(m))
 		p("}")
 		p("")
 
@@ -329,8 +329,8 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 
 		retTyp := fmt.Sprintf("%s.%s_%sClient", servSpec.Name, serv.GetName(), m.GetName())
 		p("func (c *%s) %s(ctx context.Context, opts ...gax.CallOption) (%s, error) {",
-			clientTypeName, m.GetName(), retTyp)
-		p("    return c.internalClient.%s(ctx, opts...)", m.GetName())
+			clientTypeName, g.methodName(m), retTyp)
+		p("    return c.internalClient.%s(ctx, opts...)", g.methodName(m))
 		p("}")
 		p("")
 
@@ -346,8 +346,8 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 		reqTyp := fmt.Sprintf("%s.%s", inSpec.Name, inType.GetName())
 		retTyp := fmt.Sprintf("%s.%s_%sClient", servSpec.Name, serv.GetName(), m.GetName())
 		p("func (c *%s) %s(ctx context.Context, req *%s, opts ...gax.CallOption) (%s, error) {",
-			clientTypeName, m.GetName(), reqTyp, retTyp)
-		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
+			clientTypeName, g.methodName(m), reqTyp, retTyp)
+		p("    return c.internalClient.%s(ctx, req, opts...)", g.methodName(m))
 		p("}")
 		p("")
 
@@ -362,8 +362,8 @@ func (g *generator) genClientWrapperMethod(m *descriptorpb.MethodDescriptorProto
 		}
 
 		p("func (c *%s) %s(ctx context.Context, req *%s, opts ...gax.CallOption) (%s, error) {",
-			clientTypeName, m.GetName(), reqTyp, retTyp)
-		p("    return c.internalClient.%s(ctx, req, opts...)", m.GetName())
+			clientTypeName, g.methodName(m), reqTyp, retTyp)
+		p("    return c.internalClient.%s(ctx, req, opts...)", g.methodName(m))
 		p("}")
 		p("")
 

--- a/internal/gengapic/client_init_test.go
+++ b/internal/gengapic/client_init_test.go
@@ -397,6 +397,24 @@ func TestClientInit(t *testing.T) {
 			},
 		},
 	}
+	servSelective := &descriptorpb.ServiceDescriptorProto{
+		Name: proto.String("Foo"),
+		Method: []*descriptorpb.MethodDescriptorProto{
+			{
+				Name:       proto.String("Zip"),
+				InputType:  proto.String(".mypackage.Bar"),
+				OutputType: proto.String(".mypackage.Foo"),
+				Options:    &descriptorpb.MethodOptions{},
+			},
+			{
+				Name:       proto.String("Zap"),
+				InputType:  proto.String(".mypackage.Bar"),
+				OutputType: proto.String(".mypackage.Foo"),
+				Options:    &descriptorpb.MethodOptions{},
+			},
+		},
+		Options: &descriptorpb.ServiceOptions{},
+	}
 	for _, s := range []*descriptorpb.ServiceDescriptorProto{servPlain, servDeprecated, servLRO} {
 		proto.SetExtension(s.Method[0].GetOptions(), annotations.E_Http, &annotations.HttpRule{
 			Pattern: &annotations.HttpRule_Get{
@@ -404,6 +422,16 @@ func TestClientInit(t *testing.T) {
 			},
 		})
 	}
+	proto.SetExtension(servSelective.Method[0].GetOptions(), annotations.E_Http, &annotations.HttpRule{
+		Pattern: &annotations.HttpRule_Get{
+			Get: "/zip",
+		},
+	})
+	proto.SetExtension(servSelective.Method[1].GetOptions(), annotations.E_Http, &annotations.HttpRule{
+		Pattern: &annotations.HttpRule_Get{
+			Get: "/zap",
+		},
+	})
 
 	for _, tst := range []struct {
 		tstName      string
@@ -416,6 +444,7 @@ func TestClientInit(t *testing.T) {
 		wantNumSnps  int
 		setExt       func() (protoreflect.ExtensionType, interface{})
 		features     []featureID
+		publishing   *annotations.Publishing
 	}{
 		{
 			tstName: "foo_client_init_default",
@@ -696,6 +725,36 @@ func TestClientInit(t *testing.T) {
 			},
 			features: []featureID{OpenTelemetryAttributesFeature},
 		},
+		{
+			tstName:  "selective_gapic_client_init",
+			servName: "BaseFoo",
+			serv:     servSelective,
+			parameter: proto.String("go-gapic-package=path;mypackage,F_selective_gapic_generation"),
+			imports: map[pbinfo.ImportSpec]bool{
+				{Path: "context"}:                                                  true,
+				{Path: "google.golang.org/api/option"}:                              true,
+				{Path: "google.golang.org/grpc"}:                                     true,
+				{Name: "gtransport", Path: "google.golang.org/api/transport/grpc"}:  true,
+				{Name: "mypackagepb", Path: "github.com/googleapis/mypackage"}:      true,
+				{Path: "log/slog"}:                                                 true,
+			},
+			wantNumSnps: 2,
+			features:    []featureID{SelectiveGapicGenerationFeature},
+			publishing: &annotations.Publishing{
+				LibrarySettings: []*annotations.ClientLibrarySettings{
+					{
+						GoSettings: &annotations.GoSettings{
+							Common: &annotations.CommonLanguageSettings{
+								SelectiveGapicGeneration: &annotations.SelectiveGapicGeneration{
+									GenerateOmittedAsInternal: true,
+									Methods:                   []string{"mypackage.Foo.Zip"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	} {
 		t.Run(tst.tstName, func(t *testing.T) {
 			setExt := tst.setExt
@@ -749,6 +808,7 @@ func TestClientInit(t *testing.T) {
 					{Name: "google.cloud.location.Locations"},
 					{Name: "google.longrunning.Operations"},
 				},
+				Publishing: tst.publishing,
 			}
 
 			g.aux.customOp = &customOp{

--- a/internal/gengapic/custom_operation.go
+++ b/internal/gengapic/custom_operation.go
@@ -70,7 +70,7 @@ func (g *generator) customOpPointerType() (string, error) {
 // operation wrapper type with the Go identifier for a variable that is the
 // proto-defined operation type.
 func (g *generator) customOpInit(rspVar, reqVar, opVar string, req *descriptorpb.DescriptorProto, s *descriptorpb.ServiceDescriptorProto) {
-	h := handleName(s.GetName(), g.cfg.pkgName)
+	h := g.handleName(s)
 	opName := g.aux.customOp.message.GetName()
 	pt := g.pt.Printf
 
@@ -199,8 +199,8 @@ func (g *generator) customOperationType() error {
 
 	for _, handle := range op.handles {
 		pollingParams := op.pollingParams[handle]
-		s := pbinfo.ReduceServName(handle.GetName(), opImp.Name)
-		n := handleName(handle.GetName(), opImp.Name)
+		s := g.clientName(handle, opImp.Name)
+		n := g.handleName(handle)
 
 		// Look up polling method and its input.
 		poll := operationPollingMethod(handle)
@@ -417,7 +417,11 @@ func (g *generator) pollingRequestParameters(m *descriptorpb.MethodDescriptorPro
 
 // handleName is a helper for constructing a operation handle name from the
 // operation service name and Go package name.
-func handleName(s, pkg string) string {
-	s = pbinfo.ReduceServName(s, pkg)
-	return lowerFirst(s + "Handle")
+func (g *generator) handleName(s *descriptorpb.ServiceDescriptorProto) string {
+	pkgName := ""
+	if g.cfg != nil {
+		pkgName = g.cfg.pkgName
+	}
+	name := g.clientName(s, pkgName)
+	return lowerFirst(name + "Handle")
 }

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/googleapis/gapic-generator-go/internal/license"
-	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
 	"github.com/googleapis/gapic-generator-go/internal/printer"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
@@ -91,8 +90,7 @@ func (g *generator) genDocFile(year int, services []*descriptorpb.ServiceDescrip
 	p("// To get started with this package, create a client.")
 	// Code block for client creation
 	exampleService := services[0]
-	override := g.getServiceNameOverride(exampleService)
-	servName := pbinfo.ReduceServNameWithOverride(exampleService.GetName(), g.cfg.pkgName, override)
+	servName := g.clientName(exampleService, g.cfg.pkgName)
 	tmpClient := g.pt
 	g.pt = printer.P{}
 	g.exampleInitClientWithOpts(g.cfg.pkgName, servName, true)
@@ -201,8 +199,7 @@ func (g *generator) apiVersionSection(services []*descriptorpb.ServiceDescriptor
 
 		// Construct the reduced/overridden service name used for client
 		// type name derivation.
-		override := g.getServiceNameOverride(s)
-		sn := pbinfo.ReduceServNameWithOverride(n, g.cfg.pkgName, override)
+		sn := g.clientName(s, g.cfg.pkgName)
 		ct := fmt.Sprintf("%sClient", sn)
 
 		// Use the raw proto service name in the tuple to associate it with

--- a/internal/gengapic/doc_file.go
+++ b/internal/gengapic/doc_file.go
@@ -90,6 +90,7 @@ func (g *generator) genDocFile(year int, services []*descriptorpb.ServiceDescrip
 	p("// To get started with this package, create a client.")
 	// Code block for client creation
 	exampleService := services[0]
+	g.clientProtoPkg = g.descInfo.ParentFile[exampleService].GetPackage()
 	servName := g.clientName(exampleService, g.cfg.pkgName)
 	tmpClient := g.pt
 	g.pt = printer.P{}
@@ -199,6 +200,7 @@ func (g *generator) apiVersionSection(services []*descriptorpb.ServiceDescriptor
 
 		// Construct the reduced/overridden service name used for client
 		// type name derivation.
+		g.clientProtoPkg = g.descInfo.ParentFile[s].GetPackage()
 		sn := g.clientName(s, g.cfg.pkgName)
 		ct := fmt.Sprintf("%sClient", sn)
 

--- a/internal/gengapic/example.go
+++ b/internal/gengapic/example.go
@@ -26,8 +26,7 @@ import (
 
 func (g *generator) genExampleFile(serv *descriptorpb.ServiceDescriptorProto) error {
 	pkgName := g.cfg.pkgName
-	override := g.getServiceNameOverride(serv)
-	servName := pbinfo.ReduceServNameWithOverride(serv.GetName(), pkgName, override)
+	servName := g.clientName(serv, pkgName)
 
 	g.exampleClientFactory(pkgName, servName)
 
@@ -43,8 +42,7 @@ func (g *generator) genExampleFile(serv *descriptorpb.ServiceDescriptorProto) er
 
 func (g *generator) genExampleIteratorFile(serv *descriptorpb.ServiceDescriptorProto) error {
 	pkgName := g.cfg.pkgName
-	override := g.getServiceNameOverride(serv)
-	servName := pbinfo.ReduceServNameWithOverride(serv.GetName(), pkgName, override)
+	servName := g.clientName(serv, pkgName)
 	methods := append(serv.GetMethod(), g.getMixinMethods()...)
 	for _, m := range methods {
 		// Don't need streaming RPCs
@@ -80,7 +78,7 @@ func (g *generator) genExampleIteratorFile(serv *descriptorpb.ServiceDescriptorP
 		if t == rest {
 			s += "REST"
 		}
-		p("func Example%sClient_%s_all() {", servName, m.GetName())
+		p("func Example%sClient_%s_all() {", servName, g.methodName(m))
 		g.exampleInitClient(pkgName, s)
 
 		p("")
@@ -150,7 +148,7 @@ func (g *generator) exampleMethod(pkgName, servName string, m *descriptorpb.Meth
 
 	p := g.printf
 
-	p("func Example%sClient_%s() {", servName, m.GetName())
+	p("func Example%sClient_%s() {", servName, g.methodName(m))
 	if err := g.exampleMethodBody(pkgName, servName, m); err != nil {
 		return err
 	}
@@ -246,7 +244,7 @@ func (g *generator) exampleLROCall(m *descriptorpb.MethodDescriptorProto) {
 		retVars = "err ="
 	}
 
-	p("op, err := c.%s(ctx, req)", *m.Name)
+	p("op, err := c.%s(ctx, req)", g.methodName(m))
 	p("if err != nil {")
 	p("  // TODO: Handle error.")
 	p("}")
@@ -266,7 +264,7 @@ func (g *generator) exampleLROCall(m *descriptorpb.MethodDescriptorProto) {
 func (g *generator) exampleUnaryCall(m *descriptorpb.MethodDescriptorProto) {
 	p := g.printf
 
-	p("resp, err := c.%s(ctx, req)", *m.Name)
+	p("resp, err := c.%s(ctx, req)", g.methodName(m))
 	p("if err != nil {")
 	p("  // TODO: Handle error.")
 	p("}")
@@ -277,7 +275,7 @@ func (g *generator) exampleUnaryCall(m *descriptorpb.MethodDescriptorProto) {
 func (g *generator) exampleEmptyCall(m *descriptorpb.MethodDescriptorProto) {
 	p := g.printf
 
-	p("err = c.%s(ctx, req)", *m.Name)
+	p("err = c.%s(ctx, req)", g.methodName(m))
 	p("if err != nil {")
 	p("  // TODO: Handle error.")
 	p("}")
@@ -296,7 +294,7 @@ func (g *generator) examplePagingCall(m *descriptorpb.MethodDescriptorProto) err
 
 	p := g.printf
 
-	p("it := c.%s(ctx, req)", m.GetName())
+	p("it := c.%s(ctx, req)", g.methodName(m))
 	p("for {")
 	p("  resp, err := it.Next()")
 	p("  if err == iterator.Done {")
@@ -333,7 +331,7 @@ func (g *generator) examplePagingAllCall(m *descriptorpb.MethodDescriptorProto) 
 
 	p := g.printf
 
-	p("for resp, err := range c.%s(ctx, req).All() {", m.GetName())
+	p("for resp, err := range c.%s(ctx, req).All() {", g.methodName(m))
 	p("  if err != nil {")
 	p("    // TODO: Handle error and break/return/continue. Iteration will stop after any error.")
 	p("  }")
@@ -347,7 +345,7 @@ func (g *generator) examplePagingAllCall(m *descriptorpb.MethodDescriptorProto) 
 func (g *generator) exampleBidiCall(m *descriptorpb.MethodDescriptorProto, inType pbinfo.ProtoType, inSpec pbinfo.ImportSpec) {
 	p := g.printf
 
-	p("stream, err := c.%s(ctx)", m.GetName())
+	p("stream, err := c.%s(ctx)", g.methodName(m))
 	p("if err != nil {")
 	p("  // TODO: Handle error.")
 	p("}")

--- a/internal/gengapic/example_test.go
+++ b/internal/gengapic/example_test.go
@@ -304,6 +304,7 @@ func TestGenSnippetFile(t *testing.T) {
 	g.imports = map[pbinfo.ImportSpec]bool{}
 
 	serv := sample.Service()
+	g.cfg = &generatorConfig{}
 	g.snippetMetadata = snippets.NewMetadata(sample.ProtoPackagePath, sample.GoPackagePath, sample.GoPackageName)
 	g.snippetMetadata.AddService(serv.GetName(), sample.ServiceURL)
 
@@ -342,6 +343,9 @@ func TestGenSnippetFile(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			g.reset()
 			g.cfg = test.cfg
+			g.descInfo.ParentElement = map[pbinfo.ProtoType]pbinfo.ProtoType{
+				serv.Method[0]: serv,
+			}
 			err := g.genSnippetFile(serv, serv.Method[0])
 			if err != nil {
 				t.Fatal(err)

--- a/internal/gengapic/feature.go
+++ b/internal/gengapic/feature.go
@@ -34,6 +34,7 @@ const (
 	MTLSHardBoundTokensFeature       featureID = "mtls_hard_bound_tokens"
 	OpenTelemetryAttributesFeature   featureID = "open_telemetry_attributes"
 	DynamicResourceHeuristicsFeature featureID = "dynamic_resource_heuristics"
+	SelectiveGapicGenerationFeature  featureID = "selective_gapic_generation"
 )
 
 // featureRegistry contains the registry of defined features.
@@ -42,6 +43,9 @@ const (
 // who attempt to do so will be given a stern talking to.
 var featureRegistry = map[featureID]*featureInfo{
 
+	SelectiveGapicGenerationFeature: {
+		Description: "Enable selective GAPIC generation and internal methods routing",
+	},
 	OpenTelemetryAttributesFeature: {
 		Description: "Enable OpenTelemetry attributes support (Service Identity, Resource Names, URL Templates).",
 		TrackingID:  "b/467342602,b/467403185",

--- a/internal/gengapic/generator.go
+++ b/internal/gengapic/generator.go
@@ -328,6 +328,9 @@ func (g *generator) autoPopulatedFields(_ string, m *descriptorpb.MethodDescript
 
 // getServiceNameOverride checks to see if the service has a defined service name override.
 func (g *generator) getServiceNameOverride(s *descriptorpb.ServiceDescriptorProto) string {
+	if g.cfg == nil || g.cfg.APIServiceConfig == nil || g.cfg.APIServiceConfig.GetPublishing() == nil {
+		return ""
+	}
 	ls := g.cfg.APIServiceConfig.GetPublishing().GetLibrarySettings()
 	if len(ls) == 0 {
 		return ""
@@ -340,4 +343,81 @@ func (g *generator) getServiceNameOverride(s *descriptorpb.ServiceDescriptorProt
 	}
 
 	return ""
+}
+
+// getSelectiveGapicGeneration returns the SelectiveGapicGeneration config if it is present and the feature is enabled.
+func (g *generator) getSelectiveGapicGeneration() *annotations.SelectiveGapicGeneration {
+	if g.cfg == nil {
+		return nil
+	}
+	if _, ok := g.cfg.featureEnablement[SelectiveGapicGenerationFeature]; !ok {
+		return nil
+	}
+	if g.cfg.APIServiceConfig == nil || g.cfg.APIServiceConfig.GetPublishing() == nil {
+		return nil
+	}
+	ls := g.cfg.APIServiceConfig.GetPublishing().GetLibrarySettings()
+	if len(ls) == 0 {
+		return nil
+	}
+	if goSettings := ls[0].GetGoSettings(); goSettings != nil && goSettings.GetCommon() != nil && goSettings.GetCommon().GetSelectiveGapicGeneration() != nil {
+		return goSettings.GetCommon().GetSelectiveGapicGeneration()
+	}
+	return nil
+}
+
+// isInternalMethod determines if a method should be generated as internal based on SelectiveGapicGeneration config.
+func (g *generator) isInternalMethod(fqn string) bool {
+	sgg := g.getSelectiveGapicGeneration()
+	if sgg == nil || !sgg.GetGenerateOmittedAsInternal() {
+		return false
+	}
+	for _, m := range sgg.GetMethods() {
+		if m == fqn {
+			return false
+		}
+	}
+	return true
+}
+
+// isInternalService determines if a service should be treated as internal (i.e. has at least one internal method).
+func (g *generator) isInternalService(s *descriptorpb.ServiceDescriptorProto) bool {
+	sgg := g.getSelectiveGapicGeneration()
+	if sgg == nil || !sgg.GetGenerateOmittedAsInternal() {
+		return false
+	}
+
+	// A service is internal if it has any internal methods
+	for _, m := range append(s.GetMethod(), g.getMixinMethods()...) {
+		parent := g.descInfo.ParentElement[m].(*descriptorpb.ServiceDescriptorProto)
+		fqn := fmt.Sprintf("%s.%s.%s", g.descInfo.ParentFile[parent].GetPackage(), parent.GetName(), m.GetName())
+		if g.isInternalMethod(fqn) {
+			return true
+		}
+	}
+	return false
+}
+
+// methodName returns the appropriate Go method name (exported or unexported) for a given RPC.
+func (g *generator) methodName(m *descriptorpb.MethodDescriptorProto) string {
+	sgg := g.getSelectiveGapicGeneration()
+	if sgg == nil || !sgg.GetGenerateOmittedAsInternal() {
+		return m.GetName()
+	}
+	parent := g.descInfo.ParentElement[m].(*descriptorpb.ServiceDescriptorProto)
+	fqn := fmt.Sprintf("%s.%s.%s", g.descInfo.ParentFile[parent].GetPackage(), parent.GetName(), m.GetName())
+	if g.isInternalMethod(fqn) {
+		return lowerFirst(m.GetName())
+	}
+	return m.GetName()
+}
+
+// clientName returns the appropriate Go client name for a given service.
+func (g *generator) clientName(s *descriptorpb.ServiceDescriptorProto, pkgName string) string {
+	override := g.getServiceNameOverride(s)
+	servName := pbinfo.ReduceServNameWithOverride(s.GetName(), pkgName, override)
+	if g.isInternalService(s) {
+		servName = "Base" + servName
+	}
+	return servName
 }

--- a/internal/gengapic/generator.go
+++ b/internal/gengapic/generator.go
@@ -75,6 +75,9 @@ type generator struct {
 
 	// learned vocabulary for heuristic path templates
 	vocabulary map[string]bool
+
+	// clientProtoPkg is the proto package of the service currently being generated.
+	clientProtoPkg string
 }
 
 func newGenerator(req *pluginpb.CodeGeneratorRequest) (*generator, error) {
@@ -332,21 +335,27 @@ func (g *generator) getServiceNameOverride(s *descriptorpb.ServiceDescriptorProt
 		return ""
 	}
 	ls := g.cfg.APIServiceConfig.GetPublishing().GetLibrarySettings()
-	if len(ls) == 0 {
-		return ""
-	}
 
-	renamedServices := ls[0].GetGoSettings().GetRenamedServices()
+	protoPkg := g.descInfo.ParentFile[s].GetPackage()
 
-	if v, ok := renamedServices[s.GetName()]; ok {
-		return v
+	for _, setting := range ls {
+		if setting.GetVersion() != "" && setting.GetVersion() != protoPkg {
+			continue
+		}
+		if goSettings := setting.GetGoSettings(); goSettings != nil {
+			if renamedServices := goSettings.GetRenamedServices(); renamedServices != nil {
+				if v, ok := renamedServices[s.GetName()]; ok {
+					return v
+				}
+			}
+		}
 	}
 
 	return ""
 }
 
 // getSelectiveGapicGeneration returns the SelectiveGapicGeneration config if it is present and the feature is enabled.
-func (g *generator) getSelectiveGapicGeneration() *annotations.SelectiveGapicGeneration {
+func (g *generator) getSelectiveGapicGeneration(protoPkg string) *annotations.SelectiveGapicGeneration {
 	if g.cfg == nil {
 		return nil
 	}
@@ -357,18 +366,22 @@ func (g *generator) getSelectiveGapicGeneration() *annotations.SelectiveGapicGen
 		return nil
 	}
 	ls := g.cfg.APIServiceConfig.GetPublishing().GetLibrarySettings()
-	if len(ls) == 0 {
-		return nil
+
+	for _, setting := range ls {
+		if setting.GetVersion() != "" && setting.GetVersion() != protoPkg {
+			continue
+		}
+		if goSettings := setting.GetGoSettings(); goSettings != nil && goSettings.GetCommon() != nil && goSettings.GetCommon().GetSelectiveGapicGeneration() != nil {
+			return goSettings.GetCommon().GetSelectiveGapicGeneration()
+		}
 	}
-	if goSettings := ls[0].GetGoSettings(); goSettings != nil && goSettings.GetCommon() != nil && goSettings.GetCommon().GetSelectiveGapicGeneration() != nil {
-		return goSettings.GetCommon().GetSelectiveGapicGeneration()
-	}
+
 	return nil
 }
 
 // isInternalMethod determines if a method should be generated as internal based on SelectiveGapicGeneration config.
-func (g *generator) isInternalMethod(fqn string) bool {
-	sgg := g.getSelectiveGapicGeneration()
+func (g *generator) isInternalMethod(protoPkg, fqn string) bool {
+	sgg := g.getSelectiveGapicGeneration(protoPkg)
 	if sgg == nil || !sgg.GetGenerateOmittedAsInternal() {
 		return false
 	}
@@ -382,7 +395,8 @@ func (g *generator) isInternalMethod(fqn string) bool {
 
 // isInternalService determines if a service should be treated as internal (i.e. has at least one internal method).
 func (g *generator) isInternalService(s *descriptorpb.ServiceDescriptorProto) bool {
-	sgg := g.getSelectiveGapicGeneration()
+	protoPkg := g.descInfo.ParentFile[s].GetPackage()
+	sgg := g.getSelectiveGapicGeneration(protoPkg)
 	if sgg == nil || !sgg.GetGenerateOmittedAsInternal() {
 		return false
 	}
@@ -391,7 +405,7 @@ func (g *generator) isInternalService(s *descriptorpb.ServiceDescriptorProto) bo
 	for _, m := range append(s.GetMethod(), g.getMixinMethods()...) {
 		parent := g.descInfo.ParentElement[m].(*descriptorpb.ServiceDescriptorProto)
 		fqn := fmt.Sprintf("%s.%s.%s", g.descInfo.ParentFile[parent].GetPackage(), parent.GetName(), m.GetName())
-		if g.isInternalMethod(fqn) {
+		if g.isInternalMethod(protoPkg, fqn) {
 			return true
 		}
 	}
@@ -400,13 +414,50 @@ func (g *generator) isInternalService(s *descriptorpb.ServiceDescriptorProto) bo
 
 // methodName returns the appropriate Go method name (exported or unexported) for a given RPC.
 func (g *generator) methodName(m *descriptorpb.MethodDescriptorProto) string {
-	sgg := g.getSelectiveGapicGeneration()
+	// 1. Determine the logical API package context.
+	//
+	// When we generate mixin methods (like IAM's GetIamPolicy or LRO's GetOperation),
+	// their raw Protobuf definitions live in generic packages like `google.iam.v1`
+	// rather than the specific service package being generated (e.g. `google.example.v1`).
+	//
+	// However, the `service.yaml` publishing settings (including the SGG allowlist)
+	// that govern these mixins are defined under the *current service's* version block
+	// (e.g. `version: google.example.v1`).
+	//
+	// Therefore, to look up the correct SGG config, we must use `g.clientProtoPkg`
+	// (the package of the service we are *currently generating a client for*),
+	// rather than the package where the raw method was originally defined.
+	protoPkg := g.clientProtoPkg
+
+	// 2. Fallback for testing environments.
+	//
+	// In some narrow unit testing contexts (like `TestDocFile`), `g.clientProtoPkg`
+	// might not be explicitly populated. In these cases, we fall back to reading
+	// the package directly from the method's parent service.
+	if protoPkg == "" {
+		if parent, ok := g.descInfo.ParentElement[m].(*descriptorpb.ServiceDescriptorProto); ok && parent != nil {
+			protoPkg = g.descInfo.ParentFile[parent].GetPackage()
+		}
+	}
+
+	// 3. Look up the Selective GAPIC config.
+	sgg := g.getSelectiveGapicGeneration(protoPkg)
 	if sgg == nil || !sgg.GetGenerateOmittedAsInternal() {
 		return m.GetName()
 	}
-	parent := g.descInfo.ParentElement[m].(*descriptorpb.ServiceDescriptorProto)
+
+	// 4. Construct the Fully Qualified Name (FQN) of the method.
+	// We MUST use the method's *original* package and service name for the FQN,
+	// because that is how it is referenced in the `service.yaml` allowlist
+	// (e.g. `methods: ["google.iam.v1.IAMPolicy.GetIamPolicy"]`).
+	parent, ok := g.descInfo.ParentElement[m].(*descriptorpb.ServiceDescriptorProto)
+	if !ok || parent == nil {
+		return m.GetName()
+	}
 	fqn := fmt.Sprintf("%s.%s.%s", g.descInfo.ParentFile[parent].GetPackage(), parent.GetName(), m.GetName())
-	if g.isInternalMethod(fqn) {
+
+	// 5. Evaluate visibility.
+	if g.isInternalMethod(protoPkg, fqn) {
 		return lowerFirst(m.GetName())
 	}
 	return m.GetName()

--- a/internal/gengapic/generator_test.go
+++ b/internal/gengapic/generator_test.go
@@ -138,3 +138,80 @@ func TestAutoPopulatedFields(t *testing.T) {
 		t.Errorf("got(-),want(+):\n%s", diff)
 	}
 }
+
+func TestSelectiveGapicGeneration(t *testing.T) {
+	file := &descriptorpb.FileDescriptorProto{
+		Package: proto.String("my.pkg"),
+		Options: &descriptorpb.FileOptions{
+			GoPackage: proto.String("mypackage"),
+		},
+	}
+	m := &descriptorpb.MethodDescriptorProto{
+		Name: proto.String("InternalMethod"),
+	}
+	m2 := &descriptorpb.MethodDescriptorProto{
+		Name: proto.String("PublicMethod"),
+	}
+	serv := &descriptorpb.ServiceDescriptorProto{
+		Name:   proto.String("Foo"),
+		Method: []*descriptorpb.MethodDescriptorProto{m, m2},
+	}
+
+	var g generator
+	g.cfg = &generatorConfig{
+		pkgName: "pkg",
+		featureEnablement: map[featureID]struct{}{
+			SelectiveGapicGenerationFeature: {},
+		},
+	}
+	g.descInfo.ParentElement = map[pbinfo.ProtoType]pbinfo.ProtoType{
+		m:  serv,
+		m2: serv,
+	}
+	g.descInfo.ParentFile = map[proto.Message]*descriptorpb.FileDescriptorProto{
+		serv: file,
+		m:    file,
+		m2:   file,
+	}
+
+	if g.isInternalService(serv) {
+		t.Errorf("expected isInternalService to be false when config is missing")
+	}
+
+	g.cfg.APIServiceConfig = &serviceconfig.Service{
+		Publishing: &annotations.Publishing{
+			LibrarySettings: []*annotations.ClientLibrarySettings{
+				{
+					GoSettings: &annotations.GoSettings{
+						Common: &annotations.CommonLanguageSettings{
+							SelectiveGapicGeneration: &annotations.SelectiveGapicGeneration{
+								GenerateOmittedAsInternal: true,
+								Methods:                   []string{"my.pkg.Foo.PublicMethod"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !g.isInternalService(serv) {
+		t.Errorf("expected isInternalService to be true")
+	}
+
+	if g.methodName(m) != "internalMethod" {
+		t.Errorf("expected methodName(m) to be 'internalMethod', got %q", g.methodName(m))
+	}
+
+	if g.methodName(m2) != "PublicMethod" {
+		t.Errorf("expected methodName(m2) to be 'PublicMethod', got %q", g.methodName(m2))
+	}
+
+	if got := g.clientName(serv, "pkg"); got != "BaseFoo" {
+		t.Errorf("expected clientName to be 'BaseFoo', got %q", got)
+	}
+
+	if got := g.clientName(serv, "Foo"); got != "Base" {
+		t.Errorf("expected clientName to be 'Base', got %q", got)
+	}
+}

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -110,6 +110,7 @@ func gen(genReq *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorResponse
 		// so even though the client for LoggingServiceV2 is just "Client"
 		// the file name is "logging_client.go".
 		// Keep the current behavior for now, but we could revisit this later.
+		g.clientProtoPkg = g.descInfo.ParentFile[s].GetPackage()
 		servName := g.clientName(s, "")
 		outFile := camelToSnake(servName)
 		outFile = filepath.Join(g.cfg.outDir, outFile)

--- a/internal/gengapic/gengapic.go
+++ b/internal/gengapic/gengapic.go
@@ -110,8 +110,7 @@ func gen(genReq *pluginpb.CodeGeneratorRequest) (*pluginpb.CodeGeneratorResponse
 		// so even though the client for LoggingServiceV2 is just "Client"
 		// the file name is "logging_client.go".
 		// Keep the current behavior for now, but we could revisit this later.
-		override := g.getServiceNameOverride(s)
-		servName := pbinfo.ReduceServNameWithOverride(s.GetName(), "", override)
+		servName := g.clientName(s, "")
 		outFile := camelToSnake(servName)
 		outFile = filepath.Join(g.cfg.outDir, outFile)
 
@@ -340,8 +339,7 @@ func (g *generator) genAndCommitHelpers(scopes []string) error {
 // gen generates client for the given service.
 func (g *generator) gen(serv *descriptorpb.ServiceDescriptorProto) error {
 	// If using service name overrides, use that directly for the rest of generation.
-	override := g.getServiceNameOverride(serv)
-	servName := pbinfo.ReduceServNameWithOverride(serv.GetName(), g.cfg.pkgName, override)
+	servName := g.clientName(serv, g.cfg.pkgName)
 
 	g.clientHook(servName)
 	if err := g.clientOptions(serv, servName); err != nil {
@@ -692,7 +690,7 @@ func (g *generator) lookupField(msgName, field string) *descriptorpb.FieldDescri
 }
 
 func (g *generator) appendCallOpts(m *descriptorpb.MethodDescriptorProto) {
-	g.printf("opts = append(%[1]s[0:len(%[1]s):len(%[1]s)], opts...)", "(*c.CallOptions)."+*m.Name)
+	g.printf("opts = append(%[1]s[0:len(%[1]s):len(%[1]s)], opts...)", "(*c.CallOptions)."+g.methodName(m))
 }
 
 func (g *generator) injectTelemetryContext(m *descriptorpb.MethodDescriptorProto, info *httpInfo) {
@@ -741,17 +739,17 @@ func (g *generator) methodDoc(m *descriptorpb.MethodDescriptorProto, serv *descr
 	// If the method includes a deprecation notice at the beginning of the comment, prepend a comment stating the method is deprecated and use the included deprecation notice.
 	if m.GetOptions().GetDeprecated() {
 		if com == "" {
-			com = fmt.Sprintf("\n is deprecated.\n\nDeprecated: %s may be removed in a future version.", m.GetName())
+			com = fmt.Sprintf("\n is deprecated.\n\nDeprecated: %s may be removed in a future version.", g.methodName(m))
 		} else if strings.HasPrefix(com, "Deprecated:") {
 			com = fmt.Sprintf("\n is deprecated.\n\n%s", com)
 		} else if !containsDeprecated(com) {
-			com = fmt.Sprintf("%s\n\nDeprecated: %s may be removed in a future version.", com, m.GetName())
+			com = fmt.Sprintf("%s\n\nDeprecated: %s may be removed in a future version.", com, g.methodName(m))
 		}
 	}
 	com = strings.TrimSpace(com)
 
 	// Prepend the method name to all non-empty comments.
-	com = m.GetName() + " " + lowerFirst(com)
+	com = g.methodName(m) + " " + lowerFirst(com)
 	servName := serv.GetName()
 	if override := g.getServiceNameOverride(serv); override != "" {
 		servName = override

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -580,6 +580,90 @@ func TestGenGRPCMethods(t *testing.T) {
 	}
 }
 
+func TestSelectiveGapicMethod(t *testing.T) {
+	file := &descriptorpb.FileDescriptorProto{
+		Package: proto.String("my.pkg"),
+		Options: &descriptorpb.FileOptions{
+			GoPackage: proto.String("mypackage"),
+		},
+	}
+	m := &descriptorpb.MethodDescriptorProto{
+		Name:       proto.String("Zip"),
+		InputType:  proto.String(".my.pkg.InputType"),
+		OutputType: proto.String(".my.pkg.OutputType"),
+		Options:    &descriptorpb.MethodOptions{},
+	}
+	m2 := &descriptorpb.MethodDescriptorProto{
+		Name:       proto.String("Zap"),
+		InputType:  proto.String(".my.pkg.InputType"),
+		OutputType: proto.String(".my.pkg.OutputType"),
+		Options:    &descriptorpb.MethodOptions{},
+	}
+	serv := &descriptorpb.ServiceDescriptorProto{
+		Name:   proto.String("Foo"),
+		Method: []*descriptorpb.MethodDescriptorProto{m, m2},
+	}
+
+	inputType := &descriptorpb.DescriptorProto{Name: proto.String("InputType")}
+	outputType := &descriptorpb.DescriptorProto{Name: proto.String("OutputType")}
+
+	var g generator
+	g.imports = map[pbinfo.ImportSpec]bool{}
+	g.cfg = &generatorConfig{
+		pkgName: "pkg",
+		featureEnablement: map[featureID]struct{}{
+			SelectiveGapicGenerationFeature: {},
+		},
+	}
+	g.descInfo.ParentElement = map[pbinfo.ProtoType]pbinfo.ProtoType{
+		m:    serv,
+		m2:   serv,
+		serv: file,
+	}
+	g.descInfo.ParentFile = map[proto.Message]*descriptorpb.FileDescriptorProto{
+		serv:       file,
+		m:          file,
+		m2:         file,
+		inputType:  file,
+		outputType: file,
+	}
+	g.descInfo.Type = map[string]pbinfo.ProtoType{
+		".my.pkg.InputType":  inputType,
+		".my.pkg.OutputType": outputType,
+	}
+
+	g.cfg.APIServiceConfig = &serviceconfig.Service{
+		Publishing: &annotations.Publishing{
+			LibrarySettings: []*annotations.ClientLibrarySettings{
+				{
+					GoSettings: &annotations.GoSettings{
+						Common: &annotations.CommonLanguageSettings{
+							SelectiveGapicGeneration: &annotations.SelectiveGapicGeneration{
+								GenerateOmittedAsInternal: true,
+								Methods:                   []string{"my.pkg.Foo.Zip"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	g.reset()
+	// Zap is unexported
+	if err := g.genGRPCMethod("Foo", serv, m2); err != nil {
+		t.Fatal(err)
+	}
+	txtdiff.Diff(t, g.pt.String(), filepath.Join("testdata", "method_selective_zap.want"))
+
+	g.reset()
+	// Zip is exported
+	if err := g.genGRPCMethod("Foo", serv, m); err != nil {
+		t.Fatal(err)
+	}
+	txtdiff.Diff(t, g.pt.String(), filepath.Join("testdata", "method_selective_zip.want"))
+}
+
 func TestContainsDeprecated(t *testing.T) {
 	tests := []struct {
 		in   string

--- a/internal/gengapic/gengrpc.go
+++ b/internal/gengapic/gengrpc.go
@@ -101,7 +101,7 @@ func (g *generator) unaryGRPCCall(servName string, m *descriptorpb.MethodDescrip
 	lowcaseServName := lowcaseGRPCClientName(servName)
 	retTyp := fmt.Sprintf("%s.%s", outSpec.Name, outType.GetName())
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s, error) {",
-		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), retTyp)
+		lowcaseServName, g.methodName(m), inSpec.Name, inType.GetName(), retTyp)
 
 	g.insertRequestHeaders(m, grpc)
 	g.injectTelemetryContext(m, nil)
@@ -141,7 +141,7 @@ func (g *generator) emptyUnaryGRPCCall(servName string, m *descriptorpb.MethodDe
 	lowcaseServName := lowcaseGRPCClientName(servName)
 
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) error {",
-		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName())
+		lowcaseServName, g.methodName(m), inSpec.Name, inType.GetName())
 
 	g.insertRequestHeaders(m, grpc)
 	g.injectTelemetryContext(m, nil)
@@ -163,8 +163,7 @@ func (g *generator) emptyUnaryGRPCCall(servName string, m *descriptorpb.MethodDe
 
 func (g *generator) grpcStubCall(method *descriptorpb.MethodDescriptorProto) string {
 	service := g.descInfo.ParentElement[method].(*descriptorpb.ServiceDescriptorProto)
-	override := g.getServiceNameOverride(service)
-	stub := pbinfo.ReduceServNameWithOverride(service.GetName(), g.cfg.pkgName, override)
+	stub := g.clientName(service, g.cfg.pkgName)
 	return fmt.Sprintf("executeRPC(ctx, c.%s.%s, req, settings.GRPC, c.logger, %q)", grpcClientField(stub), method.GetName(), method.GetName())
 }
 

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -81,7 +81,7 @@ func (g *generator) restClientInit(serv *descriptorpb.ServiceDescriptorProto, se
 		g.imports[pbinfo.ImportSpec{Name: "lroauto", Path: "cloud.google.com/go/longrunning/autogen"}] = true
 	}
 	if opServ, ok := g.customOpServices[serv]; ok {
-		opServName := pbinfo.ReduceServName(opServ.GetName(), g.cfg.pkgName)
+		opServName := g.clientName(opServ, g.cfg.pkgName)
 		p("// operationClient is used to call the operation-specific management service.")
 		p("operationClient *%sClient", opServName)
 		p("")
@@ -221,7 +221,7 @@ func (g *generator) restClientUtilities(serv *descriptorpb.ServiceDescriptorProt
 		p("")
 	}
 	if hasCustomOp {
-		opServName := pbinfo.ReduceServName(opServ.GetName(), g.cfg.pkgName)
+		opServName := g.clientName(opServ, g.cfg.pkgName)
 		p("o := []option.ClientOption{")
 		p("  option.WithHTTPClient(httpClient),")
 		p("  option.WithEndpoint(endpoint),")
@@ -658,7 +658,7 @@ func (g *generator) serverStreamRESTCall(servName string, s *descriptorpb.Servic
 
 	// rest-client method
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
-		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), servSpec.Name, s.GetName(), m.GetName())
+		lowcaseServName, g.methodName(m), inSpec.Name, inType.GetName(), servSpec.Name, s.GetName(), m.GetName())
 	body, logBody := "nil", "nil"
 	verb := strings.ToUpper(info.verb)
 
@@ -794,7 +794,7 @@ func (g *generator) noRequestStreamRESTCall(servName string, s *descriptorpb.Ser
 	lowcaseServName := lowcaseRestClientName(servName)
 
 	p("func (c *%s) %s(ctx context.Context, opts ...gax.CallOption) (%s.%s_%sClient, error) {",
-		lowcaseServName, m.GetName(), servSpec.Name, s.GetName(), m.GetName())
+		lowcaseServName, g.methodName(m), servSpec.Name, s.GetName(), m.GetName())
 	p(`  return nil, errors.New("%s not yet supported for REST clients")`, m.GetName())
 	p("}")
 	p("")
@@ -835,7 +835,7 @@ func (g *generator) pagingRESTCall(servName string, m *descriptorpb.MethodDescri
 	}
 
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) *%s {",
-		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), pt.iterTypeName)
+		lowcaseServName, g.methodName(m), inSpec.Name, inType.GetName(), pt.iterTypeName)
 	p("it := &%s{}", pt.iterTypeName)
 	p("req = proto.Clone(req).(*%s.%s)", inSpec.Name, inType.GetName())
 
@@ -936,7 +936,7 @@ func (g *generator) lroRESTCall(servName string, m *descriptorpb.MethodDescripto
 
 	opWrapperType := lroTypeName(m)
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s, error) {",
-		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), opWrapperType)
+		lowcaseServName, g.methodName(m), inSpec.Name, inType.GetName(), opWrapperType)
 
 	g.initializeAutoPopulatedFields(servName, m)
 	// TODO(noahdietz): handle cancellation, metadata, osv.
@@ -1033,7 +1033,7 @@ func (g *generator) emptyUnaryRESTCall(servName string, m *descriptorpb.MethodDe
 	p := g.printf
 	lowcaseServName := lowcaseRestClientName(servName)
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) error {",
-		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName())
+		lowcaseServName, g.methodName(m), inSpec.Name, inType.GetName())
 
 	g.initializeAutoPopulatedFields(servName, m)
 	// TODO(dovs): handle cancellation, metadata, osv.
@@ -1122,7 +1122,7 @@ func (g *generator) unaryRESTCall(servName string, m *descriptorpb.MethodDescrip
 	p := g.printf
 	lowcaseServName := lowcaseRestClientName(servName)
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (%s, error) {",
-		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), retTyp)
+		lowcaseServName, g.methodName(m), inSpec.Name, inType.GetName(), retTyp)
 
 	g.initializeAutoPopulatedFields(servName, m)
 	// TODO(dovs): handle cancellation, metadata, osv.

--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -41,7 +41,7 @@ func (g *generator) lroCall(servName string, m *descriptorpb.MethodDescriptorPro
 	lowcaseServName := lowerFirst(servName + "GRPCClient")
 
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (*%s, error) {",
-		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), lroType)
+		lowcaseServName, g.methodName(m), inSpec.Name, inType.GetName(), lroType)
 
 	g.insertRequestHeaders(m, grpc)
 	g.injectTelemetryContext(m, nil)

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -374,7 +374,7 @@ func (g *generator) pagingCall(servName string, m *descriptorpb.MethodDescriptor
 
 	p := g.printf
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) *%s {",
-		lowcaseServName, *m.Name, inSpec.Name, inType.GetName(), pt.iterTypeName)
+		lowcaseServName, g.methodName(m), inSpec.Name, inType.GetName(), pt.iterTypeName)
 
 	g.insertRequestHeaders(m, grpc)
 	g.injectTelemetryContext(m, nil)

--- a/internal/gengapic/snippets.go
+++ b/internal/gengapic/snippets.go
@@ -93,7 +93,7 @@ func (g *generator) genAndCommitSnippets(s *descriptorpb.ServiceDescriptorProto)
 		g.imports[pbinfo.ImportSpec{Name: g.cfg.pkgName, Path: g.cfg.pkgPath}] = true
 		// Use the client short name in this filepath.
 		// E.g. the client for LoggingServiceV2 is just "Client".
-		clientName := pbinfo.ReduceServName(servName, g.cfg.pkgName) + "Client"
+		clientName := g.clientName(s, g.cfg.pkgName) + "Client"
 		// Get the original proto namespace for the method (different from `s` only for mixins).
 		f := g.descInfo.ParentFile[m]
 		// Get the original proto service for the method (different from `s` only for mixins).
@@ -114,7 +114,7 @@ func (g *generator) genSnippetFile(s *descriptorpb.ServiceDescriptorProto, m *de
 	g.headerComment(fmt.Sprintf("[START %s]", regionTag))
 	pkgName := g.cfg.pkgName
 
-	reducedServName := pbinfo.ReduceServName(servName, pkgName)
+	reducedServName := g.clientName(s, pkgName)
 
 	p := g.printf
 	p("func main() {")

--- a/internal/gengapic/stream.go
+++ b/internal/gengapic/stream.go
@@ -35,7 +35,7 @@ func (g *generator) noRequestStreamCall(servName string, s *descriptorpb.Service
 
 	retTyp := fmt.Sprintf("%s.%s_%sClient", servSpec.Name, s.GetName(), m.GetName())
 	p("func (c *%s) %s(ctx context.Context, opts ...gax.CallOption) (%s, error) {",
-		lowcaseServName, m.GetName(), retTyp)
+		lowcaseServName, g.methodName(m), retTyp)
 	g.insertRequestHeaders(nil, grpc)
 	g.injectTelemetryContext(m, nil)
 	p("  var resp %s", retTyp)
@@ -78,7 +78,7 @@ func (g *generator) serverStreamCall(servName string, s *descriptorpb.ServiceDes
 
 	retTyp := fmt.Sprintf("%s.%s_%sClient", servSpec.Name, s.GetName(), m.GetName())
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) (%s, error) {",
-		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), retTyp)
+		lowcaseServName, g.methodName(m), inSpec.Name, inType.GetName(), retTyp)
 
 	g.insertRequestHeaders(m, grpc)
 	g.injectTelemetryContext(m, nil)

--- a/internal/gengapic/testdata/method_selective_zap.want
+++ b/internal/gengapic/testdata/method_selective_zap.want
@@ -1,0 +1,15 @@
+func (c *fooGRPCClient) zap(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
+	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, c.xGoogHeaders...)
+	opts = append((*c.CallOptions).zap[0:len((*c.CallOptions).zap):len((*c.CallOptions).zap)], opts...)
+	var resp *mypackagepb.OutputType
+	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+		var err error
+		resp, err = executeRPC(ctx, c.baseFooClient.Zap, req, settings.GRPC, c.logger, "Zap")
+		return err
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+

--- a/internal/gengapic/testdata/method_selective_zip.want
+++ b/internal/gengapic/testdata/method_selective_zip.want
@@ -1,0 +1,15 @@
+func (c *fooGRPCClient) Zip(ctx context.Context, req *mypackagepb.InputType, opts ...gax.CallOption) (*mypackagepb.OutputType, error) {
+	ctx = gax.InsertMetadataIntoOutgoingContext(ctx, c.xGoogHeaders...)
+	opts = append((*c.CallOptions).Zip[0:len((*c.CallOptions).Zip):len((*c.CallOptions).Zip)], opts...)
+	var resp *mypackagepb.OutputType
+	err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {
+		var err error
+		resp, err = executeRPC(ctx, c.baseFooClient.Zip, req, settings.GRPC, c.logger, "Zip")
+		return err
+	}, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+

--- a/internal/gengapic/testdata/selective_gapic_client_init.want
+++ b/internal/gengapic/testdata/selective_gapic_client_init.want
@@ -1,0 +1,132 @@
+// internalBaseFooClient is an interface that defines the methods available from Awesome Foo API.
+type internalBaseFooClient interface {
+	Close() error
+	setGoogleClientInfo(...string)
+	Connection() *grpc.ClientConn
+	Zip(context.Context, *mypackagepb.Bar, ...gax.CallOption) (*mypackagepb.Foo, error)
+	zap(context.Context, *mypackagepb.Bar, ...gax.CallOption) (*mypackagepb.Foo, error)
+}
+
+// BaseFooClient is a client for interacting with Awesome Foo API.
+// Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.
+//
+// Foo service does stuff.
+type BaseFooClient struct {
+	// The internal transport-dependent client.
+	internalClient internalBaseFooClient
+
+	// The call options for this service.
+	CallOptions *BaseFooCallOptions
+
+}
+
+// Wrapper methods routed to the internal client.
+
+// Close closes the connection to the API service. The user should invoke this when
+// the client is no longer required.
+func (c *BaseFooClient) Close() error {
+	return c.internalClient.Close()
+}
+
+// setGoogleClientInfo sets the name and version of the application in
+// the `x-goog-api-client` header passed on each request. Intended for
+// use by Google-written clients.
+func (c *BaseFooClient) setGoogleClientInfo(keyval ...string) {
+	c.internalClient.setGoogleClientInfo(keyval...)
+}
+
+// Connection returns a connection to the API service.
+//
+// Deprecated: Connections are now pooled so this method does not always
+// return the same resource.
+func (c *BaseFooClient) Connection() *grpc.ClientConn {
+	return c.internalClient.Connection()
+}
+
+// Zip does some stuff.
+func (c *BaseFooClient) Zip(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
+	return c.internalClient.Zip(ctx, req, opts...)
+}
+
+func (c *BaseFooClient) zap(ctx context.Context, req *mypackagepb.Bar, opts ...gax.CallOption) (*mypackagepb.Foo, error) {
+	return c.internalClient.zap(ctx, req, opts...)
+}
+
+// baseFooGRPCClient is a client for interacting with Awesome Foo API over gRPC transport.
+//
+// Methods, except Close, may be called concurrently. However, fields must not be modified concurrently with method calls.
+type baseFooGRPCClient struct {
+	// Connection pool of gRPC connections to the service.
+	connPool gtransport.ConnPool
+
+	// Points back to the CallOptions field of the containing BaseFooClient
+	CallOptions **BaseFooCallOptions
+
+	// The gRPC API client.
+	baseFooClient mypackagepb.FooClient
+
+	// The x-goog-* metadata to be sent with each request.
+	xGoogHeaders []string
+
+	logger *slog.Logger
+}
+
+// NewBaseFooClient creates a new foo client based on gRPC.
+// The returned client must be Closed when it is done being used to clean up its underlying connections.
+//
+// Foo service does stuff.
+func NewBaseFooClient(ctx context.Context, opts ...option.ClientOption) (*BaseFooClient, error) {
+	clientOpts := defaultBaseFooGRPCClientOptions()
+	if newBaseFooClientHook != nil {
+		hookOpts, err := newBaseFooClientHook(ctx, clientHookParams{})
+		if err != nil {
+			return nil, err
+		}
+		clientOpts = append(clientOpts, hookOpts...)
+	}
+
+	connPool, err := gtransport.DialPool(ctx, append(clientOpts, opts...)...)
+	if err != nil {
+		return nil, err
+	}
+	client := BaseFooClient{CallOptions: defaultBaseFooCallOptions()}
+
+	c := &baseFooGRPCClient{
+		connPool:    connPool,
+		baseFooClient: mypackagepb.NewFooClient(connPool),
+		CallOptions: &client.CallOptions,
+		logger: internaloption.GetLogger(opts),
+
+	}
+	c.setGoogleClientInfo()
+
+	client.internalClient = c
+
+	return &client, nil
+}
+
+// Connection returns a connection to the API service.
+//
+// Deprecated: Connections are now pooled so this method does not always
+// return the same resource.
+func (c *baseFooGRPCClient) Connection() *grpc.ClientConn {
+	return c.connPool.Conn()
+}
+
+// setGoogleClientInfo sets the name and version of the application in
+// the `x-goog-api-client` header passed on each request. Intended for
+// use by Google-written clients.
+func (c *baseFooGRPCClient) setGoogleClientInfo(keyval ...string) {
+	kv := append([]string{"gl-go", gax.GoVersion}, keyval...)
+	kv = append(kv, "gapic", getVersionClient(), "gax", gax.Version, "grpc", grpc.Version, "pb", protoVersion)
+	c.xGoogHeaders = []string{
+		"x-goog-api-client", gax.XGoogHeader(kv...),
+	}
+}
+
+// Close closes the connection to the API service. The user should invoke this when
+// the client is no longer required.
+func (c *baseFooGRPCClient) Close() error {
+	return c.connPool.Close()
+}
+


### PR DESCRIPTION
This PR introduces support for **Selective GAPIC Generation (SGG)** to the Go generator, gated behind the `F_selective_gapic_generation` feature flag. 

The selective GAPIC generation settings are in `google.api.ClientLibrarySettings` .https://github.com/googleapis/go-genproto/blob/4cfbd4190f5715c0e63d78baa0a8c487d4a5b3b0/googleapis/api/annotations/client.pb.go#L1152-L1169

SGG allows API producers to wrap autogenerated clients in handwritten, ergonomic veneer structs by keeping the raw autogenerated surface area internal to the package. 

When the `selective_gapic_generation` config is present in `service.yaml` and `generate_omitted_as_internal` is set to `true`:
1. **Client Prefixing:** The generated service client structs, internal interfaces, and `CallOptions` structs are prefixed with `Base` (e.g., `TableAdminClient` becomes `BaseTableAdminClient`).
2. **Internal Method Encapsulation:** RPCs that are *not* explicitly listed in the `methods` allowlist are generated as unexported `lowerCamelCase` methods (e.g., `c.internalHelper(...)`). Methods in the allowlist remain fully exported `PascalCase` methods.

### Technical Details:
*   Added `SelectiveGapicGenerationFeature` feature flag.
*   Introduced `clientNameWithPkg` and `methodName` helpers in `generator.go` to centralize naming logic and prevent regressions.
*   Updated `gengapic.go`, `gengrpc.go`, `genrest.go`, `client_init.go`, `lro.go`, `paging.go`, and `stream.go` to respect the newly computed method and client names.
*   Updated example, snippet, and documentation generation to accurately reflect the internal routing and `Base` prefixes.
*   Added comprehensive unit tests and new golden tests (`selective_gapic_client_init.want`, `method_selective_zap.want`, `method_selective_zip.want`).


