### PR TITLE
chore: librarian release pull request: 20260428T205318Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -14,7 +14,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:f2cbb6b904fdbf086efec0100536c52a79a654a5b9df21f975a2b6f6d50395a4
 libraries:
   - id: generator
-    version: 0.59.0
+    version: 0.60.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+## [0.60.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.60.0) (2026-04-28)
+
 ## [0.59.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.59.0) (2026-04-27)
 
 ### Features

--- a/internal/version.go
+++ b/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.59.0"
+const Version = "0.60.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.10.1
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:f2cbb6b904fdbf086efec0100536c52a79a654a5b9df21f975a2b6f6d50395a4
<details><summary>generator: v0.60.0</summary>

## [v0.60.0](https://github.com/googleapis/gapic-generator-go/compare/v0.59.0...v0.60.0) (2026-04-28)

</details>