### PR TITLE
chore: librarian release pull request: 20260427T223217Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,20 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:f2cbb6b904fdbf086efec0100536c52a79a654a5b9df21f975a2b6f6d50395a4
 libraries:
   - id: generator
-    version: 0.58.0
+    version: 0.59.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # Changes
 
+## [0.59.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.59.0) (2026-04-27)
+
+### Features
+
+* add proto.clone migration feature (#1730) ([2ba041d](https://github.com/googleapis/google-cloud-go/commit/2ba041dbac577695be2efdcaaad080ffd43170a7))
+* make exporting goog client info a generator capability (#1726) ([5359f2c](https://github.com/googleapis/google-cloud-go/commit/5359f2cb993205c1bc0891ea6d1a47d959dea30c))
+
+### Bug Fixes
+
+* make documentation transport aware (#1731) ([541e230](https://github.com/googleapis/google-cloud-go/commit/541e230a8f34b346215d787d4eaf7273961e466c))
+
 ## [0.58.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.58.0) (2026-04-06)
 
 ### Features

--- a/internal/version.go
+++ b/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.58.0"
+const Version = "0.59.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.10.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:f2cbb6b904fdbf086efec0100536c52a79a654a5b9df21f975a2b6f6d50395a4
<details><summary>generator: v0.59.0</summary>

## [v0.59.0](https://github.com/googleapis/gapic-generator-go/compare/v0.58.0...v0.59.0) (2026-04-27)

### Features

* add proto.clone migration feature (#1730) ([2ba041db](https://github.com/googleapis/gapic-generator-go/commit/2ba041db))

* make exporting goog client info a generator capability (#1726) ([5359f2cb](https://github.com/googleapis/gapic-generator-go/commit/5359f2cb))

### Bug Fixes

* make documentation transport aware (#1731) ([541e230a](https://github.com/googleapis/gapic-generator-go/commit/541e230a))

</details>