### PR TITLE
feat: remove unusued proto.CloneOf migration feature

### DIFF
--- a/internal/gengapic/feature.go
+++ b/internal/gengapic/feature.go
@@ -34,7 +34,6 @@ const (
 	MTLSHardBoundTokensFeature       featureID = "mtls_hard_bound_tokens"
 	OpenTelemetryAttributesFeature   featureID = "open_telemetry_attributes"
 	OrderedRoutingHeadersFeature     featureID = "ordered_routing_headers"
-	ProtoCloneOfMigrationFeature     featureID = "proto_cloneof"
 	SelectiveGapicGenerationFeature  featureID = "selective_gapic_generation"
 	WrapperTypesForPageSizeFeature   featureID = "wrapper_types_for_page_size"
 )
@@ -63,10 +62,6 @@ var featureRegistry = map[featureID]*featureInfo{
 	},
 	OrderedRoutingHeadersFeature: {
 		Description: "Specify that routing headers are emitted in a deterministic fashion.  Primarily used for firestore.",
-	},
-	ProtoCloneOfMigrationFeature: {
-		Description: "Used to migrate proto.Clone to proto.CloneOf.  Now a no-op.",
-		TrackingID:  "b/505084464",
 	},
 	SelectiveGapicGenerationFeature: {
 		Description: "Enable selective GAPIC generation, reducing public surface area based on config.",

--- a/internal/gengapic/paging_test.go
+++ b/internal/gengapic/paging_test.go
@@ -450,7 +450,7 @@ func TestPagingField(t *testing.T) {
 
 	// First, test using the default "paging" package.
 	req := pluginpb.CodeGeneratorRequest{
-		Parameter: proto.String("go-gapic-package=path;mypackage,transport=rest,F_proto_cloneof"),
+		Parameter: proto.String("go-gapic-package=path;mypackage,transport=rest"),
 		ProtoFile: []*descriptorpb.FileDescriptorProto{file},
 	}
 	g, err := newGenerator(&req)


### PR DESCRIPTION
This PR removes the feature ID from the gapic registry, now that there's no config usage of the feature.

related: internal b/505084464