### PR TITLE
fix(genrest): use info.body field for paging REST request marshaling

### DIFF
--- a/internal/gengapic/genrest.go
+++ b/internal/gengapic/genrest.go
@@ -839,24 +839,31 @@ func (g *generator) pagingRESTCall(servName string, m *descriptorpb.MethodDescri
 	p("it := &%s{}", pt.iterTypeName)
 	p("req = proto.CloneOf(req)")
 
-	maybeReqBytes, logBody := "nil", "nil"
-	if info.body != "" {
-		g.protoJSONMarshaler()
-		maybeReqBytes = "bytes.NewReader(jsonReq)"
-		logBody = "jsonReq"
-		g.imports[pbinfo.ImportSpec{Path: "bytes"}] = true
-	}
-
 	p("unm := protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}")
 	p("it.InternalFetch = func(pageSize int, pageToken string) ([]%s, string, error) {", pt.elemTypeName)
 	g.internalFetchSetup(outType, outSpec, pageSize, tok)
 
+	// Marshal body for HTTP methods that take a body.
+	maybeReqBytes, logBody := "nil", "nil"
 	if info.body != "" {
-		p("  jsonReq, err := m.Marshal(req)")
+		if verb == http.MethodGet || verb == http.MethodDelete {
+			return fmt.Errorf("invalid use of body parameter for a get/delete method %q", m.GetName())
+		}
+		g.protoJSONMarshaler()
+		requestObject := "req"
+		if info.body != "*" {
+			requestObject = "body"
+			p("  body := req%s", fieldGetter(info.body))
+		}
+		p("  jsonReq, err := m.Marshal(%s)", requestObject)
 		p("  if err != nil {")
 		p(`    return nil, "", err`)
 		p("  }")
 		p("")
+
+		maybeReqBytes = "bytes.NewReader(jsonReq)"
+		logBody = "jsonReq"
+		g.imports[pbinfo.ImportSpec{Path: "bytes"}] = true
 	}
 
 	g.generateBaseURL(info, `return nil, "", err`)


### PR DESCRIPTION
## Context
The result of applying this change onto the `compute` section of `google-cloud-go` is available [here](https://github.com/Arkelenia/google-cloud-go/pull/1)

The [current version](https://github.com/googleapis/google-cloud-go/blob/main/compute/apiv1/network_endpoint_groups_client.go#L902-L905) of `ListNextworkEndpoints` in the `NetworkEndpointGroupsClient` quietly avoids returning the health of endpoints. The reason is that it expects the following body:

```
{
    "healthStatus": "SHOW"
}
```

but instead receives the following body:

```
{
    "networkEndpointGroupsListEndpointsRequestResource": {
        "healthStatus": "SHOW"
    }
}
```

The protobuf grpc definition is properly annotated with the body to use but the gapic proto generation fails to take it into account leading it to use the top-level request as the body instead of the sub-resource.

(I can't link the exact line in the protobuf here because Github cannot display a file that big but you can grep `body: "network_endpoint_groups_list_endpoints_request_resource"` into this [file](https://raw.githubusercontent.com/googleapis/googleapis/refs/heads/master/google/cloud/compute/v1/compute.proto))

## Summary
- Paging REST calls always marshaled the entire request as JSON, ignoring `info.body` when it referenced a sub-message field instead of the whole request (`*`).
- Extract the correct body field for paging calls, mirroring how non-paging REST calls already handle `info.body`.
- Reject invalid usage of the `body` option on GET/DELETE paging methods.

## Test plan
- [x] `go test ./internal/gengapic/...` passes
- [x] Existing golden fixture `rest_PagingRPC.want` (GET, no body) unaffected