### PR TITLE
chore: add resumable_upload.go to showcase.bash

### DIFF
--- a/showcase/showcase.bash
+++ b/showcase/showcase.bash
@@ -60,7 +60,8 @@ protoc \
 	google/showcase/v1beta1/sequence.proto \
 	google/showcase/v1beta1/testing.proto \
 	google/showcase/v1beta1/messaging.proto \
-	google/showcase/v1beta1/compliance.proto
+	google/showcase/v1beta1/compliance.proto \
+	google/showcase/v1beta1/resumable_upload.proto
 
 hostos=$(go env GOHOSTOS)
 hostarch=$(go env GOHOSTARCH)


### PR DESCRIPTION
I choose not to reveal how long it took me to notice the protos are listed individually in showcase.bash