### PR TITLE
feat: add proto.clone migration feature

### DIFF
--- a/internal/gengapic/auxiliary_test.go
+++ b/internal/gengapic/auxiliary_test.go
@@ -428,6 +428,11 @@ func TestGenIterators(t *testing.T) {
 			},
 		},
 		imports: make(map[pbinfo.ImportSpec]bool),
+		cfg: &generatorConfig{
+			featureEnablement: map[featureID]struct{}{
+				ProtoCloneOfMigrationFeature: {},
+			},
+		},
 	}
 
 	wantImports := map[pbinfo.ImportSpec]bool{

--- a/internal/gengapic/feature.go
+++ b/internal/gengapic/feature.go
@@ -34,6 +34,7 @@ const (
 	MTLSHardBoundTokensFeature       featureID = "mtls_hard_bound_tokens"
 	OpenTelemetryAttributesFeature   featureID = "open_telemetry_attributes"
 	OrderedRoutingHeadersFeature     featureID = "ordered_routing_headers"
+	ProtoCloneOfMigrationFeature     featureID = "proto_cloneof"
 	WrapperTypesForPageSizeFeature   featureID = "wrapper_types_for_page_size"
 )
 
@@ -61,6 +62,10 @@ var featureRegistry = map[featureID]*featureInfo{
 	},
 	OrderedRoutingHeadersFeature: {
 		Description: "Specify that routing headers are emitted in a deterministic fashion.  Primarily used for firestore.",
+	},
+	ProtoCloneOfMigrationFeature: {
+		Description: "migrate from proto.Clone to proto.CloneOf",
+		TrackingID:  "b/505084464",
 	},
 	WrapperTypesForPageSizeFeature: {
 		Description: "Allow List RPCs to generator with support for protobuf wrapper types (e.g. Int32Value, etc).",

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -339,6 +339,7 @@ func TestGenGRPCMethods(t *testing.T) {
 		pkgName: "pkg",
 		featureEnablement: map[featureID]struct{}{
 			OpenTelemetryAttributesFeature: {},
+			ProtoCloneOfMigrationFeature:   {},
 		},
 		APIServiceConfig: &serviceconfig.Service{
 			Publishing: &annotations.Publishing{

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -837,7 +837,11 @@ func (g *generator) pagingRESTCall(servName string, m *descriptorpb.MethodDescri
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) *%s {",
 		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), pt.iterTypeName)
 	p("it := &%s{}", pt.iterTypeName)
-	p("req = proto.Clone(req).(*%s.%s)", inSpec.Name, inType.GetName())
+	if g.featureEnabled(ProtoCloneOfMigrationFeature) {
+		p("req = proto.CloneOf(req)")
+	} else {
+		p("req = proto.Clone(req).(*%s.%s)", inSpec.Name, inType.GetName())
+	}
 
 	maybeReqBytes, logBody := "nil", "nil"
 	if info.body != "" {

--- a/internal/gengapic/genrest_test.go
+++ b/internal/gengapic/genrest_test.go
@@ -803,20 +803,6 @@ func TestGenRestMethod(t *testing.T) {
 		{
 			name:   "paging_rpc",
 			method: pagingRPC,
-			cfg:    &generatorConfig{featureEnablement: map[featureID]struct{}{OpenTelemetryAttributesFeature: {}}},
-			imports: map[pbinfo.ImportSpec]bool{
-				{Path: "math"}:    true,
-				{Path: "net/url"}: true,
-				{Path: "google.golang.org/protobuf/encoding/protojson"}: true,
-				{Path: "fmt"}:                                                    true,
-				{Path: "google.golang.org/api/iterator"}:                         true,
-				{Path: "google.golang.org/protobuf/proto"}:                       true,
-				{Name: "foopb", Path: "google.golang.org/genproto/cloud/foo/v1"}: true,
-			},
-		},
-		{
-			name:   "paging_rpc_cloneof",
-			method: pagingRPC,
 			cfg: &generatorConfig{featureEnablement: map[featureID]struct{}{
 				OpenTelemetryAttributesFeature: {},
 				ProtoCloneOfMigrationFeature:   {},

--- a/internal/gengapic/genrest_test.go
+++ b/internal/gengapic/genrest_test.go
@@ -815,6 +815,23 @@ func TestGenRestMethod(t *testing.T) {
 			},
 		},
 		{
+			name:   "paging_rpc_cloneof",
+			method: pagingRPC,
+			cfg: &generatorConfig{featureEnablement: map[featureID]struct{}{
+				OpenTelemetryAttributesFeature: {},
+				ProtoCloneOfMigrationFeature:   {},
+			}},
+			imports: map[pbinfo.ImportSpec]bool{
+				{Path: "math"}:    true,
+				{Path: "net/url"}: true,
+				{Path: "google.golang.org/protobuf/encoding/protojson"}: true,
+				{Path: "fmt"}:                                                    true,
+				{Path: "google.golang.org/api/iterator"}:                         true,
+				{Path: "google.golang.org/protobuf/proto"}:                       true,
+				{Name: "foopb", Path: "google.golang.org/genproto/cloud/foo/v1"}: true,
+			},
+		},
+		{
 			name:   "server_stream_rpc",
 			method: serverStreamRPC,
 			cfg:    &generatorConfig{featureEnablement: map[featureID]struct{}{OpenTelemetryAttributesFeature: {}}},

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -380,7 +380,11 @@ func (g *generator) pagingCall(servName string, m *descriptorpb.MethodDescriptor
 	g.injectTelemetryContext(m, nil)
 	g.appendCallOpts(m)
 	p("it := &%s{}", pt.iterTypeName)
-	p("req = proto.Clone(req).(*%s.%s)", inSpec.Name, inType.GetName())
+	if g.featureEnabled(ProtoCloneOfMigrationFeature) {
+		p("req = proto.CloneOf(req)")
+	} else {
+		p("req = proto.Clone(req).(*%s.%s)", inSpec.Name, inType.GetName())
+	}
 	p("it.InternalFetch = func(pageSize int, pageToken string) ([]%s, string, error) {", pt.elemTypeName)
 	g.internalFetchSetup(outType, outSpec, pageSize, tok)
 	p("  err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -450,7 +450,7 @@ func TestPagingField(t *testing.T) {
 
 	// First, test using the default "paging" package.
 	req := pluginpb.CodeGeneratorRequest{
-		Parameter: proto.String("go-gapic-package=path;mypackage,transport=rest"),
+		Parameter: proto.String("go-gapic-package=path;mypackage,transport=rest,F_proto_cloneof"),
 		ProtoFile: []*descriptorpb.FileDescriptorProto{file},
 	}
 	g, err := newGenerator(&req)

--- a/internal/gengapic/testdata/method_GetManyOtherThings.want
+++ b/internal/gengapic/testdata/method_GetManyOtherThings.want
@@ -5,7 +5,7 @@ func (c *fooGRPCClient) GetManyOtherThings(ctx context.Context, req *mypackagepb
 	}
 	opts = append((*c.CallOptions).GetManyOtherThings[0:len((*c.CallOptions).GetManyOtherThings):len((*c.CallOptions).GetManyOtherThings)], opts...)
 	it := &StringIterator{}
-	req = proto.Clone(req).(*mypackagepb.PageInputType)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
 		resp := &mypackagepb.PageOutputType{}
 		if pageToken != "" {

--- a/internal/gengapic/testdata/method_GetManyThings.want
+++ b/internal/gengapic/testdata/method_GetManyThings.want
@@ -11,7 +11,7 @@ func (c *fooGRPCClient) GetManyThings(ctx context.Context, req *mypackagepb.Page
 	}
 	opts = append((*c.CallOptions).GetManyThings[0:len((*c.CallOptions).GetManyThings):len((*c.CallOptions).GetManyThings)], opts...)
 	it := &StringIterator{}
-	req = proto.Clone(req).(*mypackagepb.PageInputType)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
 		resp := &mypackagepb.PageOutputType{}
 		if pageToken != "" {

--- a/internal/gengapic/testdata/method_GetManyThingsOptional.want
+++ b/internal/gengapic/testdata/method_GetManyThingsOptional.want
@@ -11,7 +11,7 @@ func (c *fooGRPCClient) GetManyThingsOptional(ctx context.Context, req *mypackag
 	}
 	opts = append((*c.CallOptions).GetManyThingsOptional[0:len((*c.CallOptions).GetManyThingsOptional):len((*c.CallOptions).GetManyThingsOptional)], opts...)
 	it := &StringIterator{}
-	req = proto.Clone(req).(*mypackagepb.PageInputTypeOptional)
+	req = proto.CloneOf(req)
 	it.InternalFetch = func(pageSize int, pageToken string) ([]string, string, error) {
 		resp := &mypackagepb.PageOutputType{}
 		if pageToken != "" {

--- a/internal/gengapic/testdata/rest_PagingRPC.want
+++ b/internal/gengapic/testdata/rest_PagingRPC.want
@@ -1,6 +1,6 @@
 func (c *fooRESTClient) PagingRPC(ctx context.Context, req *foopb.PagedFooRequest, opts ...gax.CallOption) *FooIterator {
 	it := &FooIterator{}
-	req = proto.Clone(req).(*foopb.PagedFooRequest)
+	req = proto.CloneOf(req)
 	unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 	it.InternalFetch = func(pageSize int, pageToken string) ([]*foopb.Foo, string, error) {
 		resp := &foopb.PagedFooResponse{}


### PR DESCRIPTION
This is another small temporary feature for migrating code generation to use proto.CloneOf instead of proto.Clone.

Once we've validated no issues from this migration, we'll be able to deprecate this feature flag and make proto.CloneOf our default behavior.

More details: b/505084464