### PR TITLE
test: remove use_generic_streams_experimental flag

### DIFF
--- a/showcase/README.md
+++ b/showcase/README.md
@@ -54,3 +54,4 @@ and ensures all the necessary dependencies are up to date.
 
 One can use `make clean` to revert any changes and delete any of the test
 artifacts created by `showcase.bash`.
+

--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -47,7 +47,6 @@ protoc \
 	--experimental_allow_proto3_optional \
 	--go_out ./gen \
 	--go-grpc_out ./gen \
-	--go-grpc_opt=use_generic_streams_experimental=false \
 	--go_gapic_out ./gen \
 	--go_gapic_opt 'transport=rest+grpc' \
 	--go_gapic_opt 'rest-numeric-enums' \


### PR DESCRIPTION
This flag was removed in a recent [grpc-go PR](https://github.com/grpc/grpc-go/pull/8936) and is causing the latest update deps PR #1740 to fail

Related #1554