### PR TITLE
chore: configure handleGHRelease on main branch for release-please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -3,6 +3,7 @@ releaseType: go-librarian
 manifest: true
 branches:
   - branch: main
+    handleGHRelease: true
     tagPullRequestNumber: true
     manifestFile: .release-please-manifest.json
     manifestConfig: release-please-config.json


### PR DESCRIPTION
Add `handleGHRelease: true` to the branch-specific override for `main` in `.github/release-please.yml`.

### Background & Context
When branch overrides are defined in `branches:`, `repo-automation-bots` skips top-level configuration defaults and evaluates only the specific branch configuration. Because `handleGHRelease: true` was omitted under the `main` branch entry, GitHub release creation and tagging were skipped when release PR #1777 merged.

This caused release PR #1777 to remain untagged with label `autorelease: pending`, halting automated release PR creation for subsequent changes.

Adding `handleGHRelease: true` under `branch: main` ensures release-please creates the GitHub release and tag upon merge.