### PR TITLE
chore: librarian release pull request: 20260602T181727Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -14,7 +14,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:f2cbb6b904fdbf086efec0100536c52a79a654a5b9df21f975a2b6f6d50395a4
 libraries:
   - id: generator
-    version: 0.60.0
+    version: 0.61.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # Changes
 
+## [0.61.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.61.0) (2026-06-02)
+
+### Features
+
+* Selective GAPIC generation (#1729) ([9ce69a0](https://github.com/googleapis/google-cloud-go/commit/9ce69a05502f36e1b8aaf853dd236d0082e6e3f1))
+* add build tag to generated snippets (#1753) ([6ab1212](https://github.com/googleapis/google-cloud-go/commit/6ab1212c1f8b2729c58f5cda2bbd61e8b2c93e88))
+* make proto.CloneOf default behavior, no-op the feature flag (#1739) ([a785f57](https://github.com/googleapis/google-cloud-go/commit/a785f57bc7cdf255254cabd11282b0b57940c745))
+
+### Documentation
+
+* use stronger language in Close comment (#1738) ([ac17b8c](https://github.com/googleapis/google-cloud-go/commit/ac17b8c84075255ef00e378275372732d06ef2b5))
+
 ## [0.60.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.60.0) (2026-04-28)
 
 ## [0.59.0](https://github.com/googleapis/google-cloud-go/releases/tag/v0.59.0) (2026-04-27)

--- a/internal/version.go
+++ b/internal/version.go
@@ -17,4 +17,4 @@
 package internal
 
 // Version is the current tagged release of the library.
-const Version = "0.60.0"
+const Version = "0.61.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.16.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/librarian-go@sha256:f2cbb6b904fdbf086efec0100536c52a79a654a5b9df21f975a2b6f6d50395a4
<details><summary>generator: v0.61.0</summary>

## [v0.61.0](https://github.com/googleapis/gapic-generator-go/compare/v0.60.0...v0.61.0) (2026-06-02)

### Features

* add build tag to generated snippets (#1753) ([6ab1212c](https://github.com/googleapis/gapic-generator-go/commit/6ab1212c))

* Selective GAPIC generation (#1729) ([9ce69a05](https://github.com/googleapis/gapic-generator-go/commit/9ce69a05))

* make proto.CloneOf default behavior, no-op the feature flag (#1739) ([a785f57b](https://github.com/googleapis/gapic-generator-go/commit/a785f57b))

### Documentation

* use stronger language in Close comment (#1738) ([ac17b8c8](https://github.com/googleapis/gapic-generator-go/commit/ac17b8c8))

</details>