### PR TITLE
test(showcase): remove retired use_generic_streams_experimental flag

### DIFF
--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -47,7 +47,6 @@ protoc \
 	--experimental_allow_proto3_optional \
 	--go_out ./gen \
 	--go-grpc_out ./gen \
-	--go-grpc_opt=use_generic_streams_experimental=false \
 	--go_gapic_out ./gen \
 	--go_gapic_opt 'transport=rest+grpc' \
 	--go_gapic_opt 'rest-numeric-enums' \


### PR DESCRIPTION
This PR resolves the Showcase integration test compilation failure by removing the retired `--go-grpc_opt=use_generic_streams_experimental=false` flag from `showcase/showcase.bash`

Fixes: #1743 