### PR TITLE
chore: update showcase to go 1.25.8

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -120,7 +120,7 @@ py_repositories()
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
 
-go_register_toolchains(version = "1.25.0")
+go_register_toolchains(version = "1.25.8")
 
 go_rules_dependencies()
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/gapic-generator-go
 
-go 1.25.0
+go 1.25.8
 
 require (
 	cloud.google.com/go/iam v1.11.0

--- a/showcase/go.mod
+++ b/showcase/go.mod
@@ -1,6 +1,6 @@
 module showcase
 
-go 1.25.0
+go 1.25.8
 
 require (
 	cloud.google.com/go v0.123.0


### PR DESCRIPTION
Needed to unblock #1752

also updates workspace toolchain directive