### PR TITLE
feat: consolidate iterator gencode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@
 permissions:
   contents: read
 
+env:
+  GOTOOLCHAIN: local
+
 name: Generator tests
 on:
   push:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,8 +76,9 @@ jobs:
         unzip protoc-3.17.3.zip
         sudo ln -s /usr/src/protoc/bin/protoc /usr/local/bin/protoc
     - name: Install tools and dependencies
+      # TODO: unpin apidiff after 1.26 upgrade
       run: |
-        go install golang.org/x/exp/cmd/apidiff@latest
+        go install golang.org/x/exp/cmd/apidiff@v0.0.0-20260820122028-d6e0b57b1a69
         go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
         go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
         curl -sSL https://github.com/googleapis/googleapis/archive/master.zip > googleapis.zip

--- a/internal/gengapic/auxiliary.go
+++ b/internal/gengapic/auxiliary.go
@@ -79,10 +79,6 @@ func (g *generator) genAuxFile() error {
 	g.commit(filepath.Join(g.cfg.outDir, "auxiliary.go"), g.cfg.pkgName)
 	g.reset()
 
-	g.genIteratorsGo123()
-	g.commitWithBuildTag(filepath.Join(g.cfg.outDir, "auxiliary_go123.go"), g.cfg.pkgName, "go1.23")
-	g.reset()
-
 	return nil
 }
 
@@ -125,17 +121,6 @@ func (g *generator) genIterators() error {
 	}
 
 	return nil
-}
-
-// genIteratorsGo123 generates adapters for Go iterators for Go versions 1.23+.
-func (g *generator) genIteratorsGo123() {
-	// Sort iterators to generate by type name to
-	// avoid spurious regenerations created by
-	// non-deterministic map traversal order.
-	iters := sortIteratorMap(g.aux.iters)
-	for _, iter := range iters {
-		g.pagingIterGo123(iter)
-	}
 }
 
 // sortIteratorMap sorts the map of iterator types by iterTypeName.

--- a/internal/gengapic/auxiliary_test.go
+++ b/internal/gengapic/auxiliary_test.go
@@ -435,7 +435,7 @@ func TestGenIterators(t *testing.T) {
 		{Name: "examplepb", Path: "cloud.google.com/go/example/apiv1/examplepb"}: true,
 		{Path: "google.golang.org/api/iterator"}:                                 true,
 		{Path: "iter"}:                                                           true,
-		{Name: "gaxIterator", Path: "github.com/googleapis/gax-go/v2/iterator"}:  true,
+		{Name: "gaxiter", Path: "github.com/googleapis/gax-go/v2/iterator"}:      true,
 	}
 
 	if err := g.genIterators(); err != nil {

--- a/internal/gengapic/auxiliary_test.go
+++ b/internal/gengapic/auxiliary_test.go
@@ -434,6 +434,8 @@ func TestGenIterators(t *testing.T) {
 	wantImports := map[pbinfo.ImportSpec]bool{
 		{Name: "examplepb", Path: "cloud.google.com/go/example/apiv1/examplepb"}: true,
 		{Path: "google.golang.org/api/iterator"}:                                 true,
+		{Path: "iter"}:                                                           true,
+		{Name: "gaxIterator", Path: "github.com/googleapis/gax-go/v2/iterator"}:  true,
 	}
 
 	if err := g.genIterators(); err != nil {
@@ -448,19 +450,6 @@ func TestGenIterators(t *testing.T) {
 
 	g.reset()
 
-	wantImports = map[pbinfo.ImportSpec]bool{
-		{Path: "iter"}: true,
-		{Path: "github.com/googleapis/gax-go/v2/iterator"}:                       true,
-		{Name: "examplepb", Path: "cloud.google.com/go/example/apiv1/examplepb"}: true,
-	}
-
-	g.genIteratorsGo123()
-
-	if diff := cmp.Diff(g.imports, wantImports); diff != "" {
-		t.Errorf("imports got(-),want(+):\n%s", diff)
-	}
-
-	txtdiff.Diff(t, g.pt.String(), filepath.Join("testdata", "gen_iterators_go123.want"))
 }
 
 func TestSortOperationWrapperMap(t *testing.T) {

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -412,6 +412,18 @@ func (g *generator) pagingCall(servName string, m *descriptorpb.MethodDescriptor
 
 func (g *generator) pagingIter(pt *iterType) {
 	p := g.printf
+
+	// include the new style iterator first.
+	p("// All returns an iterator. If an error is returned by the iterator, the")
+	p("// iterator will stop after that iteration.")
+	p("func (it *%s) All() iter.Seq2[%s, error] {", pt.iterTypeName, pt.elemTypeName)
+	p("  return gaxIterator.RangeAdapter(it.Next)")
+	p("}")
+	p("")
+
+	g.imports[pbinfo.ImportSpec{Path: "iter"}] = true
+	g.imports[pbinfo.ImportSpec{Name: "gaxIterator", Path: "github.com/googleapis/gax-go/v2/iterator"}] = true
+
 	if pt.mapValueTypeName != "" {
 		p("// %s is a holder type for string/%s map entries", pt.elemTypeName, pt.mapValueTypeName)
 		p("type %s struct {", pt.elemTypeName)
@@ -473,23 +485,6 @@ func (g *generator) pagingIter(pt *iterType) {
 	p("")
 
 	g.imports[pbinfo.ImportSpec{Path: "google.golang.org/api/iterator"}] = true
-	for _, spec := range pt.elemImports {
-		g.imports[spec] = true
-	}
-}
-
-func (g *generator) pagingIterGo123(pt *iterType) {
-	p := g.printf
-
-	p("// All returns an iterator. If an error is returned by the iterator, the")
-	p("// iterator will stop after that iteration.")
-	p("func (it *%s) All() iter.Seq2[%s, error] {", pt.iterTypeName, pt.elemTypeName)
-	p("  return iterator.RangeAdapter(it.Next)")
-	p("}")
-	p("")
-
-	g.imports[pbinfo.ImportSpec{Path: "iter"}] = true
-	g.imports[pbinfo.ImportSpec{Path: "github.com/googleapis/gax-go/v2/iterator"}] = true
 	for _, spec := range pt.elemImports {
 		g.imports[spec] = true
 	}

--- a/internal/gengapic/paging.go
+++ b/internal/gengapic/paging.go
@@ -417,12 +417,12 @@ func (g *generator) pagingIter(pt *iterType) {
 	p("// All returns an iterator. If an error is returned by the iterator, the")
 	p("// iterator will stop after that iteration.")
 	p("func (it *%s) All() iter.Seq2[%s, error] {", pt.iterTypeName, pt.elemTypeName)
-	p("  return gaxIterator.RangeAdapter(it.Next)")
+	p("  return gaxiter.RangeAdapter(it.Next)")
 	p("}")
 	p("")
 
 	g.imports[pbinfo.ImportSpec{Path: "iter"}] = true
-	g.imports[pbinfo.ImportSpec{Name: "gaxIterator", Path: "github.com/googleapis/gax-go/v2/iterator"}] = true
+	g.imports[pbinfo.ImportSpec{Name: "gaxiter", Path: "github.com/googleapis/gax-go/v2/iterator"}] = true
 
 	if pt.mapValueTypeName != "" {
 		p("// %s is a holder type for string/%s map entries", pt.elemTypeName, pt.mapValueTypeName)

--- a/internal/gengapic/testdata/gen_iterators.want
+++ b/internal/gengapic/testdata/gen_iterators.want
@@ -1,3 +1,9 @@
+// All returns an iterator. If an error is returned by the iterator, the
+// iterator will stop after that iteration.
+func (it *FooIterator) All() iter.Seq2[*examplepb.Foo, error] {
+	return gaxIterator.RangeAdapter(it.Next)
+}
+
 // FooIterator manages a stream of *examplepb.Foo.
 type FooIterator struct {
 	items    []*examplepb.Foo

--- a/internal/gengapic/testdata/gen_iterators.want
+++ b/internal/gengapic/testdata/gen_iterators.want
@@ -1,7 +1,7 @@
 // All returns an iterator. If an error is returned by the iterator, the
 // iterator will stop after that iteration.
 func (it *FooIterator) All() iter.Seq2[*examplepb.Foo, error] {
-	return gaxIterator.RangeAdapter(it.Next)
+	return gaxiter.RangeAdapter(it.Next)
 }
 
 // FooIterator manages a stream of *examplepb.Foo.

--- a/internal/gengapic/testdata/gen_iterators_go123.want
+++ b/internal/gengapic/testdata/gen_iterators_go123.want
@@ -1,6 +1,0 @@
-// All returns an iterator. If an error is returned by the iterator, the
-// iterator will stop after that iteration.
-func (it *FooIterator) All() iter.Seq2[*examplepb.Foo, error] {
-	return iterator.RangeAdapter(it.Next)
-}
-

--- a/showcase/go.mod
+++ b/showcase/go.mod
@@ -1,6 +1,6 @@
 module showcase
 
-go 1.26.5
+go 1.25.0
 
 require (
 	cloud.google.com/go v0.123.0
@@ -42,5 +42,3 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 // indirect
 )
-
-replace github.com/googleapis/gapic-showcase => ./gen/github.com/googleapis/gapic-showcase

--- a/showcase/go.mod
+++ b/showcase/go.mod
@@ -1,6 +1,6 @@
 module showcase
 
-go 1.25.0
+go 1.26.5
 
 require (
 	cloud.google.com/go v0.123.0
@@ -42,3 +42,5 @@ require (
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260630182238-925bb5da69e7 // indirect
 )
+
+replace github.com/googleapis/gapic-showcase => ./gen/github.com/googleapis/gapic-showcase


### PR DESCRIPTION
This PR consolidates the newer All() style iteration methods into auxiliary.go rather than having them in a go:build protected file (iterator_go123.go).

We are now well-past the point where new style iterators are supported.

related: https://github.com/googleapis/google-cloud-go/issues/20229