### PR TITLE
feat: make proto.CloneOf default behavior, no-op the feature flag

### DIFF
--- a/internal/gengapic/auxiliary_test.go
+++ b/internal/gengapic/auxiliary_test.go
@@ -428,11 +428,7 @@ func TestGenIterators(t *testing.T) {
 			},
 		},
 		imports: make(map[pbinfo.ImportSpec]bool),
-		cfg: &generatorConfig{
-			featureEnablement: map[featureID]struct{}{
-				ProtoCloneOfMigrationFeature: {},
-			},
-		},
+		cfg:     &generatorConfig{},
 	}
 
 	wantImports := map[pbinfo.ImportSpec]bool{

--- a/internal/gengapic/feature.go
+++ b/internal/gengapic/feature.go
@@ -64,7 +64,7 @@ var featureRegistry = map[featureID]*featureInfo{
 		Description: "Specify that routing headers are emitted in a deterministic fashion.  Primarily used for firestore.",
 	},
 	ProtoCloneOfMigrationFeature: {
-		Description: "migrate from proto.Clone to proto.CloneOf",
+		Description: "Used to migrate proto.Clone to proto.CloneOf.  Now a no-op.",
 		TrackingID:  "b/505084464",
 	},
 	WrapperTypesForPageSizeFeature: {

--- a/internal/gengapic/gengapic_test.go
+++ b/internal/gengapic/gengapic_test.go
@@ -339,7 +339,6 @@ func TestGenGRPCMethods(t *testing.T) {
 		pkgName: "pkg",
 		featureEnablement: map[featureID]struct{}{
 			OpenTelemetryAttributesFeature: {},
-			ProtoCloneOfMigrationFeature:   {},
 		},
 		APIServiceConfig: &serviceconfig.Service{
 			Publishing: &annotations.Publishing{

--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -837,11 +837,7 @@ func (g *generator) pagingRESTCall(servName string, m *descriptorpb.MethodDescri
 	p("func (c *%s) %s(ctx context.Context, req *%s.%s, opts ...gax.CallOption) *%s {",
 		lowcaseServName, m.GetName(), inSpec.Name, inType.GetName(), pt.iterTypeName)
 	p("it := &%s{}", pt.iterTypeName)
-	if g.featureEnabled(ProtoCloneOfMigrationFeature) {
-		p("req = proto.CloneOf(req)")
-	} else {
-		p("req = proto.Clone(req).(*%s.%s)", inSpec.Name, inType.GetName())
-	}
+	p("req = proto.CloneOf(req)")
 
 	maybeReqBytes, logBody := "nil", "nil"
 	if info.body != "" {

--- a/internal/gengapic/genrest_test.go
+++ b/internal/gengapic/genrest_test.go
@@ -805,7 +805,6 @@ func TestGenRestMethod(t *testing.T) {
 			method: pagingRPC,
 			cfg: &generatorConfig{featureEnablement: map[featureID]struct{}{
 				OpenTelemetryAttributesFeature: {},
-				ProtoCloneOfMigrationFeature:   {},
 			}},
 			imports: map[pbinfo.ImportSpec]bool{
 				{Path: "math"}:    true,

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -380,11 +380,7 @@ func (g *generator) pagingCall(servName string, m *descriptorpb.MethodDescriptor
 	g.injectTelemetryContext(m, nil)
 	g.appendCallOpts(m)
 	p("it := &%s{}", pt.iterTypeName)
-	if g.featureEnabled(ProtoCloneOfMigrationFeature) {
-		p("req = proto.CloneOf(req)")
-	} else {
-		p("req = proto.Clone(req).(*%s.%s)", inSpec.Name, inType.GetName())
-	}
+	p("req = proto.CloneOf(req)")
 	p("it.InternalFetch = func(pageSize int, pageToken string) ([]%s, string, error) {", pt.elemTypeName)
 	g.internalFetchSetup(outType, outSpec, pageSize, tok)
 	p("  err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {")


### PR DESCRIPTION
This PR makes the newer proto.CloneOf usage the default, and no-ops the feature flag so that usages of the feature can be removed safely.

We've now released most (all?) clients using proto.CloneOf, so moving forward with this.  We'll still need to promote a new release of the generator before this behavior takes effect during regeneration.