### PR TITLE
chore: librarian release pull request: 20260406T225732Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:f2cbb6b904fdbf086efec0100536c52a79a654a5b9df21f975a2b6f6d50395a4
 libraries:
   - id: generator
-    version: 0.57.0
+    version: 0.58.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changes
 
+## [0.58.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.58.0) (2026-04-06)
+
+### Features
+
+* ClientMetrics Integration for Go GAPIC (#1709) ([719ba65](https://github.com/googleapis/google-cloud-go/commit/719ba655ff83e8015fd23f71c6e61d847e30228d))
+* add dynamic resource name heuristics (#1722) ([9515cd2](https://github.com/googleapis/google-cloud-go/commit/9515cd2880312bad869d69acf7618722363c5559))
+
+### Bug Fixes
+
+* update bazel_features URL to bazel-contrib (#1718) ([f8fba25](https://github.com/googleapis/google-cloud-go/commit/f8fba25a0b91dfc01ce9d7efe648469fa35125ac))
+* upgrade bazel toolchains to support go 1.25.0 (#1715) ([1ecf8a0](https://github.com/googleapis/google-cloud-go/commit/1ecf8a08996bbeddcdf2a8b9899fda7997a57784))
+
 ## [0.57.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.57.0) (2026-02-06)
 
 ### Features

--- a/internal/version.go
+++ b/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.57.0"
+const Version = "0.58.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.9.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:f2cbb6b904fdbf086efec0100536c52a79a654a5b9df21f975a2b6f6d50395a4
<details><summary>generator: v0.58.0</summary>

## [v0.58.0](https://github.com/googleapis/gapic-generator-go/compare/v0.57.0...v0.58.0) (2026-04-06)

### Features

* ClientMetrics Integration for Go GAPIC (#1709) ([719ba655](https://github.com/googleapis/gapic-generator-go/commit/719ba655))

* add dynamic resource name heuristics (#1722) ([9515cd28](https://github.com/googleapis/gapic-generator-go/commit/9515cd28))

### Bug Fixes

* upgrade bazel toolchains to support go 1.25.0 (#1715) ([1ecf8a08](https://github.com/googleapis/gapic-generator-go/commit/1ecf8a08))

* update bazel_features URL to bazel-contrib (#1718) ([f8fba25a](https://github.com/googleapis/gapic-generator-go/commit/f8fba25a))

</details>