### PR TITLE
feat(o11y): implement explicit context capture for LROs to support tracing

### DIFF
--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -1004,15 +1004,20 @@ func (g *generator) lroRESTCall(servName string, m *descriptorpb.MethodDescripto
 	p("")
 	override := g.getOperationPathOverride(g.descInfo.ParentFile[m].GetPackage())
 	p("override := fmt.Sprintf(%q, resp.GetName())", override)
-	p("return &%s{", opWrapperType)
-	p("  lro: longrunning.InternalNewOperation(*c.LROClient, resp),")
-	p("  pollPath: override,")
-	p("}, nil")
+	p("  lro := longrunning.InternalNewOperationWithMetadata(*c.LROClient, resp, %q)", fmt.Sprintf("*%s.%s", g.cfg.pkgName, opWrapperType))
+	p("  if gax.IsFeatureEnabled(%q) {", "TRACING")
+	p("    lro.SetParentSpanContext(trace.SpanContextFromContext(ctx))")
+	p("  }")
+	p("  return &%s{", opWrapperType)
+	p("    lro: lro,")
+	p("    pollPath: override,")
+	p("  }, nil")
 	p("}")
 	p("")
 
 	g.imports[pbinfo.ImportSpec{Path: "fmt"}] = true
 	g.imports[pbinfo.ImportSpec{Path: "cloud.google.com/go/longrunning"}] = true
+	g.imports[pbinfo.ImportSpec{Name: "trace", Path: "go.opentelemetry.io/otel/trace"}] = true
 	g.imports[pbinfo.ImportSpec{Path: "google.golang.org/protobuf/encoding/protojson"}] = true
 
 	return nil

--- a/internal/gengapic/genrest_test.go
+++ b/internal/gengapic/genrest_test.go
@@ -857,6 +857,7 @@ func TestGenRestMethod(t *testing.T) {
 				{Path: "google.golang.org/protobuf/encoding/protojson"}: true,
 				{Path: "net/url"}: true,
 				{Name: "longrunningpb", Path: "cloud.google.com/go/longrunning/autogen/longrunningpb"}: true,
+				{Name: "trace", Path: "go.opentelemetry.io/otel/trace"}:                                true,
 				{Path: "github.com/googleapis/gax-go/v2/callctx"}:                                      true,
 				{Name: "gax", Path: "github.com/googleapis/gax-go/v2"}:                                 true,
 			},

--- a/internal/gengapic/lro.go
+++ b/internal/gengapic/lro.go
@@ -15,6 +15,7 @@
 package gengapic
 
 import (
+	"fmt"
 	"sort"
 
 	"github.com/googleapis/gapic-generator-go/internal/pbinfo"
@@ -57,14 +58,19 @@ func (g *generator) lroCall(servName string, m *descriptorpb.MethodDescriptorPro
 	p("  if err != nil {")
 	p("    return nil, err")
 	p("  }")
+	p("  lro := longrunning.InternalNewOperationWithMetadata(*c.LROClient, resp, %q)", fmt.Sprintf("*%s.%s", g.cfg.pkgName, lroType))
+	p("  if gax.IsFeatureEnabled(%q) {", "TRACING")
+	p("    lro.SetParentSpanContext(trace.SpanContextFromContext(ctx))")
+	p("  }")
 	p("  return &%s{", lroType)
-	p("    lro: longrunning.InternalNewOperation(*c.LROClient, resp),")
+	p("    lro: lro,")
 	p("  }, nil")
 
 	p("}")
 	p("")
 
 	g.imports[pbinfo.ImportSpec{Path: "cloud.google.com/go/longrunning"}] = true
+	g.imports[pbinfo.ImportSpec{Name: "trace", Path: "go.opentelemetry.io/otel/trace"}] = true
 	g.imports[inSpec] = true
 	g.imports[outSpec] = true
 	return nil
@@ -112,7 +118,7 @@ func (g *generator) genOperationBuilder(servName string, m *descriptorpb.MethodD
 				receiver := lowcaseGRPCClientName(servName)
 				p("func (c *%s) %s(name string) *%[3]s {", receiver, builderName, ow.name)
 				p("  return &%s{", ow.name)
-				p("    lro: longrunning.InternalNewOperation(*c.LROClient, &longrunningpb.Operation{Name: name}),")
+				p("    lro: longrunning.InternalNewOperationWithMetadata(*c.LROClient, &longrunningpb.Operation{Name: name}, %q),", fmt.Sprintf("*%s.%s", g.cfg.pkgName, ow.name))
 				p("  }")
 				p("}")
 				p("")
@@ -122,7 +128,7 @@ func (g *generator) genOperationBuilder(servName string, m *descriptorpb.MethodD
 				p("func (c *%s) %s(name string) *%[3]s {", receiver, builderName, ow.name)
 				p("  override := fmt.Sprintf(%q, name)", override)
 				p("  return &%s{", ow.name)
-				p("    lro: longrunning.InternalNewOperation(*c.LROClient, &longrunningpb.Operation{Name: name}),")
+				p("    lro: longrunning.InternalNewOperationWithMetadata(*c.LROClient, &longrunningpb.Operation{Name: name}, %q),", fmt.Sprintf("*%s.%s", g.cfg.pkgName, ow.name))
 				p("    pollPath: override,")
 				p("  }")
 				p("}")

--- a/internal/gengapic/testdata/method_EmptyLRO.want
+++ b/internal/gengapic/testdata/method_EmptyLRO.want
@@ -13,8 +13,12 @@ func (c *fooGRPCClient) EmptyLRO(ctx context.Context, req *mypackagepb.InputType
 	if err != nil {
 		return nil, err
 	}
+	lro := longrunning.InternalNewOperationWithMetadata(*c.LROClient, resp, "*pkg.EmptyLROOperation")
+	if gax.IsFeatureEnabled("TRACING") {
+		lro.SetParentSpanContext(trace.SpanContextFromContext(ctx))
+	}
 	return &EmptyLROOperation{
-		lro: longrunning.InternalNewOperation(*c.LROClient, resp),
+		lro: lro,
 	}, nil
 }
 

--- a/internal/gengapic/testdata/method_RespLRO.want
+++ b/internal/gengapic/testdata/method_RespLRO.want
@@ -10,8 +10,12 @@ func (c *fooGRPCClient) RespLRO(ctx context.Context, req *mypackagepb.InputType,
 	if err != nil {
 		return nil, err
 	}
+	lro := longrunning.InternalNewOperationWithMetadata(*c.LROClient, resp, "*pkg.RespLROOperation")
+	if gax.IsFeatureEnabled("TRACING") {
+		lro.SetParentSpanContext(trace.SpanContextFromContext(ctx))
+	}
 	return &RespLROOperation{
-		lro: longrunning.InternalNewOperation(*c.LROClient, resp),
+		lro: lro,
 	}, nil
 }
 

--- a/internal/gengapic/testdata/rest_LongrunningRPC.want
+++ b/internal/gengapic/testdata/rest_LongrunningRPC.want
@@ -49,8 +49,12 @@ func (c *fooRESTClient) LongrunningRPC(ctx context.Context, req *foopb.Foo, opts
 	}
 
 	override := fmt.Sprintf("/v1beta1/%s", resp.GetName())
+	lro := longrunning.InternalNewOperationWithMetadata(*c.LROClient, resp, "*.LongrunningRPCOperation")
+	if gax.IsFeatureEnabled("TRACING") {
+		lro.SetParentSpanContext(trace.SpanContextFromContext(ctx))
+	}
 	return &LongrunningRPCOperation{
-		lro: longrunning.InternalNewOperation(*c.LROClient, resp),
+		lro: lro,
 		pollPath: override,
 	}, nil
 }
@@ -60,7 +64,7 @@ func (c *fooRESTClient) LongrunningRPC(ctx context.Context, req *foopb.Foo, opts
 func (c *fooRESTClient) LongrunningRPCOperation(name string) *LongrunningRPCOperation {
 	override := fmt.Sprintf("/v1beta1/%s", name)
 	return &LongrunningRPCOperation{
-		lro: longrunning.InternalNewOperation(*c.LROClient, &longrunningpb.Operation{Name: name}),
+		lro: longrunning.InternalNewOperationWithMetadata(*c.LROClient, &longrunningpb.Operation{Name: name}, "*.LongrunningRPCOperation"),
 		pollPath: override,
 	}
 }


### PR DESCRIPTION
Update the generator to explicitly capture the parent context for Long-Running Operations (LROs) when the `"TRACING"` feature flag is enabled. 

Previously, when a GAPIC client initiated a Long-Running Operation, the subsequent polling loops (e.g., `Wait()`) ran asynchronously without any knowledge of the parent span context from the initial method call. This resulted in orphaned child spans and disconnected trace graphs in `google-cloud-go` telemetry. 

This allows the `longrunning` package to link the background `.Wait()` loops back to the parent span that initiated the LRO, providing a complete view of the lifecycle.

Staged @ https://github.com/googleapis/google-cloud-go/pull/20107
